### PR TITLE
Nf csd calibration

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -843,7 +843,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
 
 def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
                        init_fa=0.08, init_trace=0.0021, iter=8,
-                       convergence=0.001, parallel=True,
+                       convergence=0.001, parallel=True, nbr_processes=None,
                        sphere=default_sphere):
     """ Recursive calibration of response function using peak threshold
 
@@ -873,6 +873,9 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     parallel : bool, optional
         Whether to use parallelization in peak-finding during the calibration
         procedure. Default: True
+    nbr_processes: int
+        If `parallel` is True, the number of subprocesses to use
+        (default multiprocessing.cpu_count()).
     sphere : Sphere, optional.
         The sphere used for peak finding. Default: default_sphere.
     
@@ -919,7 +922,8 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
                                      sphere=sphere,
                                      relative_peak_threshold=peak_thr,
                                      min_separation_angle=25,
-                                     parallel=parallel)
+                                     parallel=parallel,
+                                     nbr_processes=nbr_processes)
 
         dirs = csd_peaks.peak_dirs
         vals = csd_peaks.peak_values

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -8,23 +8,22 @@ import scipy.linalg as la
 import scipy.linalg.lapack as ll
 
 from dipy.data import small_sphere, get_sphere
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm,
+                              order_from_ncoef, sph_harm_lookup, lazy_index,
+                              SphHarmFit, real_sym_sh_basis, sh_to_rh,
+                              gen_dirac, forward_sdeconv_mat, SphHarmModel,
+                              sh_to_sf)
+from dipy.data import get_sphere
 from dipy.core.geometry import cart2sphere
 from dipy.core.ndindex import ndindex
 from dipy.sims.voxel import single_tensor
 from dipy.utils.six.moves import range
 
-from dipy.reconst.multi_voxel import multi_voxel_fit
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
-from dipy.reconst.shm import (sph_harm_ind_list, real_sph_harm,
-                              sph_harm_lookup, lazy_index, SphHarmFit,
-                              real_sym_sh_basis, sh_to_rh, forward_sdeconv_mat,
-                              SphHarmModel)
 
 from dipy.reconst.peaks import peaks_from_model
 from dipy.core.geometry import vec2vec_rotmat
-from dipy.reconst.shm import sh_to_sf
-from dipy.viz import fvtk
-from dipy.sims.voxel import single_tensor_odf
 
 
 class ConstrainedSphericalDeconvModel(SphHarmModel):
@@ -825,7 +824,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
         peak in order to call it a single fiber population [1]
     init_fa : float
         FA of the initial 'fat' response function (tensor)
-    init_trace : fload
+    init_trace : float
         trace of the initial 'fat' response function (tensor)
     iter : int
         maximum number of iterations for calibration
@@ -860,7 +859,8 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
     if mask is None:
-        data = data[np.ones(data.shape[0:(data.ndim-1)], dtype=bool)]
+        data = data.reshape(-1, data.shape[-1])
+#        data = data[np.ones(data.shape[0:(data.ndim-1)], dtype=bool)]
     else:
         data = data[mask]
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -873,17 +873,17 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
-    r_sh_all = np.zeros(no_params)
     if mask is None:
         data = data[np.ones(data.shape[0:(data.ndim-1)], dtype=bool)]
     else:
         data = data[mask]
 
-    rot_gradients = np.zeros(gtab.gradients.shape)
+#    rot_gradients = np.zeros(gtab.gradients.shape)
     m, n = sph_harm_ind_list(sh_order)
     where_dwi = lazy_index(~gtab.b0s_mask)
 
     for num_it in range(1, iter):
+        r_sh_all = np.zeros(no_params)
         print(num_it)
         csd_model = ConstrainedSphericalDeconvModel(gtab, response,
                                                     None, sh_order)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -903,7 +903,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
         response[sh_mask] = 0
 
         change = abs((response_p[~sh_mask] - response[~sh_mask])/response_p[~sh_mask])
-        if change.all() < convergence:
+        if all(change < convergence):
             break
 
         response_p = response

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -79,7 +79,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         Parameters
         ----------
         gtab : GradientTable
-        response : tuple
+        response : tuple or AxSymShResponse object
             A tuple with two elements. The first is the eigen-values as an (3,)
             ndarray and the second is the signal value for the response
             function without diffusion weighting.  This is to be able to
@@ -852,25 +852,30 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     gtab : GradientTable
     data : ndarray
         diffusion data
-    mask : ndarray
+    mask : ndarray, optional
         mask for recursive calibration, for example a white matter mask. It has
-        shape `data.shape[0:3]` and dtype=bool.
-    sh_order : int
-        maximal spherical harmonics order
-    peak_thr : float
+        shape `data.shape[0:3]` and dtype=bool. Default: use the entire data
+        array. 
+    sh_order : int, optional
+        maximal spherical harmonics order. Default: 8
+    peak_thr : float, optional
         peak threshold, how large the second peak can be relative to the first
-        peak in order to call it a single fiber population [1]
-    init_fa : float
-        FA of the initial 'fat' response function (tensor)
-    init_trace : float
-        trace of the initial 'fat' response function (tensor)
-    iter : int
-        maximum number of iterations for calibration
-    convergence : float
-        convergence criterion, maximum relative change of SH coefficients
-    sphere : Sphere
-        The sphere used for peak finding.
-
+        peak in order to call it a single fiber population [1]. Default: 0.01
+    init_fa : float, optional
+        FA of the initial 'fat' response function (tensor). Default: 0.08
+    init_trace : float, optional
+        trace of the initial 'fat' response function (tensor). Default: 0.0021
+    iter : int, optional
+        maximum number of iterations for calibration. Default: 8.
+    convergence : float, optional
+        convergence criterion, maximum relative change of SH
+        coefficients. Default: 0.001.
+    parallel : bool, optional
+        Whether to use parallelization in peak-finding during the calibration
+        procedure. Default: True
+    sphere : Sphere, optional.
+        The sphere used for peak finding. Default: default_sphere.
+    
     Returns
     -------
     response : ndarray

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -24,6 +24,7 @@ from dipy.reconst.dti import TensorModel, fractional_anisotropy
 
 from dipy.reconst.peaks import peaks_from_model
 from dipy.core.geometry import vec2vec_rotmat
+from dipy.core.sphere import HemiSphere
 
 
 class ConstrainedSphericalDeconvModel(SphHarmModel):
@@ -855,6 +856,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     evals = fa_trace_to_lambdas(init_fa, init_trace)
     response = (evals, S0)
     sphere = get_sphere('symmetric724')
+    hemisphere = HemiSphere.from_sphere(sphere)
 
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
@@ -865,6 +867,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
         data = data[mask]
 
     m, n = sph_harm_ind_list(sh_order)
+    sh_mask = m != 0
     where_dwi = lazy_index(~gtab.b0s_mask)
 
     for num_it in range(1, iter):
@@ -874,7 +877,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
         csd_peaks = peaks_from_model(model=csd_model,
                                      data=data,
-                                     sphere=sphere,
+                                     sphere=hemisphere,
                                      relative_peak_threshold=peak_thr,
                                      min_separation_angle=25,
                                      parallel=parallel)
@@ -898,8 +901,9 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
                                                   data[num_vox, where_dwi])[0]
 
         response = r_sh_all/data.shape[0]
+        response[sh_mask] = 0
 
-        change = abs((response_p - response)/response_p)
+        change = abs((response_p[~sh_mask] - response[~sh_mask])/response_p[~sh_mask])
         if change.all() < convergence:
             break
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -111,15 +111,18 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         self.B_reg = real_sph_harm(m, n, theta[:, None], phi[:, None])
 
         if response is None:
-            S_r = estimate_response(gtab, np.array([0.0015, 0.0003, 0.0003]), 1)
-            r_sh = np.linalg.lstsq(self.B_dwi, S_r[self._where_dwi])[0]
+            self.response = (np.array([0.0015, 0.0003, 0.0003]), 1)
+            self.S_r = estimate_response(gtab, self.response)
+            r_sh = np.linalg.lstsq(self.B_dwi, self.S_r[self._where_dwi])[0]
             r_rh = sh_to_rh(r_sh, m, n)
         elif isinstance(response, tuple):
-            S_r = estimate_response(gtab, response[0], response[1])
-            r_sh = np.linalg.lstsq(self.B_dwi, S_r[self._where_dwi])[0]
+            self.response = response
+            self.S_r = estimate_response(gtab, self.response[0], self.response[1])
+            r_sh = np.linalg.lstsq(self.B_dwi, self.S_r[self._where_dwi])[0]
             r_rh = sh_to_rh(r_sh, m, n)
         else:
-            r_rh = sh_to_rh(response, m, n)
+            self.response = response
+            r_rh = sh_to_rh(self.response, m, n)
 
         self.R = forward_sdeconv_mat(r_rh, n)
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -124,6 +124,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             self.response = response
             r_rh = sh_to_rh(self.response, m, n)
 
+        self.response_scaling = self.response[1]
         self.R = forward_sdeconv_mat(r_rh, n)
 
         # scale lambda_ to account for differences in the number of

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -849,20 +849,20 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     calibrates the response function, for more information see [1].
 
     References
-        ----------
-        .. [1] Tax, C.M.W., et al. NeuroImage 2014. Recursive calibration of
-               the fiber response function for spherical deconvolution of
-               diffusion MRI data
+    ----------
+    .. [1] Tax, C.M.W., et al. NeuroImage 2014. Recursive calibration of
+           the fiber response function for spherical deconvolution of
+           diffusion MRI data.
     """
