### PR TITLE
BUG:   plot_2d_diffeomorphic_map

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -801,12 +801,14 @@ class DiffeomorphicMap(object):
         See _warp_forward and _warp_backward documentation for further
         information.
         """
+        if sampling_shape is not None:
+            sampling_shape = np.asarray(sampling_shape, dtype=np.int32)
         if self.is_inverse:
             warped = self._warp_backward(image, interpolation, world_to_image,
-                                       sampling_shape, sampling_affine)
+                                         sampling_shape, sampling_affine)
         else:
             warped = self._warp_forward(image, interpolation, world_to_image,
-                                       sampling_shape, sampling_affine)
+                                        sampling_shape, sampling_affine)
         return np.asarray(warped)
 
     def transform_inverse(self, image, interpolation='linear', world_to_image=None,

--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -204,7 +204,6 @@ def plot_2d_diffeomorphic_map(mapping, delta=10, fname=None,
         world_to_image = np.linalg.inv(inverse_grid_affine)
 
     # Draw the squares on the output grid
-    X1, X0 = np.mgrid[0:inverse_grid_shape[0], 0:inverse_grid_shape[1]]
     lattice_out = draw_lattice_2d(
         (inverse_grid_shape[0] + delta) / (delta + 1),
         (inverse_grid_shape[1] + delta) / (delta + 1),
@@ -222,7 +221,6 @@ def plot_2d_diffeomorphic_map(mapping, delta=10, fname=None,
         world_to_image = np.linalg.inv(direct_grid_affine)
 
     # Draw the squares on the input grid
-    X1, X0 = np.mgrid[0:direct_grid_shape[0], 0:direct_grid_shape[1]]
     lattice_in = draw_lattice_2d((direct_grid_shape[0] + delta) / (delta + 1),
                                  (direct_grid_shape[1] + delta) / (delta + 1),
                                  delta)

--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -3,23 +3,25 @@ from ..utils.optpkg import optional_package
 matplotlib, has_mpl, setup_module = optional_package("matplotlib")
 plt, _, _ = optional_package("matplotlib.pyplot")
 
+
 def overlay_images(img0, img1, title0='', title_mid='', title1='', fname=None):
     r""" Plot two images one on top of the other using red and green channels.
 
-    Creates a figure containing three images: the first image to the left plotted
-    on the red channel of a color image, the second to the right plotted on the 
-    green channel of a color image and the two given images on top of each other
-    using the red channel for the first image and the green channel for the 
-    second one. It is assumed that both images have the same shape. The intended
-    use of this function is to visually assess the quality of a registration
-    result.
+    Creates a figure containing three images: the first image to the left
+    plotted on the red channel of a color image, the second to the right
+    plotted on the green channel of a color image and the two given images on
+    top of each other using the red channel for the first image and the green
+    channel for the second one. It is assumed that both images have the same
+    shape. The intended use of this function is to visually assess the quality
+    of a registration result.
 
     Parameters
     ----------
     img0 : array, shape(R, C)
         the image to be plotted on the red channel, to the left of the figure
     img1 : array, shape(R, C)
-        the image to be plotted on the green channel, to the right of the figure
+        the image to be plotted on the green channel, to the right of the
+        figure
     title0 : string (optional)
         the title to be written on top of the image to the left. By default, no
         title is displayed.
@@ -27,29 +29,29 @@ def overlay_images(img0, img1, title0='', title_mid='', title1='', fname=None):
         the title to be written on top of the middle image. By default, no
         title is displayed.
     title1 : string (optional)
-        the title to be written on top of the image to the right. By default, no
-        title is displayed.
+        the title to be written on top of the image to the right. By default,
+        no title is displayed.
     fname : string (optional)
