### PR TITLE
A better way to create a response function for CSD

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -52,7 +52,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             ndarray and the second is the signal value for the response
             function without diffusion weighting.  This is to be able to
             generate a single fiber synthetic signal. The response function
-            will be used as deconvolution kernel ([1]_)
+            will be used as deconvolution git pull nipy-dipy masterkernel ([1]_)
         reg_sphere : Sphere (optional)
             sphere used to build the regularization B matrix.
             Default: 'symmetric362'.

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -873,17 +873,17 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
-    r_sh_all = np.zeros(no_params)
     if mask is None:
         data = data[np.ones(data.shape[0:(data.ndim-1)], dtype=bool)]
     else:
         data = data[mask]
 
-    rot_gradients = np.zeros(gtab.gradients.shape)
+#    rot_gradients = np.zeros(gtab.gradients.shape)
     m, n = sph_harm_ind_list(sh_order)
     where_dwi = lazy_index(~gtab.b0s_mask)
 
     for num_it in range(1, iter):
+        r_sh_all = np.zeros(no_params)
         print(num_it)
         csd_model = ConstrainedSphericalDeconvModel(gtab, response,
                                                     None, sh_order)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -906,7 +906,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
         response[sh_mask] = 0
 
         change = abs((response_p[~sh_mask] - response[~sh_mask])/response_p[~sh_mask])
-        if change.all() < convergence:
+        if all(change < convergence):
             break
 
         response_p = response

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -27,6 +27,7 @@ from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.reconst.peaks import peaks_from_model
 from dipy.core.geometry import vec2vec_rotmat
 from scipy.special import sph_harm
+from dipy.core.sphere import HemiSphere
 
 
 class ConstrainedSphericalDeconvModel(SphHarmModel):
@@ -858,6 +859,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     evals = fa_trace_to_lambdas(init_fa, init_trace)
     response = (evals, S0)
     sphere = get_sphere('symmetric724')
+    hemisphere = HemiSphere.from_sphere(sphere)
 
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
@@ -868,6 +870,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
         data = data[mask]
 
     m, n = sph_harm_ind_list(sh_order)
+    sh_mask = m != 0
     where_dwi = lazy_index(~gtab.b0s_mask)
 
     for num_it in range(1, iter):
@@ -877,7 +880,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
         csd_peaks = peaks_from_model(model=csd_model,
                                      data=data,
-                                     sphere=sphere,
+                                     sphere=hemisphere,
                                      relative_peak_threshold=peak_thr,
                                      min_separation_angle=25,
                                      parallel=parallel)
@@ -901,8 +904,9 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
                                                   data[num_vox, where_dwi])[0]
 
         response = r_sh_all/data.shape[0]
+        response[sh_mask] = 0
 
-        change = abs((response_p - response)/response_p)
+        change = abs((response_p[~sh_mask] - response[~sh_mask])/response_p[~sh_mask])
         if change.all() < convergence:
             break
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -8,23 +8,25 @@ import scipy.linalg as la
 import scipy.linalg.lapack as ll
 
 from dipy.data import small_sphere, get_sphere
+from dipy.reconst.odf import OdfModel
+from dipy.reconst.cache import Cache
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm, order_from_ncoef,
+                              sph_harm_lookup, lazy_index, SphHarmFit,
+                              real_sym_sh_basis, sh_to_rh, gen_dirac,
+                              forward_sdeconv_mat, real_sph_harm2, sph_harm2, SphHarmModel,
+                              sh_to_sf)
+from dipy.data import get_sphere
 from dipy.core.geometry import cart2sphere
 from dipy.core.ndindex import ndindex
-from dipy.sims.voxel import single_tensor
+from dipy.sims.voxel import (single_tensor, single_tensor_odf)
 from dipy.utils.six.moves import range
 
-from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
-from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm,
-                              sph_harm_lookup, lazy_index, SphHarmFit,
-                              real_sym_sh_basis, sh_to_rh, forward_sdeconv_mat,
-                              SphHarmModel)
 
 from dipy.reconst.peaks import peaks_from_model
 from dipy.core.geometry import vec2vec_rotmat
