### PR TITLE
NF - multiprocessing multi voxel fit

### DIFF
--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -21,7 +21,6 @@ def multi_voxel_fit(single_voxel_fit):
     """
     def new_fit(self, data, mask=None, nbr_processes=1):
         """Fit method for every voxel in data"""
-
         # If only one voxel just return a normal fit
         if data.ndim == 1:
             return single_voxel_fit(self, data)

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -46,7 +46,7 @@ def multi_voxel_fit(single_voxel_fit):
         return MultiVoxelFit(self, fit_array, mask)
 
     def parallel_fit(self, data, mask, nbr_processes):
-        if nbr_processes is None or nbr_processes == 0:
+        if nbr_processes < 1:
             try:
                 nbr_processes = cpu_count()
             except NotImplementedError:

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -19,7 +19,7 @@ def multi_voxel_fit(single_voxel_fit):
     """Method decorator to turn a single voxel model fit
     definition into a multi voxel model fit definition
     """
-    def new_fit(self, data, mask=None, nbr_processes=2):
+    def new_fit(self, data, mask=None, nbr_processes=1):
         """Fit method for every voxel in data"""
 
         # If only one voxel just return a normal fit
@@ -36,7 +36,7 @@ def multi_voxel_fit(single_voxel_fit):
             raise ValueError("mask and data shape do not match")
 
         # Lauch mutliprocessing is nbr_processes != 1
-        if not nbr_processes == 1 and np.sum(mask > 0) > nbr_processes:
+        if not nbr_processes == 1:
             return parallel_fit(self, data, mask, nbr_processes)
 
         # Fit data where mask is True
@@ -47,7 +47,6 @@ def multi_voxel_fit(single_voxel_fit):
         return MultiVoxelFit(self, fit_array, mask)
 
     def parallel_fit(self, data, mask, nbr_processes):
-
         if nbr_processes is None or nbr_processes == 0:
             try:
                 nbr_processes = cpu_count()

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -1,4 +1,12 @@
 """Tools to easily make multi voxel models"""
+
+from itertools import repeat
+from multiprocessing import cpu_count, Pool
+from os import path
+from warnings import warn
+
+import dill
+from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
@@ -11,8 +19,9 @@ def multi_voxel_fit(single_voxel_fit):
     """Method decorator to turn a single voxel model fit
     definition into a multi voxel model fit definition
     """
-    def new_fit(self, data, mask=None):
+    def new_fit(self, data, mask=None, nbr_processes=2):
         """Fit method for every voxel in data"""
+
         # If only one voxel just return a normal fit
         if data.ndim == 1:
             return single_voxel_fit(self, data)
@@ -26,14 +35,81 @@ def multi_voxel_fit(single_voxel_fit):
         elif mask.shape != data.shape[:-1]:
             raise ValueError("mask and data shape do not match")
 
+        # Lauch mutliprocessing is nbr_processes != 1
+        if not nbr_processes == 1 and np.sum(mask > 0) > nbr_processes:
+            return parallel_fit(self, data, mask, nbr_processes)
+
         # Fit data where mask is True
         fit_array = np.empty(data.shape[:-1], dtype=object)
         for ijk in ndindex(data.shape[:-1]):
             if mask[ijk]:
                 fit_array[ijk] = single_voxel_fit(self, data[ijk])
         return MultiVoxelFit(self, fit_array, mask)
+
+    def parallel_fit(self, data, mask, nbr_processes):
+
+        if nbr_processes is None or nbr_processes == 0:
+            try:
+                nbr_processes = cpu_count()
+            except NotImplementedError:
+                warn("Cannot determine number of cpus. \
+                     Uses a single process")
+                return new_fit(self, data, mask=mask, nbr_processes=1)
+
+        shape = mask.shape
+        data = np.reshape(data, (-1, data.shape[-1]))
+        n = np.prod(mask.shape)
+
+        nbr_chunks = min(nbr_processes ** 2, n)
+        chunk_size = int(np.ceil(n / nbr_chunks))
+        indices = list(zip(np.arange(0, n, chunk_size),
+                           np.arange(0, n, chunk_size) + chunk_size))
+
+        with InTemporaryDirectory() as tmpdir:
+            data_file_name = path.join(tmpdir, 'data.npy')
+            np.save(data_file_name, data)
+            if mask is not None:
+                mask = mask.flatten()
+                mask_file_name = path.join(tmpdir, 'mask.npy')
+                np.save(mask_file_name, mask)
+            else:
+                mask_file_name = None
+
+            pool = Pool(nbr_processes)
+            results = pool.map(_fit_parallel_sub,
+                               zip(repeat((data_file_name, mask_file_name)),
+                                   indices,
+                                   repeat(self),
+                                   repeat(dill.dumps(single_voxel_fit))))
+            pool.close()
+        fit_array = np.empty(len(mask), dtype=object)
+        for i, (start_pos, end_pos) in enumerate(indices):
+            fit_array[start_pos: end_pos] = results[i]
+
+        # Make sure all worker processes have exited before leaving context
+        # manager in order to prevent temporary file deletion errors in windows
+        pool.join()
+
+        fit_array = np.reshape(fit_array, shape)
+        mask = np.reshape(mask, shape)
+        return MultiVoxelFit(self, fit_array, mask)
+
     return new_fit
 
+def _fit_parallel_sub(args):
+    (data_file_name, mask_file_name) = args[0]
+    (start_pos, end_pos) = args[1]
+    self = args[2]
+    single_voxel_fit = dill.loads(args[3])
+    data = np.load(data_file_name, mmap_mode='r')[start_pos:end_pos]
+    mask = np.load(mask_file_name, mmap_mode='r')[start_pos:end_pos]
+
+    fit_array = np.empty(len(mask), dtype=object)
+    for i in range(len(mask)):
+        if mask[i]:
+            fit_array[i] = single_voxel_fit(self, data[i])
+
+    return fit_array
 
 class MultiVoxelFit(ReconstFit):
     """Holds an array of fits and allows access to their attributes and

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -105,28 +105,29 @@ def test_CallableArray():
     npt.assert_array_equal(callarray(4), expected)
 
 