-        the file name to write the resulting figure. If None (default), the image
-        is not saved.
+        the file name to write the resulting figure. If None (default), the
+        image is not saved.
     """
-    #Normalize the input images to [0,255]
+    # Normalize the input images to [0,255]
     img0 = 255*((img0 - img0.min()) / (img0.max() - img0.min()))
     img1 = 255*((img1 - img1.min()) / (img1.max() - img1.min()))
 
-    #Create the color images
-    img0_red=np.zeros(shape=(img0.shape) + (3,), dtype=np.uint8)
-    img1_green=np.zeros(shape=(img0.shape) + (3,), dtype=np.uint8)
-    overlay=np.zeros(shape=(img0.shape) + (3,), dtype=np.uint8)
+    # Create the color images
+    img0_red = np.zeros(shape=(img0.shape) + (3,), dtype=np.uint8)
+    img1_green = np.zeros(shape=(img0.shape) + (3,), dtype=np.uint8)
+    overlay = np.zeros(shape=(img0.shape) + (3,), dtype=np.uint8)
 
-    #Copy the normalized intensities into the appropriate channels of the
-    #color images
+    # Copy the normalized intensities into the appropriate channels of the
+    # color images
     img0_red[..., 0] = img0
     img1_green[..., 1] = img1
-    overlay[..., 0]=img0
-    overlay[..., 1]=img1
+    overlay[..., 0] = img0
+    overlay[..., 1] = img1
 
-    #Create a new figure and plot the three images
+    # Create a new figure and plot the three images
     plt.figure()
     plt.subplot(1, 3, 1).set_axis_off()
     plt.imshow(img0_red)
@@ -61,9 +63,9 @@ def overlay_images(img0, img1, title0='', title_mid='', title1='', fname=None):
     plt.imshow(img1_green)
     plt.title(title1)
 
-    #If a file name was given, save the figure
+    # If a file name was given, save the figure
     if fname is not None:
-      plt.savefig(fname, bbox_inches='tight')
+        plt.savefig(fname, bbox_inches='tight')
 
 
 def draw_lattice_2d(nrows, ncols, delta):
@@ -80,7 +82,8 @@ def draw_lattice_2d(nrows, ncols, delta):
     ncols : int
         the number of squares to be drawn horizontally
     delta : int
-        the size of each square of the grid. Each square is delta x delta pixels
+        the size of each square of the grid. Each square is delta x delta
+        pixels
 
     Returns
     -------
@@ -90,33 +93,33 @@ def draw_lattice_2d(nrows, ncols, delta):
         R = 1 + (delta + 1) * nrows
         C = 1 + (delta + 1) * ncols
     """
-    lattice=np.ndarray((1 + (delta + 1) * nrows, 
-                        1 + (delta + 1) * ncols), 
-                        dtype = np.float64)
+    lattice = np.ndarray((1 + (delta + 1) * nrows,
+                         1 + (delta + 1) * ncols),
+                         dtype=np.float64)
 
-    #Fill the lattice with "white"
+    # Fill the lattice with "white"
     lattice[...] = 127
 
-    #Draw the horizontal lines in "black"
+    # Draw the horizontal lines in "black"
     for i in range(nrows + 1):
         lattice[i*(delta + 1), :] = 0
 
-    #Draw the vertical lines in "black"
+    # Draw the vertical lines in "black"
     for j in range(ncols + 1):
         lattice[:, j * (delta + 1)] = 0
 
     return lattice
 
 
-def plot_2d_diffeomorphic_map(mapping, delta = 10, fname = None,
+def plot_2d_diffeomorphic_map(mapping, delta=10, fname=None,
                               direct_grid_shape=None, direct_grid_affine=-1,
                               inverse_grid_shape=None, inverse_grid_affine=-1,
-                              show_figure = True):
+                              show_figure=True):
     r"""Draw the effect of warping a regular lattice by a diffeomorphic map.
 
     Draws a diffeomorphic map by showing the effect of the deformation on a
     regular grid. The resulting figure contains two images: the direct
-    transformation is plotted to the left, and the inverse transformation is 
+    transformation is plotted to the left, and the inverse transformation is
     plotted to the right.
 
     Parameters
@@ -140,7 +143,7 @@ def plot_2d_diffeomorphic_map(mapping, delta = 10, fname = None,
     direct_grid_affine : array, shape (3, 3) (optional)
         the affine transformation mapping the direct grid's coordinates to
         physical space. By default, this transformation will correspond to
-        the image-to-world transformation corresponding to the default 
+        the image-to-world transformation corresponding to the default
         direct_grid_shape (in general, if users specify a direct_grid_shape,
         they should also specify direct_grid_affine).
     inverse_grid_shape : tuple, shape (2,) (optional)
@@ -153,7 +156,7 @@ def plot_2d_diffeomorphic_map(mapping, delta = 10, fname = None,
     inverse_grid_affine : array, shape (3, 3) (optional)
         the affine transformation mapping inverse grid's coordinates to
         physical space. By default, this transformation will correspond to
-        the image-to-world transformation corresponding to the default 
+        the image-to-world transformation corresponding to the default
         inverse_grid_shape (in general, if users specify an inverse_grid_shape,
         they should also specify inverse_grid_affine).
     show_figure : Boolean (optional)
@@ -170,82 +173,83 @@ def plot_2d_diffeomorphic_map(mapping, delta = 10, fname = None,
 
     """
     if mapping.is_inverse:
