### PR TITLE
BF: Add missing opacity property to point actor

### DIFF
--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -623,6 +623,7 @@ def point(points, colors, opacity=1, point_radius=0.1, theta=8, phi=8):
         mapper.SetInputData(glyph.GetOutput())
     actor = vtk.vtkActor()
     actor.SetMapper(mapper)
+    actor.GetProperty().SetOpacity(opacity)
 
     return actor
 


### PR DESCRIPTION
I'm playing with some example visualizations of points and lines, and noticed that changing opacity argument in point actor didn't work so I added it. It works, but it also shows some little artifacts in order of rendering when you use lower opacity---works as before with opacity=1. I'll explore the topic.