-from dipy.reconst.shm import sh_to_sf
-from dipy.viz import fvtk
-from dipy.sims.voxel import single_tensor_odf
+from scipy.special import sph_harm
 
 
 class ConstrainedSphericalDeconvModel(SphHarmModel):
@@ -825,7 +827,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
         peak in order to call it a single fiber population [1]
     init_fa : float
         FA of the initial 'fat' response function (tensor)
-    init_trace : fload
+    init_trace : float
         trace of the initial 'fat' response function (tensor)
     iter : int
         maximum number of iterations for calibration
@@ -860,7 +862,8 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
     if mask is None:
-        data = data[np.ones(data.shape[0:(data.ndim-1)], dtype=bool)]
+        data = data.reshape(-1, data.shape[-1])
+#        data = data[np.ones(data.shape[0:(data.ndim-1)], dtype=bool)]
     else:
         data = data[mask]
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -859,7 +859,6 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     evals = fa_trace_to_lambdas(init_fa, init_trace)
     response = (evals, S0)
     sphere = get_sphere('symmetric724')
-    hemisphere = HemiSphere.from_sphere(sphere)
 
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
@@ -880,7 +879,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
         csd_peaks = peaks_from_model(model=csd_model,
                                      data=data,
-                                     sphere=hemisphere,
+                                     sphere=sphere,
                                      relative_peak_threshold=peak_thr,
                                      min_separation_angle=25,
                                      parallel=parallel)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -127,6 +127,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             self.response = response
             r_rh = sh_to_rh(self.response, m, n)
 
+        self.response_scaling = self.response[1]
         self.R = forward_sdeconv_mat(r_rh, n)
 
         # scale lambda_ to account for differences in the number of

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -114,15 +114,18 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         self.B_reg = real_sph_harm(m, n, theta[:, None], phi[:, None])
 
         if response is None:
-            S_r = estimate_response(gtab, np.array([0.0015, 0.0003, 0.0003]), 1)
-            r_sh = np.linalg.lstsq(self.B_dwi, S_r[self._where_dwi])[0]
+            self.response = (np.array([0.0015, 0.0003, 0.0003]), 1)
+            self.S_r = estimate_response(gtab, self.response)
+            r_sh = np.linalg.lstsq(self.B_dwi, self.S_r[self._where_dwi])[0]
             r_rh = sh_to_rh(r_sh, m, n)
         elif isinstance(response, tuple):
-            S_r = estimate_response(gtab, response[0], response[1])
-            r_sh = np.linalg.lstsq(self.B_dwi, S_r[self._where_dwi])[0]
+            self.response = response
+            self.S_r = estimate_response(gtab, self.response[0], self.response[1])
+            r_sh = np.linalg.lstsq(self.B_dwi, self.S_r[self._where_dwi])[0]
             r_rh = sh_to_rh(r_sh, m, n)
         else:
-            r_rh = sh_to_rh(response, m, n)
+            self.response = response
+            r_rh = sh_to_rh(self.response, m, n)
 
         self.R = forward_sdeconv_mat(r_rh, n)
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -849,20 +849,20 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     calibrates the response function, for more information see [1].
 
     References
