### PR TITLE
BF: csd predict multi

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -213,7 +213,6 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         predict_matrix = SH_basis * self.R.diagonal()
         S0 = np.asarray(S0)[..., None]
         scaling = S0 / self.response_scaling
-
         # This is the key operation: convolve and multiply by S0:
         pre_pred_sig = scaling * np.dot(predict_matrix, sh_coeff)
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -152,7 +152,8 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             n_response = response.n
             m_response = response.m
         else:
-            self.S_r = estimate_response(gtab, self.response[0], self.response[1])
+            self.S_r = estimate_response(gtab, self.response[0],
+                                         self.response[1])
             r_sh = np.linalg.lstsq(self.B_dwi, self.S_r[self._where_dwi])[0]
             n_response = n
             m_response = m
@@ -181,8 +182,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
 
     def predict(self, sh_coeff, gtab=None, S0=1):
         """Compute a signal prediction given spherical harmonic coefficients
-        and (optionally) a response function for the provided GradientTable
-        class instance.
+        for the provided GradientTable class instance.
 
         Parameters
         ----------
@@ -232,7 +232,7 @@ class ConstrainedSDTModel(SphHarmModel):
 
         The SDT computes a fiber orientation distribution (FOD) as opposed to a
         diffusion ODF as the QballModel or the CsaOdfModel. This results in a
-        sharper angular profile with better angular resolution. The Contrained
+        sharper angular profile with better angular resolution. The Constrained
         SDTModel is similar to the Constrained CSDModel but mathematically it
         deconvolves the q-ball ODF as oppposed to the HARDI signal (see [1]_
         for a comparison and a through discussion).

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -61,6 +61,33 @@ class MultiVoxelFit(ReconstFit):
         else:
             return item
 
+    def predict(self, *args, **kwargs):
+        """
+        Predict for the multi-voxel object using each single-object's
+        prediction API, with S0 provided from an array.
+        """
+        if not hasattr(self.model, 'predict'):
+            msg = "This model does not have prediction implemented yet"
+            raise NotImplementedError(msg)
+
+        S0 = kwargs.get('S0', np.ones(self.fit_array.shape))
+        idx = ndindex(self.fit_array.shape)
+        ijk = idx.next()
+        def gimme_S0(S0, ijk):
+            if isinstance(S0, np.ndarray):
+                return S0[ijk]
+            else:
+                return S0
+
+        kwargs['S0'] = gimme_S0(S0, ijk)
+        first_pred = self.fit_array[ijk].predict(*args, **kwargs)
+        result = np.empty(self.fit_array.shape + (first_pred.shape[-1],))
+        result[ijk] = first_pred
+        for ijk in idx:
+            kwargs['S0'] = gimme_S0(S0, ijk)
+            result[ijk] = self.fit_array[ijk].predict(*args, **kwargs)
+
+        return result
 
 class CallableArray(np.ndarray):
     """An array which can be called like a function"""

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -72,7 +72,7 @@ class MultiVoxelFit(ReconstFit):
 
         S0 = kwargs.get('S0', np.ones(self.fit_array.shape))
         idx = ndindex(self.fit_array.shape)
-        ijk = idx.next()
+        ijk = next(idx)
         def gimme_S0(S0, ijk):
             if isinstance(S0, np.ndarray):
                 return S0[ijk]

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -613,7 +613,6 @@ class SphHarmFit(OdfFit):
         """
         return self._shm_coef
 
-
     def predict(self, gtab=None, S0=1.0):
         """
         Predict the diffusion signal from the model coefficients.
@@ -624,9 +623,8 @@ class SphHarmFit(OdfFit):
             The directions and bvalues on which prediction is desired
 
         S0 : float array
-           The mean non-diffusion-weighted signal in each voxel. Default: 1 in
-           all voxels
-
+           The mean non-diffusion-weighted signal in each voxel.
+           Default: 1.0 in all voxels
         """
         if not hasattr(self.model, 'predict'):
             msg = "This model does not have prediction implemented yet"

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -392,26 +392,20 @@ def test_csd_predict_multi():
 
     """
     SNR = 100
-    S0 = 1
+    S0 = 123.
     _, fbvals, fbvecs = get_data('small_64D')
     bvals = np.load(fbvals)
     bvecs = np.load(fbvecs)
     gtab = gradient_table(bvals, bvecs)
-    mevals = np.array(([0.0015, 0.0003, 0.0003],
-                       [0.0015, 0.0003, 0.0003]))
-    angles = [(0, 0), (60, 0)]
-    S, sticks = multi_tensor(gtab, mevals, S0, angles=angles,
-                             fractions=[50, 50], snr=SNR)
-    sphere = small_sphere
-    odf_gt = multi_tensor_odf(sphere.vertices, mevals, angles, [50, 50])
     response = (np.array([0.0015, 0.0003, 0.0003]), S0)
-
     csd = ConstrainedSphericalDeconvModel(gtab, response)
-    multi_S = np.array([[S, S], [S, S]]) * 123.
+    coeff = np.random.random(45) - .5
+    coeff[..., 0] = 10.
+    S = csd.predict(coeff, S0=123.)
+    multi_S = np.array([[S, S], [S, S]])
     csd_fit_multi = csd.fit(multi_S)
     S0_multi = np.mean(multi_S[..., gtab.b0s_mask], -1)
     pred_multi = csd_fit_multi.predict(S0=S0_multi)
-    npt.assert_equal(pred_multi.shape, multi_S.shape)
     npt.assert_array_almost_equal(pred_multi, multi_S)
 
 


### PR DESCRIPTION
Prediction from arrays of models was failing. Specifically, for multi-voxel fits, we need to provide an array of S0, which matches the 3D shape of the data. In the previous implementation, this silently added multiple dimensions to the array. The solution proposed here is to push the prediction in the `MultiVoxelFit` object, so that it calls out to each individual item's prediction, with the right S0 taken from the inputs (or defaulting to the right thing - all 1's).