### PR TITLE
Added build status icon to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://travis-ci.org/nipy/dipy.svg?branch=master
+    :target: https://travis-ci.org/nipy/dipy
 ======
  DIPY
 ======


### PR DESCRIPTION
Looks so nice! As for why it's useful since pull request are already all passing build test before merging, think of what happened with cython 0.22 giving failures everywhere for no particular reason. Same thing could happen to the master branch if a dependency becomes borked up/change it's API between two master merge, and nobody would likely notice it. A seemingly unlucky random user could clone a non working version and claim the whole thing to be broken due to pure (un)luck.

Which brings me to this little icon. Well, it only makes sense if the build triggers automatically from time to time or for each merge, which would make it not cover the case stated here. But anyway, it still useful for first time users to see the master branch is working. 

At the same time, why is the project's title in all caps? It always bug me, since it's the only place in the readme where it's like that, as opposed to having the first letter capitalized and everything else not capitalized (is there an english word for non-capitalized letters? Just curious).