-        ----------
-        .. [1] Tax, C.M.W., et al. NeuroImage 2014. Recursive calibration of
-               the fiber response function for spherical deconvolution of
-               diffusion MRI data
+    ----------
+    .. [1] Tax, C.M.W., et al. NeuroImage 2014. Recursive calibration of
+           the fiber response function for spherical deconvolution of
+           diffusion MRI data.
     """
-    vis = True
+    vis = False
 
     S0 = 1
     evals = fa_trace_to_lambdas(init_fa, init_trace)
 #    evals = np.array([0.0015, 0.0003, 0.0003])
     response = (evals, S0)
-
+    sphere = get_sphere('symmetric724')
     if vis is True:
-        sphere = get_sphere('symmetric724')
+
         ren = fvtk.ren()
         evals = response[0]
         evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
@@ -919,9 +919,11 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
         for num_vox in range(0, data.shape[0]):
             rotmat = vec2vec_rotmat(dirs[num_vox, 0], np.array([0, 0, 1]))
-            for num_grad in range(0, gtab.gradients.shape[0]):
-                rot_gradients[num_grad] = np.dot(rotmat,
-                                                 gtab.gradients[num_grad])
+            #for num_grad in range(0, gtab.gradients.shape[0]):
+            #    rot_gradients[num_grad] = np.dot(rotmat,
+            #                                    gtab.gradients[num_grad])
+
+            rot_gradients = np.dot(rotmat, gtab.gradients.T).T
 
             x, y, z = rot_gradients[where_dwi].T
             r, theta, phi = cart2sphere(x, y, z)

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -962,7 +962,6 @@ def sh_to_sf_matrix(sphere, sh_order, basis_type=None, return_inv=True, smooth=0
         L = -n * (n + 1)
         invB = smooth_pinv(B, np.sqrt(smooth) * L)
         return B.T, invB.T
-
     return B.T
 
 

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -964,3 +964,24 @@ def sh_to_sf_matrix(sphere, sh_order, basis_type=None, return_inv=True, smooth=0
         return B.T, invB.T
 
     return B.T
+
+
+def real_sph_harm2(m, n, theta, phi):
+    m = np.abs(m)
+    x = np.cos(phi)
+    val = lpmv(abs(m), n, x).astype(complex)
+    val *= np.sqrt((2*n + 1) / 4.0 / np.pi)
+    val *= np.exp(0.5*(gammaln(n-m+1)-gammaln(n+m+1)))
+    val = val * np.exp(1j * m * theta)
+    real_sh = np.where(m > 0, val.imag, val.real)
+    real_sh *= np.where(m == 0, 1., np.sqrt(2))
+    return real_sh
+
+
+def sph_harm2(m, n, theta, phi):
+    x = np.cos(phi)
+    val = lpmv(abs(m), n, x).astype(complex)
+    val *= np.sqrt((2*n + 1) / 4.0 / np.pi)
+    val *= np.exp(0.5*(gammaln(n-m+1)-gammaln(n+m+1)))
+    val = val * np.exp(1j * m * theta)
+    return val

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -40,6 +40,7 @@ from dipy.reconst.cache import Cache
 from distutils.version import StrictVersion
 import scipy
 
+
 if StrictVersion(scipy.version.short_version) >= StrictVersion('0.15.0'):
     SCIPY_15_PLUS = True
 else:
@@ -977,7 +978,6 @@ def real_sph_harm2(m, n, theta, phi):
     return real_sh
 
 
-<<<<<<< HEAD
 def sph_harm2(m, n, theta, phi):
     x = np.cos(phi)
     val = lpmv(abs(m), n, x).astype(complex)
@@ -985,6 +985,3 @@ def sph_harm2(m, n, theta, phi):
     val *= np.exp(0.5*(gammaln(n-m+1)-gammaln(n+m+1)))
     val = val * np.exp(1j * m * theta)
     return val
-=======
-    return B.T
->>>>>>> Updated with faster sph_harm version

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -977,6 +977,7 @@ def real_sph_harm2(m, n, theta, phi):
     return real_sh
 
 
+<<<<<<< HEAD
 def sph_harm2(m, n, theta, phi):
     x = np.cos(phi)
     val = lpmv(abs(m), n, x).astype(complex)
@@ -984,3 +985,6 @@ def sph_harm2(m, n, theta, phi):
     val *= np.exp(0.5*(gammaln(n-m+1)-gammaln(n+m+1)))
     val = val * np.exp(1j * m * theta)
     return val
+=======
+    return B.T
+>>>>>>> Updated with faster sph_harm version

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -60,7 +60,7 @@ def test_recursive_response_calibration():
     odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
     response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.08,
+                                  peak_thr=0.01, init_fa=0.1,
                                   init_trace=0.0021, iter=8, convergence=0.001,
                                   parallel=False)
 

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -52,12 +52,6 @@ def test_recursive_response_calibration():
 
     S_single = single_tensor(gtab, S0, evals, evecs, snr=SNR)
 
-    m, n = sph_harm_ind_list(sh_order)
-    x, y, z = gtab.gradients[where_dwi].T
-    r, theta, phi = cart2sphere(x, y, z)
-    B_dwi = real_sph_harm(m, n, theta[:, None], phi[:, None])
-    sh = np.linalg.lstsq(B_dwi, S_single[where_dwi])[0]
-
     data = np.concatenate((np.tile(S_cross, (8, 1)), np.tile(S_single, (2, 1))),
                           axis=0)
 

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -8,7 +8,7 @@ from dipy.data import get_sphere, get_data, default_sphere, small_sphere
 from dipy.sims.voxel import (multi_tensor,
                              single_tensor,
                              multi_tensor_odf,
-                             all_tensor_evecs)
+                             all_tensor_evecs, single_tensor_odf)
 from dipy.core.gradients import gradient_table
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    ConstrainedSDTModel,
@@ -18,54 +18,90 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response, recursive_response)
 from dipy.reconst.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
-
 from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
-                              real_sym_sh_basis, sph_harm_ind_list)
+                              real_sym_sh_basis, sph_harm_ind_list, real_sph_harm)
+from dipy.reconst.shm import lazy_index
+from dipy.core.geometry import cart2sphere
+import dipy.reconst.dti as dti
+from dipy.reconst.dti import fractional_anisotropy
+from dipy.core.sphere import Sphere
 
 
 def test_recursive_response_calibration():
     SNR = 100
     S0 = 1
+    sh_order = 8
 
     _, fbvals, fbvecs = get_data('small_64D')
 
     bvals = np.load(fbvals)
     bvecs = np.load(fbvecs)
+    sphere = get_sphere('symmetric724')
 
     gtab = gradient_table(bvals, bvecs)
     evals = np.array([0.0015, 0.0003, 0.0003])
+    evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
-    evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
+    angles = [(0, 0), (60, 0)]
 
-    angles = [(0, 0), (90, 0)]
+    where_dwi = lazy_index(~gtab.b0s_mask)
 
     S_cross, sticks_cross = multi_tensor(gtab, mevals, S0, angles=angles,
                                          fractions=[50, 50], snr=SNR)
 
     S_single = single_tensor(gtab, S0, evals, evecs, snr=SNR)
 
-    data = np.concatenate((np.tile(S_cross, (8, 1)), np.tile(S_single, (2, 1))), axis=0)
-    data = np.concatenate(np.tile(S_single, (2, 1)), axis=0)
-#    where_dwi = lazy_index(~gtab.b0s_mask)
+    m, n = sph_harm_ind_list(sh_order)
+    x, y, z = gtab.gradients[where_dwi].T
+    r, theta, phi = cart2sphere(x, y, z)
+    B_dwi = real_sph_harm(m, n, theta[:, None], phi[:, None])
+    sh = np.linalg.lstsq(B_dwi, S_single[where_dwi])[0]
 
-    sphere = get_sphere('symmetric362')
+    data = np.concatenate((np.tile(S_cross, (8, 1)), np.tile(S_single, (2, 1))),
+                          axis=0)
 
-#    ren = fvtk.ren()
-#    response_actor = fvtk.sphere_funcs(data[:, where_dwi], bvecs)
-#    fvtk.add(ren, response_actor)
-#    fvtk.show(ren)
+    odf_gt_cross = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
 
-
-    odf_gt = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
+    odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
     response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.05,
-                                  init_trace=0.0021, iter=8, convergence=0.01)
+                                  peak_thr=0.01, init_fa=0.08,
+                                  init_trace=0.0021, iter=8, convergence=0.001,
+                                  parallel=False)
 
     csd = ConstrainedSphericalDeconvModel(gtab, response)
 
     csd_fit = csd.fit(data)
+
+    assert_equal(csd_fit.shm_coeff[:, 0].all > 0, True)
+
+    fodf = csd_fit.odf(sphere)
+
+    directions_gt_single, _, _ = peak_directions(odf_gt_single, sphere)
+    directions_gt_cross, _, _ = peak_directions(odf_gt_cross, sphere)
+    directions_single, _, _ = peak_directions(fodf[8, :], sphere)
+    directions_cross, _, _ = peak_directions(fodf[0, :], sphere)
+
+    ang_sim = angular_similarity(directions_cross, directions_gt_cross)
+    assert_equal(ang_sim > 1.9, True)
+    assert_equal(directions_cross.shape[0], 2)
+    assert_equal(directions_gt_cross.shape[0], 2)
+
+    ang_sim = angular_similarity(directions_single, directions_gt_single)
+    assert_equal(ang_sim > 0.9, True)
+    assert_equal(directions_single.shape[0], 1)
+    assert_equal(directions_gt_single.shape[0], 1)
+
+    sf = sh_to_sf(response, Sphere(xyz=gtab.gradients[where_dwi]), sh_order, None)
+    sf = np.concatenate((np.array([S0]), sf))
+
+    tenmodel = dti.TensorModel(gtab, min_signal=0.001)
+
+    tenfit = tenmodel.fit(sf)
+    FA = fractional_anisotropy(tenfit.evals)
+    FA_gt = fractional_anisotropy(evals)
+    assert_almost_equal(FA, FA_gt, 2)
 
 
 def test_csdeconv():

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -41,9 +41,10 @@ def test_recursive_response_calibration():
     gtab = gradient_table(bvals, bvecs)
     evals = np.array([0.0015, 0.0003, 0.0003])
     evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
+#    evecs = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).T
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
-    angles = [(0, 0), (60, 0)]
+    angles = [(0, 0), (90, 0)]
 
     where_dwi = lazy_index(~gtab.b0s_mask)
 
@@ -60,7 +61,7 @@ def test_recursive_response_calibration():
     odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
     response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.1,
+                                  peak_thr=0.01, init_fa=0.05,
                                   init_trace=0.0021, iter=8, convergence=0.001,
                                   parallel=False)
 
@@ -95,7 +96,7 @@ def test_recursive_response_calibration():
     tenfit = tenmodel.fit(sf)
     FA = fractional_anisotropy(tenfit.evals)
     FA_gt = fractional_anisotropy(evals)
-    assert_almost_equal(FA, FA_gt, 2)
+    assert_almost_equal(FA, FA_gt, 1)
 
 
 def test_csdeconv():

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -22,6 +22,7 @@ from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
                               real_sym_sh_basis, sph_harm_ind_list)
 
 
+
 def test_csdeconv():
     SNR = 100
     S0 = 1

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -68,7 +68,7 @@ def test_recursive_response_calibration():
 
     csd_fit = csd.fit(data)
 
-    assert_equal(csd_fit.shm_coeff[:, 0].all > 0, True)
+    assert_equal(np.all(csd_fit.shm_coeff[:, 0] >= 0), True)
 
     fodf = csd_fit.odf(sphere)
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -74,6 +74,12 @@ We can double check that we have a good response function by visualizing the
 response's function's ODF. Here is how:
 """
 
+data_small = data[20:30, 55:65, 38:39]
+
+from dipy.reconst.csdeconv import recursive_response
+
+response = recursive_response(gtab, data_small, mask=None, sh_order=8, peak_thr=0.01, init_fa=0.05, init_trace=0.0021, iter=8, convergence=0.01)
+
 from dipy.viz import fvtk
 
 ren = fvtk.ren()
@@ -120,7 +126,7 @@ csd_model = ConstrainedSphericalDeconvModel(gtab, response)
 For illustration purposes we will fit only a slice of the datasets.
 """
 
-data_small = data[20:50, 55:85, 38:39]
+data_small = data[20:30, 55:65, 38:39]
 
 csd_fit = csd_model.fit(data_small)
 


### PR DESCRIPTION
This implementation includes the recursive calibration of the response function for CSD, Using an FA threshold is not a very robust method.It is dependent on the dataset (non-informed used subjectivity), and still depends on the diffusion tensor (FA and first eigenvector), which has low accuracy at high b-value. This function recursively calibrates the response function, for more information see Tax et al. NeuroImage 2014.

This implementation is slow only on one line (788) which calls real_sph_harm. I would appreciate any help to optimize this function. Thx!