-    vis = True
+    vis = False
 
     S0 = 1
     evals = fa_trace_to_lambdas(init_fa, init_trace)
 #    evals = np.array([0.0015, 0.0003, 0.0003])
     response = (evals, S0)
-
+    sphere = get_sphere('symmetric724')
     if vis is True:
-        sphere = get_sphere('symmetric724')
+
         ren = fvtk.ren()
         evals = response[0]
         evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
@@ -919,9 +919,11 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
         for num_vox in range(0, data.shape[0]):
             rotmat = vec2vec_rotmat(dirs[num_vox, 0], np.array([0, 0, 1]))
-            for num_grad in range(0, gtab.gradients.shape[0]):
-                rot_gradients[num_grad] = np.dot(rotmat,
-                                                 gtab.gradients[num_grad])
+            #for num_grad in range(0, gtab.gradients.shape[0]):
+            #    rot_gradients[num_grad] = np.dot(rotmat,
+            #                                    gtab.gradients[num_grad])
+
+            rot_gradients = np.dot(rotmat, gtab.gradients.T).T
 
             x, y, z = rot_gradients[where_dwi].T
             r, theta, phi = cart2sphere(x, y, z)

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -856,7 +856,6 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
     evals = fa_trace_to_lambdas(init_fa, init_trace)
     response = (evals, S0)
     sphere = get_sphere('symmetric724')