+class SillyModel(object):
+
+    @multi_voxel_fit
+    def fit(self, data, mask=None):
+        return SillyFit(self)
+
+
+class SillyFit(object):
+
+    def __init__(self, model):
+        self.model = model
+
+    model_attr = 2.
+
+    def odf(self, sphere):
+        return np.ones(len(sphere.phi))
+
+    @property
+    def directions(self):
+        n = np.random.randint(0, 10)
+        return np.zeros((n, 3))
+
 def test_multi_voxel_fit():
-
-    class SillyModel(object):
-
-        @multi_voxel_fit
-        def fit(self, data, mask=None):
-            return SillyFit(model)
-
-    class SillyFit(object):
-
-        def __init__(self, model):
-            self.model = model
-
-        model_attr = 2.
-
-        def odf(self, sphere):
-            return np.ones(len(sphere.phi))
-
-        @property
-        def directions(self):
-            n = np.random.randint(0, 10)
-            return np.zeros((n, 3))
 
     # Test the single voxel case
     model = SillyModel()
@@ -148,6 +149,41 @@ def test_multi_voxel_fit():
     mask = np.eye(3).astype('bool')
     data = np.zeros((3, 3, 64))
     fit = model.fit(data, mask)
+    npt.assert_array_equal(fit.model_attr, np.eye(3) * 2)
+    odf = fit.odf(unit_icosahedron)
+    npt.assert_equal(odf.shape, (3, 3, 12))
+    npt.assert_array_equal(odf[~mask], 0)
+    npt.assert_array_equal(odf[mask], 1)
+
+    # Test fit.shape
+    npt.assert_equal(fit.shape, (3, 3))
+
+    # Test indexing into a fit
+    npt.assert_equal(type(fit[0, 0]), SillyFit)
+    npt.assert_equal(fit[:2, :2].shape, (2, 2))
+
+def test_multi_voxel_fit_parallel():
+
+    # Test the single voxel case
+    model = SillyModel()
+    single_voxel = np.zeros(64)
+    fit = model.fit(single_voxel, nbr_processes=4)
+    npt.assert_equal(type(fit), SillyFit)
+
+    # Test without a mask
+    many_voxels = np.zeros((2, 3, 4, 64))
+    fit = model.fit(many_voxels, nbr_processes=4)
+    expected = np.empty((2, 3, 4))
+    expected[:] = 2.
+    npt.assert_array_equal(fit.model_attr, expected)
+    expected = np.ones((2, 3, 4, 12))
+    npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
+    npt.assert_equal(fit.directions.shape, (2, 3, 4))
+
+    # Test with a mask
+    mask = np.eye(3).astype('bool')
+    data = np.zeros((3, 3, 64))
+    fit = model.fit(data, mask, nbr_processes=4)
     npt.assert_array_equal(fit.model_attr, np.eye(3) * 2)
     odf = fit.odf(unit_icosahedron)
     npt.assert_equal(odf.shape, (3, 3, 12))


### PR DESCRIPTION
This is pretty straight forward. I did the multiprocessing in the same way as in peaks_from_model. This work with all models implementing the multi_voxel_fit. 

My main concern is the new dependency to dill (https://pypi.python.org/pypi/dill). I needed dill to serialize the single voxel fit function and send it to subprocesses. I didn't found a way without. What do you suggest?

I had to put SillyModel and SillyFit out the test_..() fct, since they need to be imported in subprocesses.

thanks, 
Gab
