### PR TITLE
WIP: BF: Catching initial fodf creation of SDT 

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -495,8 +495,12 @@ def odf_deconv(odf_sh, R, B_reg, lambda_=1., tau=0.1, r2_term=False):
         return np.zeros_like(odf_sh), 0
 
     # Generate initial fODF estimate, which is the ODF truncated at SH order 4
-    fodf_sh = np.linalg.lstsq(R, odf_sh)[0]
-    fodf_sh[15:] = 0
+    try:
+        fodf_sh = np.linalg.lstsq(R, odf_sh)[0]
+        fodf_sh[15:] = 0
+    except np.linalg.LinAlgError:
+        warnings.warn('Computation of initial fODF did not converge')
+        return np.zeros_like(odf_sh), 0        
 
     fodf = np.dot(B_reg, fodf_sh)
 


### PR DESCRIPTION
Julio Villalon has reported that on some Linux clusters with MKL (if I remember correctly) sometimes and in some voxels of some datasets the initial fodf creation in SDT gives a LinalgError and stops the execution. This PR catches this error and prohibits execution from stopping. 