-    hemisphere = HemiSphere.from_sphere(sphere)
 
     no_params = ((sh_order + 1) * (sh_order + 2)) / 2
     response_p = np.ones(no_params)
@@ -877,7 +876,7 @@ def recursive_response(gtab, data, mask=None, sh_order=8, peak_thr=0.01,
 
         csd_peaks = peaks_from_model(model=csd_model,
                                      data=data,
-                                     sphere=hemisphere,
+                                     sphere=sphere,
                                      relative_peak_threshold=peak_thr,
                                      min_separation_angle=25,
                                      parallel=parallel)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -60,7 +60,7 @@ def test_recursive_response_calibration():
     odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
     response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.08,
+                                  peak_thr=0.01, init_fa=0.1,
                                   init_trace=0.0021, iter=8, convergence=0.001,
                                   parallel=False)
 

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -52,12 +52,6 @@ def test_recursive_response_calibration():
 
     S_single = single_tensor(gtab, S0, evals, evecs, snr=SNR)
 
-    m, n = sph_harm_ind_list(sh_order)
-    x, y, z = gtab.gradients[where_dwi].T
-    r, theta, phi = cart2sphere(x, y, z)
-    B_dwi = real_sph_harm(m, n, theta[:, None], phi[:, None])
-    sh = np.linalg.lstsq(B_dwi, S_single[where_dwi])[0]
-
     data = np.concatenate((np.tile(S_cross, (8, 1)), np.tile(S_single, (2, 1))),
                           axis=0)
 

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -8,7 +8,7 @@ from dipy.data import get_sphere, get_data, default_sphere, small_sphere
 from dipy.sims.voxel import (multi_tensor,
                              single_tensor,
                              multi_tensor_odf,
-                             all_tensor_evecs)
+                             all_tensor_evecs, single_tensor_odf)
 from dipy.core.gradients import gradient_table
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    ConstrainedSDTModel,
@@ -18,54 +18,90 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response, recursive_response)
 from dipy.reconst.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
