### PR TITLE
DOC: Corrected typos in Restore tutorial and docstring.

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1345,7 +1345,7 @@ def _nlls_err_func(tensor, design_matrix, data, weighting=None,
         all directions (when a float is provided), or to an estimate of the
         noise in each diffusion-weighting direction (if an array is
         provided). If 'gmm', the Geman-Mclure M-estimator is used for
-        weighting (see Notes.
+        weighting (see Notes).
 
     Notes
     -----

--- a/doc/examples/restore_dti.py
+++ b/doc/examples/restore_dti.py
@@ -8,7 +8,7 @@ but not other kinds, such as "physiological" noise. For example, if a subject
 moves during the acquisition of one of the diffusion-weighted samples, this
 might have a substantial effect on the parameters of the tensor fit calculated
 in all voxels in the brain for that subject. One of the pernicious consequences
-of this is that it can lead to wrong interepertation of group differences. For
+of this is that it can lead to wrong interpretation of group differences. For
 example, some groups of participants (e.g. young children, patient groups,
 etc.) are particularly prone to motion and differences in tensor parameters and
 derived statistics (such as FA) due to motion would be confounded with actual
@@ -85,7 +85,7 @@ And use them to index into the data:
 data = img.get_data()[roi_idx]
 
 """
-This data-set is not very noisy, so we will artificially corrupt it to simulate
+This dataset is not very noisy, so we will artificially corrupt it to simulate
 the effects of "physiological" noise, such as subject motion. But first, let's
 establish a baseline, using the data as it is:
 """


### PR DESCRIPTION
Found 2 small typos in the restore tutorial + a missing closing parenthesis in reconst/dti.py.