### PR TITLE
Fixed undetected compilation errors prior to Cython 0.22

### DIFF
--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -153,7 +153,7 @@ cdef class ClustersCentroid(Clusters):
 
         Clusters.c_assign(self, id_cluster, id_element, element)
 
-    cdef int c_update(ClustersCentroid self, np.npy_intp id_cluster) nogil:
+    cdef int c_update(ClustersCentroid self, np.npy_intp id_cluster) nogil except -1:
         """ Update the centroid of a cluster.
 
         Parameters

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -36,7 +36,7 @@ cdef class Feature(object):
         def __set__(self, int value):
             self.is_order_invariant = bool(value)
 
-    cdef Shape c_infer_shape(Feature self, Data2D datum) nogil:
+    cdef Shape c_infer_shape(Feature self, Data2D datum) nogil  except *:
         """ Cython version of `Feature.infer_shape`. """
         with gil:
             shape = self.infer_shape(np.asarray(datum))
@@ -49,7 +49,7 @@ cdef class Feature(object):
             else:
                 raise TypeError("Only scalar, 1D or 2D array features are supported!")
 
-    cdef void c_extract(Feature self, Data2D datum, Data2D out) nogil:
+    cdef void c_extract(Feature self, Data2D datum, Data2D out) nogil  except *:
         """ Cython version of `Feature.extract`. """
         cdef Data2D c_features
         with gil:
@@ -174,10 +174,10 @@ cdef class IdentityFeature(CythonFeature):
     def __init__(IdentityFeature self):
         super(IdentityFeature, self).__init__(is_order_invariant=False)
 
-    cdef Shape c_infer_shape(IdentityFeature self, Data2D datum) nogil:
+    cdef Shape c_infer_shape(IdentityFeature self, Data2D datum) nogil except *:
         return shape_from_memview(datum)
 
-    cdef void c_extract(IdentityFeature self, Data2D datum, Data2D out) nogil:
+    cdef void c_extract(IdentityFeature self, Data2D datum, Data2D out) nogil except *:
         cdef:
             int N = datum.shape[0], D = datum.shape[1]
             int n, d
@@ -199,7 +199,7 @@ cdef class CenterOfMassFeature(CythonFeature):
     def __init__(CenterOfMassFeature self):
         super(CenterOfMassFeature, self).__init__(is_order_invariant=True)
 
-    cdef Shape c_infer_shape(CenterOfMassFeature self, Data2D datum) nogil:
+    cdef Shape c_infer_shape(CenterOfMassFeature self, Data2D datum) nogil except *:
         cdef Shape shape
         shape.ndim = 2
         shape.dims[0] = 1
@@ -207,7 +207,7 @@ cdef class CenterOfMassFeature(CythonFeature):
         shape.size = datum.shape[1]
         return shape
 
-    cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) nogil:
+    cdef void c_extract(CenterOfMassFeature self, Data2D datum, Data2D out) nogil except *:
         cdef int N = datum.shape[0], D = datum.shape[1]
         cdef int i, d
 

--- a/dipy/segment/metricspeed.pxd
+++ b/dipy/segment/metricspeed.pxd
@@ -6,8 +6,8 @@ cdef class Metric(object):
     cdef Feature feature
     cdef int is_order_invariant
 
-    cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1.0
+    cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1
     cdef int c_are_compatible(Metric self, Shape shape1, Shape shape2) nogil except -1
 
-    cpdef double dist(Metric self, features1, features2) except -1.0
+    cpdef double dist(Metric self, features1, features2) except -1
     cpdef are_compatible(Metric self, shape1, shape2)

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -49,7 +49,7 @@ cdef class Metric(object):
         with gil:
             return self.are_compatible(shape2tuple(shape1), shape2tuple(shape2))
 
-    cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1.0:
+    cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1:
         """ Cython version of `Metric.dist`. """
         with gil:
             return self.dist(np.asarray(features1), np.asarray(features2))
@@ -74,7 +74,7 @@ cdef class Metric(object):
         """
         raise NotImplementedError("Metric's subclasses must implement method `are_compatible(self, shape1, shape2)`!")
 
