### PR TITLE
Bf cart2sphere

### DIFF
--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -126,6 +126,7 @@ def cart2sphere(x, y, z):
     '''
     r = np.sqrt(x * x + y * y + z * z)
     theta = np.arccos(z / r)
+    theta = np.where(r > 0, theta, 0.)
     phi = np.arctan2(y, x)
     r, theta, phi = np.broadcast_arrays(r, theta, phi)
     return r, theta, phi

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -64,6 +64,10 @@ def test_sphere_cart():
     xyz = sphere2cart(r, theta, phi)
     yield assert_array_almost_equal, xyz, pt
 
+    # Test full circle on x=0, y=0, z=0
+    x, y, z = sphere2cart(*cart2sphere(0., 0., 0.))
+    yield assert_array_equal, (x, y, z), (0., 0., 0.)
+
 def test_invert_transform():
     n = 100.
     theta = np.arange(n)/n * np.pi   # Limited to 0,pi


### PR DESCRIPTION
I don't think `cart2sphere(0, 0, 0)` should return any nans. Here is a fix.