-
 from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
-                              real_sym_sh_basis, sph_harm_ind_list)
+                              real_sym_sh_basis, sph_harm_ind_list, real_sph_harm)
+from dipy.reconst.shm import lazy_index
+from dipy.core.geometry import cart2sphere
+import dipy.reconst.dti as dti
+from dipy.reconst.dti import fractional_anisotropy
+from dipy.core.sphere import Sphere
 
 
 def test_recursive_response_calibration():
     SNR = 100
     S0 = 1
+    sh_order = 8
 
     _, fbvals, fbvecs = get_data('small_64D')
 
     bvals = np.load(fbvals)
     bvecs = np.load(fbvecs)
+    sphere = get_sphere('symmetric724')
 
     gtab = gradient_table(bvals, bvecs)
     evals = np.array([0.0015, 0.0003, 0.0003])
+    evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
-    evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
+    angles = [(0, 0), (60, 0)]
 
-    angles = [(0, 0), (90, 0)]
+    where_dwi = lazy_index(~gtab.b0s_mask)
 
     S_cross, sticks_cross = multi_tensor(gtab, mevals, S0, angles=angles,
                                          fractions=[50, 50], snr=SNR)
 
     S_single = single_tensor(gtab, S0, evals, evecs, snr=SNR)
 
-    data = np.concatenate((np.tile(S_cross, (8, 1)), np.tile(S_single, (2, 1))), axis=0)
-    data = np.concatenate(np.tile(S_single, (2, 1)), axis=0)
-#    where_dwi = lazy_index(~gtab.b0s_mask)
+    m, n = sph_harm_ind_list(sh_order)
+    x, y, z = gtab.gradients[where_dwi].T
+    r, theta, phi = cart2sphere(x, y, z)
+    B_dwi = real_sph_harm(m, n, theta[:, None], phi[:, None])
+    sh = np.linalg.lstsq(B_dwi, S_single[where_dwi])[0]
 
-    sphere = get_sphere('symmetric362')
+    data = np.concatenate((np.tile(S_cross, (8, 1)), np.tile(S_single, (2, 1))),
+                          axis=0)
 
-#    ren = fvtk.ren()
-#    response_actor = fvtk.sphere_funcs(data[:, where_dwi], bvecs)
-#    fvtk.add(ren, response_actor)
-#    fvtk.show(ren)
+    odf_gt_cross = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
 
-
-    odf_gt = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
+    odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
     response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.05,