-        #By default, direct_grid_shape is the codomain grid
+        # By default, direct_grid_shape is the codomain grid
         if direct_grid_shape is None:
             direct_grid_shape = mapping.codomain_shape
         if direct_grid_affine is -1:
             direct_grid_affine = mapping.codomain_affine
 
-        #By default, the inverse grid is the domain grid
+        # By default, the inverse grid is the domain grid
         if inverse_grid_shape is None:
             inverse_grid_shape = mapping.domain_shape
         if inverse_grid_affine is -1:
             inverse_grid_affine = mapping.domain_affine
     else:
-        #Now by default, direct_grid_shape is the mapping's input grid
+        # Now by default, direct_grid_shape is the mapping's input grid
         if direct_grid_shape is None:
             direct_grid_shape = mapping.domain_shape
         if direct_grid_affine is -1:
             direct_grid_affine = mapping.domain_affine
 
-        #By default, the output grid is the mapping's domain grid
+        # By default, the output grid is the mapping's domain grid
         if inverse_grid_shape is None:
             inverse_grid_shape = mapping.codomain_shape
         if inverse_grid_affine is -1:
             inverse_grid_affine = mapping.codomain_affine
 
-    #The world-to-image (image = drawn lattice on the output grid)
-    #transformation is the inverse of the output affine
+    # The world-to-image (image = drawn lattice on the output grid)
+    # transformation is the inverse of the output affine
     world_to_image = None
     if inverse_grid_affine is not None:
-        world_to_image = np.linalg.inv(inverse_grid_affine) 
+        world_to_image = np.linalg.inv(inverse_grid_affine)
 
-    #Draw the squares on the output grid
-    X1,X0 = np.mgrid[0:inverse_grid_shape[0], 0:inverse_grid_shape[1]]
-    lattice_out=draw_lattice_2d((inverse_grid_shape[0] + delta) / (delta + 1), 
-                                (inverse_grid_shape[1] + delta) / (delta + 1),
-                                delta)
-    lattice_out=lattice_out[0:inverse_grid_shape[0], 0:inverse_grid_shape[1]]
+    # Draw the squares on the output grid
+    X1, X0 = np.mgrid[0:inverse_grid_shape[0], 0:inverse_grid_shape[1]]
+    lattice_out = draw_lattice_2d(
+        (inverse_grid_shape[0] + delta) / (delta + 1),
+        (inverse_grid_shape[1] + delta) / (delta + 1),
+        delta)
+    lattice_out = lattice_out[0:inverse_grid_shape[0], 0:inverse_grid_shape[1]]
 
-    #Warp in the forward direction (sampling it on the input grid)
+    # Warp in the forward direction (sampling it on the input grid)
     warped_forward = mapping.transform(lattice_out, 'linear', world_to_image,
                                        direct_grid_shape, direct_grid_affine)
 
-    
-    #Now, the world-to-image (image = drawn lattice on the input grid) 
-    #transformation is the inverse of the input affine
-    world_to_image = None 
+    # Now, the world-to-image (image = drawn lattice on the input grid)
+    # transformation is the inverse of the input affine
+    world_to_image = None
     if direct_grid_affine is not None:
-        world_to_image = np.linalg.inv(direct_grid_affine) 
+        world_to_image = np.linalg.inv(direct_grid_affine)
 
-    #Draw the squares on the input grid
-    X1,X0 = np.mgrid[0:direct_grid_shape[0], 0:direct_grid_shape[1]]
-    lattice_in=draw_lattice_2d((direct_grid_shape[0] + delta) / (delta + 1), 
-                               (direct_grid_shape[1] + delta) / (delta + 1),
-                               delta)
-    lattice_in=lattice_in[0:direct_grid_shape[0], 0:direct_grid_shape[1]]
+    # Draw the squares on the input grid
+    X1, X0 = np.mgrid[0:direct_grid_shape[0], 0:direct_grid_shape[1]]
+    lattice_in = draw_lattice_2d((direct_grid_shape[0] + delta) / (delta + 1),
+                                 (direct_grid_shape[1] + delta) / (delta + 1),
+                                 delta)
+    lattice_in = lattice_in[0:direct_grid_shape[0], 0:direct_grid_shape[1]]
 
-    #Warp in the backward direction (sampling it on the output grid)
-    warped_backward = mapping.transform_inverse(lattice_in, 'linear',
-        world_to_image, inverse_grid_shape, inverse_grid_affine)
+    # Warp in the backward direction (sampling it on the output grid)
+    warped_backward = mapping.transform_inverse(
+        lattice_in, 'linear', world_to_image, inverse_grid_shape,
+        inverse_grid_affine)
 
