### PR TITLE
Added option to return the number of voxels fitting the fa threshold

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -614,7 +614,7 @@ def odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15., sh_order=8,
 
 def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
                   return_number_of_voxels=False):
-    """ Automatic estimation of response function using FA
+    """ Automatic estimation of response function using FA.
 
     Parameters
     ----------
@@ -638,7 +638,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
         (`evals`, `S0`)
     ratio : float
         The ratio between smallest versus largest eigenvalue of the response.
-    number of voxels : int
+    number of voxels : int (optional)
         The number of voxels used for estimating the response function.
 
     Notes
@@ -663,7 +663,13 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
     the number of voxels used for estimating the response function is also
     returned, which can be used to judge the fidelity of the response function.
     As a rule of thumb, at least 300 voxels should be used to estimate a good
-    response function.
+    response function (see [1]_).
+    
+    References
+    ----------
+    .. [1] Tournier, J.D., et al. NeuroImage 2004. Direct estimation of the
+    fiber orientation density function from diffusion-weighted MRI
+    data using spherical deconvolution
     """
 
     ten = TensorModel(gtab)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -2,21 +2,20 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import numpy as np
 from scipy.integrate import quad
-from dipy.reconst.cache import Cache
+from scipy.special import lpn, gamma
+
 from dipy.reconst.multi_voxel import multi_voxel_fit
-from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm, order_from_ncoef,
-                              sph_harm_lookup, lazy_index, SphHarmFit,
-                              real_sym_sh_basis, sh_to_rh, gen_dirac,
-                              forward_sdeconv_mat, SphHarmModel)
 from dipy.data import small_sphere, get_sphere
 from dipy.core.geometry import cart2sphere
 from dipy.core.ndindex import ndindex
 from dipy.sims.voxel import single_tensor
 from dipy.utils.six.moves import range
 
-from scipy.special import lpn, gamma
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
-from scipy.integrate import quad
+from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm,
+                              sph_harm_lookup, lazy_index, SphHarmFit,
+                              real_sym_sh_basis, sh_to_rh, forward_sdeconv_mat,
+                              SphHarmModel)
 
 
 class ConstrainedSphericalDeconvModel(SphHarmModel):
@@ -613,7 +612,8 @@ def odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15., sh_order=8,
     return fodf_sh
 
 
-def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7):
+def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
+                  return_number_of_voxels=False):
     """ Automatic estimation of response function using FA
 
     Parameters
@@ -628,13 +628,18 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7):
         radius of cubic ROI
     fa_thr : float
         FA threshold
+    return_number_of_voxels : bool
+        If True, returns the number of voxels used for estimating the response
+        function.
 
     Returns
     -------
     response : tuple, (2,)
         (`evals`, `S0`)
     ratio : float
-        the ratio between smallest versus largest eigenvalue of the response
+        The ratio between smallest versus largest eigenvalue of the response.
+    number of voxels : int
+        The number of voxels used for estimating the response function.
 
     Notes
     -----
@@ -643,7 +648,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7):
     anisotropic configurations. For example we can use an ROI (20x20x20) at
     the center of the volume and store the signal values for the voxels with
     FA values higher than 0.7. Of course, if we haven't precalculated FA we
-    need to fit a Tensor model to the datasets. Which is what we do  in this
+    need to fit a Tensor model to the datasets. Which is what we do in this
     function.
 
     For the response we also need to find the average S0 in the ROI. This is
@@ -654,7 +659,11 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7):
     the highest and second highest eigenvalues in the ROI with FA higher than
     threshold. We also include the average S0s.
 
-    Finally, we also return the `ratio` which is used for the SDT models.
+    We also return the `ratio` which is used for the SDT models. If requested,
+    the number of voxels used for estimating the response function is also
+    returned, which can be used to judge the fidelity of the response function.
+    As a rule of thumb, at least 300 voxels should be used to estimate a good
+    response function.
     """
 
     ten = TensorModel(gtab)
@@ -668,12 +677,21 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7):
     FA = fractional_anisotropy(tenfit.evals)
     FA[np.isnan(FA)] = 0
     indices = np.where(FA > fa_thr)
+
+    if indices[0].size == 0:
+        msg = "No voxel with a FA higher than " + str(fa_thr) + " were found."
+        msg += " Try a larger roi or a lower threshold."
+        warnings.warn(msg, UserWarning)
+
     lambdas = tenfit.evals[indices][:, :2]
     S0s = roi[indices][:, np.nonzero(gtab.b0s_mask)[0]]
     S0 = np.mean(S0s)
     l01 = np.mean(lambdas, axis=0)
     evals = np.array([l01[0], l01[1], l01[1]])
     response = (evals, S0)
-    ratio = evals[1]/evals[0]
-    return response, ratio
+    ratio = evals[1] / evals[0]
 
+    if return_number_of_voxels:
+        return response, ratio, indices[0].size
+
+    return response, ratio

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -16,7 +16,7 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    odf_deconv,
                                    odf_sh_to_sharp,
                                    auto_response)
-from dipy.reconst.peaks import peak_directions, default_sphere
+from dipy.reconst.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.shm import (sf_to_sh, sh_to_sf, QballModel,
                               CsaOdfModel, sph_harm_ind_list)
@@ -88,6 +88,13 @@ def test_csdeconv():
 
     aresponse2, aratio2 = auto_response(gtab, big_S, roi_radius=3, fa_thr=0.5)
     assert_array_almost_equal(aresponse[0], response[0])
+
+    _, _, nvoxels = auto_response(gtab, big_S, roi_center=(5, 5, 4),
+                                  roi_radius=30, fa_thr=0.5, return_number_of_voxels=True)
+    assert_equal(nvoxels, 1000)
+    _, _, nvoxels = auto_response(gtab, big_S, roi_center=(5, 5, 4),
+                                  roi_radius=30, fa_thr=1, return_number_of_voxels=True)
+    assert_equal(nvoxels, 0)
 
 
 def test_odfdeconv():
@@ -231,7 +238,7 @@ def test_r2_term_odf_sharp():
     angles = [(0, 0), (angle, 0)]
 
     S, sticks = multi_tensor(gtab, mevals, S0, angles=angles,
-                             fractions=[50, 50], snr=SNR)    
+                             fractions=[50, 50], snr=SNR)
 
     odf_gt = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
     odfs_sh = sf_to_sh(odf_gt, sphere, sh_order=8, basis_type=None)
@@ -250,7 +257,7 @@ def test_r2_term_odf_sharp():
     sdt_model = ConstrainedSDTModel(gtab, ratio=3/15., sh_order=8)
     sdt_fit = sdt_model.fit(S)
     fodf = sdt_fit.odf(sphere)
-    
+
     directions_gt, _, _ = peak_directions(odf_gt, sphere)
     directions, _, _ = peak_directions(fodf, sphere)
     ang_sim = angular_similarity(directions_gt, directions)
@@ -388,4 +395,3 @@ def test_csd_superres():
 
 if __name__ == '__main__':
     run_module_suite()
-


### PR DESCRIPTION
As per the title, I added an option to return the number of voxels used in the response function estimation. That way, one can increase the roi or lower the threshold if only a small number of voxel is found.

A warning is also raised if no voxel fitting the threshold is found, which is inherently lower than 0.7 in small animal data, highly noisy data, badly behaved synthetic data, etc.