-                                  init_trace=0.0021, iter=8, convergence=0.01)
+                                  peak_thr=0.01, init_fa=0.08,
+                                  init_trace=0.0021, iter=8, convergence=0.001,
+                                  parallel=False)
 
     csd = ConstrainedSphericalDeconvModel(gtab, response)
 
     csd_fit = csd.fit(data)
+
+    assert_equal(csd_fit.shm_coeff[:, 0].all > 0, True)
+
+    fodf = csd_fit.odf(sphere)
+
+    directions_gt_single, _, _ = peak_directions(odf_gt_single, sphere)
+    directions_gt_cross, _, _ = peak_directions(odf_gt_cross, sphere)
+    directions_single, _, _ = peak_directions(fodf[8, :], sphere)
+    directions_cross, _, _ = peak_directions(fodf[0, :], sphere)
+
+    ang_sim = angular_similarity(directions_cross, directions_gt_cross)
+    assert_equal(ang_sim > 1.9, True)
+    assert_equal(directions_cross.shape[0], 2)
+    assert_equal(directions_gt_cross.shape[0], 2)
+
+    ang_sim = angular_similarity(directions_single, directions_gt_single)
+    assert_equal(ang_sim > 0.9, True)
+    assert_equal(directions_single.shape[0], 1)
+    assert_equal(directions_gt_single.shape[0], 1)
+
+    sf = sh_to_sf(response, Sphere(xyz=gtab.gradients[where_dwi]), sh_order, None)
+    sf = np.concatenate((np.array([S0]), sf))
+
+    tenmodel = dti.TensorModel(gtab, min_signal=0.001)
+
+    tenfit = tenmodel.fit(sf)
+    FA = fractional_anisotropy(tenfit.evals)
+    FA_gt = fractional_anisotropy(evals)
+    assert_almost_equal(FA, FA_gt, 2)
 
 
 def test_csdeconv():

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -19,7 +19,7 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
 from dipy.reconst.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
-                              real_sym_sh_basis, sph_harm_ind_list, real_sph_harm)
+                              real_sym_sh_basis, sph_harm_ind_list)
 from dipy.reconst.shm import lazy_index
 from dipy.core.geometry import cart2sphere
 import dipy.reconst.dti as dti
@@ -88,12 +88,13 @@ def test_recursive_response_calibration():
     assert_equal(directions_single.shape[0], 1)
     assert_equal(directions_gt_single.shape[0], 1)
 
-    sf = sh_to_sf(response, Sphere(xyz=gtab.gradients[where_dwi]), sh_order, None)
-    sf = np.concatenate((np.array([S0]), sf))
+    sphere = Sphere(xyz=gtab.gradients[where_dwi])
+    sf = response.on_sphere(sphere)
+    S = np.concatenate(([response.S0], sf))
 
     tenmodel = dti.TensorModel(gtab, min_signal=0.001)
 
-    tenfit = tenmodel.fit(sf)
+    tenfit = tenmodel.fit(S)
     FA = fractional_anisotropy(tenfit.evals)
     FA_gt = fractional_anisotropy(evals)
     assert_almost_equal(FA, FA_gt, 1)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -41,9 +41,10 @@ def test_recursive_response_calibration():
     gtab = gradient_table(bvals, bvecs)
     evals = np.array([0.0015, 0.0003, 0.0003])
     evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
+#    evecs = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).T
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
-    angles = [(0, 0), (60, 0)]
+    angles = [(0, 0), (90, 0)]
 
     where_dwi = lazy_index(~gtab.b0s_mask)
 
@@ -60,7 +61,7 @@ def test_recursive_response_calibration():
     odf_gt_single = single_tensor_odf(sphere.vertices, evals, evecs)
 
     response = recursive_response(gtab, data, mask=None, sh_order=8,
-                                  peak_thr=0.01, init_fa=0.1,
+                                  peak_thr=0.01, init_fa=0.05,
                                   init_trace=0.0021, iter=8, convergence=0.001,
                                   parallel=False)
 
