### PR TITLE
BF: all_tensor_evecs should rotate from eye(3) to e0.

### DIFF
--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -867,12 +867,6 @@ def vec2vec_rotmat(u, v):
     if np.sum(np.isnan(Rp)) > 0:
         return np.eye(3)
 
-    # Everything's fine, up to a sign reversal:
-    rot_back = np.dot(Rp, v)
-    sign_reverser = np.sign((np.sign(rot_back) == np.sign(u)) - 0.5).squeeze()
-    # Multiply each line by it's reverser and reassemble the matrix:
-    Rp = Rp * sign_reverser[:, np.newaxis]
-
     return Rp
 
 

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -102,6 +102,16 @@ def test_snr():
         assert_array_almost_equal(np.var(s_noise - s), sigma ** 2, decimal=2)
 
 
+def test_all_tensor_evecs():
+    e0 = np.array([1/np.sqrt(2), 1/np.sqrt(2), 0])
+
+    desired = np.array([[1/np.sqrt(2), 1/np.sqrt(2), 0],
+                        [-1/np.sqrt(2), 1/np.sqrt(2), 0],
+                        [0, 0, 1]])
+
+    assert_array_almost_equal(all_tensor_evecs(e0), desired)
+
+
 if __name__ == "__main__":
 
     test_multi_tensor()

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -353,7 +353,7 @@ def all_tensor_evecs(e0):
 
     """
     axes = np.eye(3)
-    mat = vec2vec_rotmat(e0, axes[0])
+    mat = vec2vec_rotmat(axes[0], e0)
     e1 = np.dot(mat, axes[1])
     e2 = np.dot(mat, axes[2])
     return np.array([e0, e1, e2])


### PR DESCRIPTION
This also entails removing some hackish stuff in geometry.

H/T to @cpoetter for pointing this out. 