-    cpdef double dist(Metric self, features1, features2) except -1.0:
+    cpdef double dist(Metric self, features1, features2) except -1:
         """ Computes a distance between two data points based on their features.
 
         Parameters
@@ -134,7 +134,7 @@ cdef class CythonMetric(Metric):
         """
         return self.c_are_compatible(tuple2shape(shape1), tuple2shape(shape2)) == 1
 
-    cpdef double dist(CythonMetric self, features1, features2) except -1.0:
+    cpdef double dist(CythonMetric self, features1, features2) except -1:
         """ Computes a distance between two data points based on their features.
 
         Parameters
@@ -191,7 +191,7 @@ cdef class SumPointwiseEuclideanMetric(CythonMetric):
     is equal to $a+b+c$ where $a$ is the Euclidean distance between s1[0] and
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
-    cdef double c_dist(SumPointwiseEuclideanMetric self, Data2D features1, Data2D features2) nogil except -1.0:
+    cdef double c_dist(SumPointwiseEuclideanMetric self, Data2D features1, Data2D features2) nogil except -1:
         cdef :
             int N = features1.shape[0], D = features1.shape[1]
             int n, d
@@ -243,7 +243,7 @@ cdef class AveragePointwiseEuclideanMetric(SumPointwiseEuclideanMetric):
     is equal to $(a+b+c)/3$ where $a$ is the Euclidean distance between s1[0] and
     s2[0], $b$ between s1[1] and s2[1] and $c$ between s1[2] and s2[2].
     """
-    cdef double c_dist(AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2) nogil except -1.0:
+    cdef double c_dist(AveragePointwiseEuclideanMetric self, Data2D features1, Data2D features2) nogil except -1:
         cdef int N = features1.shape[0]
         cdef double dist = SumPointwiseEuclideanMetric.c_dist(self, features1, features2)
         return dist / N
@@ -284,7 +284,7 @@ cdef class MinimumAverageDirectFlipMetric(AveragePointwiseEuclideanMetric):
         def __get__(MinimumAverageDirectFlipMetric self):
             return True  # Ordering is handled in the distance computation
 
-    cdef double c_dist(MinimumAverageDirectFlipMetric self, Data2D features1, Data2D features2) nogil except -1.0:
+    cdef double c_dist(MinimumAverageDirectFlipMetric self, Data2D features1, Data2D features2) nogil except -1:
         cdef double dist_direct = AveragePointwiseEuclideanMetric.c_dist(self, features1, features2)
         cdef double dist_flipped = AveragePointwiseEuclideanMetric.c_dist(self, features1, features2[::-1])
         return min(dist_direct, dist_flipped)
@@ -334,7 +334,7 @@ cpdef distance_matrix(Metric metric, data1, data2=None):
     return distance_matrix
 
 
-cpdef double dist(Metric metric, datum1, datum2) except -1.0:
+cpdef double dist(Metric metric, datum1, datum2) except -1:
     """ Computes a distance between `datum1` and `datum2`.
 
     A sequence of N-dimensional points is represented as a 2D array with

--- a/dipy/tracking/local/tissue_classifier.pyx
+++ b/dipy/tracking/local/tissue_classifier.pyx
@@ -26,7 +26,7 @@ cdef class BinaryTissueClassifier(TissueClassifier):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef TissueClass check_point(self, double[::1] point):
+    cpdef TissueClass check_point(self, double[::1] point) except PYERROR:
         cdef:
             unsigned char result
             int err
@@ -122,7 +122,7 @@ cdef class ActTissueClassifier(TissueClassifier):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.initializedcheck(False)
-    cpdef TissueClass check_point(self, double[::1] point):
+    cpdef TissueClass check_point(self, double[::1] point) except PYERROR:
         cdef:
             double include_result, exclude_result
             int include_err, exclude_err


### PR DESCRIPTION
Fixes compilation errors in Cython code.

Cython's version 0.22 fixes the following bug "* Mismatching 'except' declarations on signatures in .pxd and .pyx files failed to produce a compile error".

Closes #597 