-    #Now plot the grids
+    # Now plot the grids
     if show_figure:
         plt.figure()
 
         plt.subplot(1, 2, 1).set_axis_off()
-        plt.imshow(warped_forward, cmap = plt.cm.gray)
+        plt.imshow(warped_forward, cmap=plt.cm.gray)
         plt.title('Direct transform')
 
         plt.subplot(1, 2, 2).set_axis_off()
-        plt.imshow(warped_backward, cmap = plt.cm.gray)
+        plt.imshow(warped_backward, cmap=plt.cm.gray)
         plt.title('Inverse transform')
 
-    #Finally, save the figure to disk
+    # Finally, save the figure to disk
     if fname is not None:
-        plt.savefig(fname, bbox_inches = 'tight')
+        plt.savefig(fname, bbox_inches='tight')
 
-    #Return the deformed grids
+    # Return the deformed grids
     return warped_forward, warped_backward
 
 
@@ -271,34 +275,34 @@ def plot_slices(V, slice_indices=None, fname=None):
     if slice_indices is None:
         slice_indices = np.array(V.shape)//2
 
-    #Normalize the intensities to [0, 255]
-    sh=V.shape
-    V = np.asarray(V, dtype = np.float64)
+    # Normalize the intensities to [0, 255]
+    sh = V.shape
+    V = np.asarray(V, dtype=np.float64)
     V = 255 * (V - V.min()) / (V.max() - V.min())
 
-    #Extract the middle slices
+    # Extract the middle slices
     axial = np.asarray(V[:, :, slice_indices[2]]).astype(np.uint8).T
     coronal = np.asarray(V[:, slice_indices[1], :]).astype(np.uint8).T
     sagital = np.asarray(V[slice_indices[0], :, :]).astype(np.uint8).T
-    
-    #Plot the slices
+
+    # Plot the slices
     plt.figure()
     plt.subplot(1, 3, 1).set_axis_off()
-    plt.imshow(axial, cmap = plt.cm.gray, origin='lower')
+    plt.imshow(axial, cmap=plt.cm.gray, origin='lower')
     plt.title('Axial')
     plt.subplot(1, 3, 2).set_axis_off()
-    plt.imshow(coronal, cmap = plt.cm.gray, origin='lower')
+    plt.imshow(coronal, cmap=plt.cm.gray, origin='lower')
     plt.title('Coronal')
     plt.subplot(1, 3, 3).set_axis_off()
-    plt.imshow(sagital, cmap = plt.cm.gray, origin='lower')
+    plt.imshow(sagital, cmap=plt.cm.gray, origin='lower')
     plt.title('Sagittal')
-    
-    #Save the figure if requested
+
+    # Save the figure if requested
     if fname is not None:
         plt.savefig(fname, bbox_inches='tight')
 
 
