### PR TITLE
docstring for tensor fit was wrong

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -748,7 +748,7 @@ class TensorModel(ReconstModel):
 
         mask : array
             A boolean array used to mark the coordinates in the data that
-            should be analyzed that has the shape data.shape[-1]
+            should be analyzed that has the shape data.shape[:-1]
 
         """
         if mask is None:


### PR DESCRIPTION
Small kind of typo according to line 762.

While I'm at it, would it be easier to instead create a mask excluding a non zero voxel like when the scanner masks the background instead of processing all voxels? All submodels could call a subfunction creating a mask where at least one voxel is not zero along the 4th D.