@@ -95,7 +96,7 @@ def test_recursive_response_calibration():
     tenfit = tenmodel.fit(sf)
     FA = fractional_anisotropy(tenfit.evals)
     FA_gt = fractional_anisotropy(evals)
-    assert_almost_equal(FA, FA_gt, 2)
+    assert_almost_equal(FA, FA_gt, 1)
 
 
 def test_csdeconv():

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -22,6 +22,7 @@ from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
                               real_sym_sh_basis, sph_harm_ind_list)
 
 
+
 def test_csdeconv():
     SNR = 100
     S0 = 1

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -68,7 +68,7 @@ def test_recursive_response_calibration():
 
     csd_fit = csd.fit(data)
 
-    assert_equal(csd_fit.shm_coeff[:, 0].all > 0, True)
+    assert_equal(np.all(csd_fit.shm_coeff[:, 0] >= 0), True)
 
     fodf = csd_fit.odf(sphere)
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -145,7 +145,7 @@ response_actor = fvtk.sphere_funcs(response_signal, sphere)
 ren = fvtk.ren()
 
 fvtk.add(ren, response_actor)
-print('Saving illustration as csd_response.png')
+print('Saving illustration as csd_recursive_response.png')
 fvtk.record(ren, out_path='csd_recursive_response.png', size=(200, 200))
 
 """

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -75,25 +75,15 @@ response's function's ODF. Here is how:
 """
 
 from dipy.viz import fvtk
-
 ren = fvtk.ren()
-
 evals = response[0]
-
 evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
-
 from dipy.data import get_sphere
-
 sphere = get_sphere('symmetric724')
-
 from dipy.sims.voxel import single_tensor_odf
-
 response_odf = single_tensor_odf(sphere.vertices, evals, evecs)
-
 response_actor = fvtk.sphere_funcs(response_odf, sphere)
-
 fvtk.add(ren, response_actor)
-
 print('Saving illustration as csd_response.png')
 fvtk.record(ren, out_path='csd_response.png', size=(200, 200))
 
@@ -109,9 +99,11 @@ fvtk.rm(ren, response_actor)
 
 """
 However, using an FA threshold is not a very robust method. It is dependent on
-the dataset (non-informed used subjectivity), and still depends on the diffusion tensor
-(FA and first eigenvector), which has low accuracy at high b-value. Alternatively,
-one can calibrate the response function directly from the data according to [Tax2014]_.
+the dataset (non-informed used subjectivity), and still depends on the
+diffusion tensor (FA and first eigenvector), which has low accuracy at high
+b-value. Alternatively, one can calibrate the response function directly from
+the data according to [Tax2014]_. 
+
 First, the data is deconvolved with a 'fat' response function. All voxels that
 contain only one peak (as determined by the peak threshold which gives an upper
 limit of the ratio of the second peak to the first peak) are maintained, and from
@@ -119,8 +111,6 @@ these voxels a new response function is determined. This process is repeated
 until convergence is reached. Here we calibrate the response function on a small
 part of the data.
 """
-
-data_small = data[20:50, 55:85, 38:39]
 
 from dipy.reconst.csdeconv import recursive_response
 
@@ -130,17 +120,12 @@ based on the DTI fit.
 """
 
 import dipy.reconst.dti as dti
-
 tenmodel = dti.TensorModel(gtab)
-
 tenfit = tenmodel.fit(data, mask=data[..., 0] > 200)
 
 from dipy.reconst.dti import fractional_anisotropy
-
 FA = fractional_anisotropy(tenfit.evals)
-
 MD = dti.mean_diffusivity(tenfit.evals)
-
 wm_mask = (np.logical_or(FA >= 0.4, (np.logical_and(FA >= 0.15, MD >= 0.0011))))
 
 response = recursive_response(gtab, data, mask=wm_mask, sh_order=8,
@@ -150,8 +135,8 @@ response = recursive_response(gtab, data, mask=wm_mask, sh_order=8,
 
 
 """