-def overlay_slices(L, R, slice_index=None, slice_type=1, ltitle='Left', 
+def overlay_slices(L, R, slice_index=None, slice_type=1, ltitle='Left',
                    rtitle='Right', fname=None):
     r"""Plot three overlaid slices from the given volumes.
 
@@ -320,7 +324,7 @@ def overlay_slices(L, R, slice_index=None, slice_type=1, ltitle='Left',
         the index of the slices (along the axis given by slice_type) to be
         overlaid. If None, the slice along the specified axis is used
     slice_type : int (optional)
-        the type of slice to be extracted: 
+        the type of slice to be extracted:
         0=sagital, 1=coronal (default), 2=axial.
     ltitle : string (optional)
         the string to be written as title of the left image. By default,
@@ -333,57 +337,57 @@ def overlay_slices(L, R, slice_index=None, slice_type=1, ltitle='Left',
         figure is not saved to disk.
     """
 
-    #Normalize the intensities to [0,255]
+    # Normalize the intensities to [0,255]
     sh = L.shape
-    L = np.asarray(L, dtype = np.float64)
-    R = np.asarray(R, dtype = np.float64)
+    L = np.asarray(L, dtype=np.float64)
+    R = np.asarray(R, dtype=np.float64)
     L = 255 * (L - L.min()) / (L.max() - L.min())
     R = 255 * (R - R.min()) / (R.max() - R.min())
-    
-    #Create the color image to draw the overlapped slices into, and extract
-    #the slices (note the transpositions)
+
+    # Create the color image to draw the overlapped slices into, and extract
+    # the slices (note the transpositions)
     if slice_type is 0:
         if slice_index is None:
             slice_index = sh[0]//2
-        colorImage = np.zeros(shape = (sh[2], sh[1], 3), dtype = np.uint8)
+        colorImage = np.zeros(shape=(sh[2], sh[1], 3), dtype=np.uint8)
         ll = np.asarray(L[slice_index, :, :]).astype(np.uint8).T
         rr = np.asarray(R[slice_index, :, :]).astype(np.uint8).T
     elif slice_type is 1:
         if slice_index is None:
             slice_index = sh[1]//2
-        colorImage = np.zeros(shape = (sh[2], sh[0], 3), dtype = np.uint8)
+        colorImage = np.zeros(shape=(sh[2], sh[0], 3), dtype=np.uint8)
         ll = np.asarray(L[:, slice_index, :]).astype(np.uint8).T
         rr = np.asarray(R[:, slice_index, :]).astype(np.uint8).T
     elif slice_type is 2:
         if slice_index is None:
             slice_index = sh[2]//2
         slice_index = sh[2]//2
-        colorImage = np.zeros(shape = (sh[1], sh[0], 3), dtype = np.uint8)
+        colorImage = np.zeros(shape=(sh[1], sh[0], 3), dtype=np.uint8)
         ll = np.asarray(L[:, :, slice_index]).astype(np.uint8).T
         rr = np.asarray(R[:, :, slice_index]).astype(np.uint8).T
     else:
         print("Slice type must be 0, 1 or 2.")
         return
 
-    #Draw the intensity images to the appropriate channels of the color image
-    #The "(ll > ll[0, 0])" condition is just an attempt to eliminate the 
-    #background when its intensity is not exactly zero (the [0,0] corner is
-    #usually background)
+    # Draw the intensity images to the appropriate channels of the color image
+    # The "(ll > ll[0, 0])" condition is just an attempt to eliminate the
+    # background when its intensity is not exactly zero (the [0,0] corner is
+    # usually background)
     colorImage[..., 0] = ll * (ll > ll[0, 0])
     colorImage[..., 1] = rr * (rr > rr[0, 0])
 
-    #Create the figure
+    # Create the figure
     plt.figure()
     plt.subplot(1, 3, 1).set_axis_off()
-    plt.imshow(ll, cmap = plt.cm.gray, origin = 'lower')
+    plt.imshow(ll, cmap=plt.cm.gray, origin='lower')
     plt.title(ltitle)
     plt.subplot(1, 3, 2).set_axis_off()
-    plt.imshow(colorImage, origin = 'lower')
+    plt.imshow(colorImage, origin='lower')
     plt.title('Overlay')
     plt.subplot(1, 3, 3).set_axis_off()
-    plt.imshow(rr, cmap = plt.cm.gray, origin = 'lower')
+    plt.imshow(rr, cmap=plt.cm.gray, origin='lower')
     plt.title(rtitle)
 
-    #Save the figure to disk, if requested
+    # Save the figure to disk, if requested
     if fname is not None:
-        plt.savefig(fname, bbox_inches = 'tight')
+        plt.savefig(fname, bbox_inches='tight')

--- a/dipy/viz/regtools.py
+++ b/dipy/viz/regtools.py
@@ -245,9 +245,9 @@ def plot_2d_diffeomorphic_map(mapping, delta=10, fname=None,
         plt.imshow(warped_backward, cmap=plt.cm.gray)
         plt.title('Inverse transform')
 
-    # Finally, save the figure to disk
-    if fname is not None:
-        plt.savefig(fname, bbox_inches='tight')
+        # Finally, save the figure to disk
+        if fname is not None:
+            plt.savefig(fname, bbox_inches='tight')
 
     # Return the deformed grids
     return warped_forward, warped_backward


### PR DESCRIPTION
This pull request fixes two minor bugs in plot_2d_diffeomorphic_map that I came across when playing around with the new align functionality (which is great by the way!):

-  If fname is set, but show_figure is false, the call to plt.savefig() should not be performed

- The docstring states that `direct_grid_shape` and `inverse_grid_shape` should be a tuple, but if a tuple is used, the call to `mapping.transform()` raises an exception because the warp functions expect a `numpy.int32` array.

To fix this, I put a conversion to numpy.int32 within the `transform` method itself, because it is also an issue there if the provided `sampling_shape` array is not of type `numpy.int32`. 

I also removed a couple of unused mgrid variables from plot_2d_diffeomorphic_map and did some PEP8 formatting of regtools.py.

Finally, if interested, I can submit a separate pull request with an enhancement where draw_lattice_2d is generalized to draw_lattice_nd and there is a plot_diffeomorphic_map() function that works for either 2d or 3d cases.  

