### PR TITLE
RF: use cholesky to solve csd

### DIFF
--- a/dipy/reconst/benchmarks/bench_csd.py
+++ b/dipy/reconst/benchmarks/bench_csd.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import numpy as np
+import numpy.testing as npt
+
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
+from dipy.core.gradients import GradientTable
+from dipy.data import read_stanford_labels
+
+def num_grad(gtab):
+    return (~gtab.b0s_mask).sum()
+
+
+def bench_csdeconv(center=(50, 40, 40), width=12):
+    img, gtab, labels_img = read_stanford_labels()
+    data = img.get_data()
+
+    labels = labels_img.get_data()
+    shape = labels.shape
+    mask = np.in1d(labels, [1, 2])
+    mask.shape = shape
+
+    a, b, c = center
+    hw = width // 2
+    idx = (slice(a - hw, a + hw), slice(b - hw, b + hw), slice(c - hw, c + hw))
+
+    data_small = data[idx].copy()
+    mask_small = mask[idx].copy()
+    voxels = mask_small.sum()
+
+    cmd = "model.fit(data_small, mask_small)"
+    print("== Benchmarking CSD fit on %d voxels ==" % voxels)
+    msg = "SH order - %d, gradient directons - %d :: %g sec"
+
+    # Basic case
+    sh_order = 8
+    model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=sh_order)
+    time = npt.measure(cmd)
+    print(msg % (sh_order, num_grad(gtab), time))
+
+    # Smaller data set
+    data_small = data_small[..., :75].copy()
+    gtab = GradientTable(gtab.gradients[:75])
+    model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=sh_order)
+    time = npt.measure(cmd)
+    print(msg % (sh_order, num_grad(gtab), time))
+
+    # Super resolution
+    sh_order = 12
+    model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=sh_order)
+    time = npt.measure(cmd)
+    print(msg % (sh_order, num_grad(gtab), time))
+
+if __name__ == "__main__":
+    bench_csdeconv()

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -353,8 +353,7 @@ def forward_sdt_deconv_mat(ratio, n, r2_term=False):
     return np.diag(b), np.diag(bb)
 
 
-potrf, = la.lapack.get_lapack_funcs(('potrf',))
-potrs, = la.lapack.get_lapack_funcs(('potrs',))
+potrf, potrs = la.get_lapack_funcs(('potrf', 'potrs'))
 
 def _solve_cholesky(Q, z):
     L, info = potrf(Q, lower=False, overwrite_a=False, clean=False)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -132,8 +132,8 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
     @multi_voxel_fit
     def fit(self, data):
         dwi_data = data[self._where_dwi]
-        shm_coeff, _ = csdeconv(dwi_data, self.sh_order, self._X, self.B_reg,
-                                self.tau, P=self._P)
+        shm_coeff, _ = csdeconv(dwi_data, self._X, self.B_reg, self.tau,
+                                P=self._P)
         return SphHarmFit(self, shm_coeff, None)
 
 
@@ -359,7 +359,7 @@ def _solve_cholesky(Q, z):
     return f
 
 
-def csdeconv(dwsignal, sh_order, X, B_reg, tau=0.1, convergence=50, P=None):
+def csdeconv(dwsignal, X, B_reg, tau=0.1, convergence=50, P=None):
     r""" Constrained-regularized spherical deconvolution (CSD) [1]_
 
     Deconvolves the axially symmetric single fiber response function `r_rh` in
@@ -370,8 +370,6 @@ def csdeconv(dwsignal, sh_order, X, B_reg, tau=0.1, convergence=50, P=None):
     ----------
     dwsignal, : array
         Diffusion weighted signals to be deconvolved.
-    sh_order : int
-         maximal SH order of the SH representation
     X : array
         Prediction matrix which estimates diffusion weighted signals from FOD
         coefficients.

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -421,7 +421,7 @@ def csdeconv(dwsignal, X, B_reg, tau=0.1, convergence=50, P=None):
     $F(f_n) = ||Xf_n - S||^2 + \lambda^2 ||H_{n-1} f_n||^2$
 
     Where $X$ maps current FOD SH coefficients $f_n$ to DW signals $s$ and
-    $H_n-1$ maps FOD SH coefficients $f_n$ to amplitudes along set of negative
+    $H_{n-1}$ maps FOD SH coefficients $f_n$ to amplitudes along set of negative
     directions identified in previous iteration, i.e. the matrix formed by the
     rows of $B_{reg}$ for which $Hf_{n-1}<0$ where $B_{reg}$ maps $f_n$ to FOD
     amplitude on a sphere.
@@ -436,7 +436,7 @@ def csdeconv(dwsignal, X, B_reg, tau=0.1, convergence=50, P=None):
     $(X^TX + \lambda^2 H_{n-1}^TH_{n-1})f_n = X^Ts$
 
     Define $Q = X^TX + \lambda^2 H_{n-1}^TH_{n-1}$ , which by construction is a
-    square positive definite symmetric matrix of size $(n_{SH} n_{SH})$. If
+    square positive definite symmetric matrix of size $n_{SH} by n_{SH}$. If
     needed, positive definiteness can be enforced with a small minimum norm
     regulariser (helps a lot with poorly conditioned direction sets and/or
     superresolution):
@@ -461,7 +461,7 @@ def csdeconv(dwsignal, X, B_reg, tau=0.1, convergence=50, P=None):
 
         for each voxel: form $z = X^Ts$
 
-            estimate $f_0$ by solving $Pf_0=z$. We use a simplified $l_max=4$
+            estimate $f_0$ by solving $Pf_0=z$. We use a simplified $l_{max}=4$
             solution here, but it might not make a big difference.
 
             Then iterate until no change in rows of $H$ used in $H_n$

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -18,8 +18,8 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response)
 from dipy.reconst.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
-from dipy.reconst.shm import (sf_to_sh, sh_to_sf, QballModel,
-                              CsaOdfModel, sph_harm_ind_list)
+from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
+                              real_sym_sh_basis, sph_harm_ind_list)
 
 
 def test_csdeconv():
@@ -360,7 +360,8 @@ def test_default_lambda_csdmodel():
         model_full = ConstrainedSphericalDeconvModel(gtab, response,
                                                      sh_order=sh_order,
                                                      reg_sphere=sphere)
-        assert_almost_equal(model_full.lambda_, expected)
+        B_reg, _, _ = real_sym_sh_basis(sh_order, sphere.theta, sphere.phi)
+        npt.assert_array_almost_equal(model_full.B_reg, expected * B_reg)
 
 
 def test_csd_superres():


### PR DESCRIPTION
I've implemented the CSD fitting using the Cholesky decomposition. Here are the fitting times I get with the new and old versions:

New:
SH order - 8, gradient directons - 150 :: 1.76 sec
SH order - 8, gradient directons - 65 :: 2.01 sec
SH order - 12, gradient directons - 65 :: 5.77 sec

Old:
SH order - 8, gradient directons - 150 :: 7.81 sec
SH order - 8, gradient directons - 65 :: 8.22 sec
SH order - 12, gradient directons - 65 :: 30.87 sec

I'd like to include the document I got from @Garyfallidis as a reference in this PR somehow, but it's a PDF and I'm not sure the best way to do it. Should we maybe upload the PDF tot he website and include a link?