-We can check the shape of the signal of the response function, which should be like
-a pancake:
+We can check the shape of the signal of the response function, which should be
+like  a pancake:
 """
 
 response_signal = response.on_sphere(sphere)
@@ -160,7 +145,7 @@ response_actor = fvtk.sphere_funcs(response_signal, sphere)
 ren = fvtk.ren()
 
 fvtk.add(ren, response_actor)
-
+print('Saving illustration as csd_response.png')
 fvtk.record(ren, out_path='csd_recursive_response.png', size=(200, 200))
 
 """
@@ -179,13 +164,12 @@ process. Let's import the CSD model and fit the datasets.
 """
 
 from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
-
 csd_model = ConstrainedSphericalDeconvModel(gtab, response)
 
 """
-For illustration purposes we will fit only a slice of the datasets.
+For illustration purposes we will fit only a small portion of the data.
 """
-
+data_small = data[20:50, 55:85, 38:39]
 csd_fit = csd_model.fit(data_small)
 
 """
@@ -212,7 +196,7 @@ fvtk.record(ren, out_path='csd_odfs.png', size=(600, 600))
    **CSD ODFs**.
 
 In Dipy we also provide tools for finding the peak directions (maxima) of the
-ODFs. For this purpose we strongly recommend using ``peaks_from_model``.
+ODFs. For this purpose we recommend using ``peaks_from_model``.
 """
 
 from dipy.direction import peaks_from_model
@@ -225,9 +209,7 @@ csd_peaks = peaks_from_model(model=csd_model,
                              parallel=True)
 
 fvtk.clear(ren)
-
 fodf_peaks = fvtk.peaks(csd_peaks.peak_dirs, csd_peaks.peak_values, scale=1.3)
-
 fvtk.add(ren, fodf_peaks)
 
 print('Saving illustration as csd_peaks.png')

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -154,10 +154,7 @@ We can check the shape of the signal of the response function, which should be l
 a pancake:
 """
 
-from dipy.reconst.shm import sh_to_sf
-
-response_signal = sh_to_sf(response, sphere, sh_order=8, basis_type=None)
-
+response_signal = response.on_sphere(sphere)
 response_actor = fvtk.sphere_funcs(response_signal, sphere)
 
 ren = fvtk.ren()

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -74,6 +74,12 @@ We can double check that we have a good response function by visualizing the
 response's function's ODF. Here is how:
 """
 
+data_small = data[20:30, 55:65, 38:39]
+
+from dipy.reconst.csdeconv import recursive_response
+
+response = recursive_response(gtab, data_small, mask=None, sh_order=8, peak_thr=0.01, init_fa=0.05, init_trace=0.0021, iter=8, convergence=0.01)
+
 from dipy.viz import fvtk
 
 ren = fvtk.ren()
@@ -120,7 +126,7 @@ csd_model = ConstrainedSphericalDeconvModel(gtab, response)
 For illustration purposes we will fit only a slice of the datasets.
 """
 
-data_small = data[20:50, 55:85, 38:39]
+data_small = data[20:30, 55:65, 38:39]
 
 csd_fit = csd_model.fit(data_small)
 


### PR DESCRIPTION
I re-based #404 to clean it up a little bit. The changes I made are:

1) Took out new functions in `dipy.reconst.shm`, these functions were not being called or tested. (Did this via rebase).
2) I re-worked a little bit how the SH response was being handled. Only axially symmetric SH functions are needed so we don't bother to fit all the SH functions and zero out the non-symmetric coefficients. This should improve accuracy and performance.
3) Changed recursive_response to use `default_sphere`. 
4) Fixed issue with response_scaling being wrong when an SH response was used.

@arokem  @ChantalTax can you guys look over this.