### PR TITLE
Added estimate_sigma bias correction + update example

### DIFF
--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -275,8 +275,8 @@ def estimate_sigma(arr, disable_background_masking=False, N=1):
     This function is the same as manually taking the standard deviation of the
     background and gives one value for the whole 3D array.
     It also includes the coil-dependent correction factor of Koay 2006
-    (see [1], equation 18) with theta = 0.
-    Since this function was introduced in [2] for T1 imaging,
+    (see [1]_, equation 18) with theta = 0.
+    Since this function was introduced in [2]_ for T1 imaging,
     it is expected to perform ok on diffusion MRI data, but might oversmooth
     some regions and leave others un-denoised for spatially varying noise profiles.
     Consider using :func:`piesno` to estimate sigma instead if visual inacuracies
@@ -284,11 +284,11 @@ def estimate_sigma(arr, disable_background_masking=False, N=1):
 
     Reference
     -------
-    [1] Koay, C. G., & Basser, P. J. (2006). Analytically exact correction
+    .. [1] Koay, C. G., & Basser, P. J. (2006). Analytically exact correction
     scheme for signal extraction from noisy magnitude MR signals.
     Journal of Magnetic Resonance), 179(2), 317-22.
 
-    [2] Coupe, P., Yger, P., Prima, S., Hellier, P., Kervrann, C., Barillot, C., 2008.
+    .. [2] Coupe, P., Yger, P., Prima, S., Hellier, P., Kervrann, C., Barillot, C., 2008.
     An optimized blockwise nonlocal means denoising filter for 3-D magnetic
     resonance images, IEEE Trans. Med. Imaging 27, 425-41.
     """

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -270,23 +270,28 @@ def estimate_sigma(arr, disable_background_masking=False, N=1):
     sigma : ndarray
         standard deviation of the noise, one estimation per volume.
 
+    Note
+    -------
+    This function is the same as manually taking the standard deviation of the
+    background and gives one value for the whole 3D array.
+    It also includes the coil-dependent correction factor of Koay 2006 (see [1], equation 18)
+    with theta = 0
+    Since this function was introduced in [2] T1 imaging, it is expected to
+    perform ok on diffusion MRI data,  but might oversmooth some regions and
+    leave others un-denoised for spatially varying noise profiles.
+    Consider using :func:`piesno` to estimate sigma instead if visual inacuracies
+    are apparent in the denoised result.
+
     Reference
     -------
     [1] Koay, C. G., & Basser, P. J. (2006). Analytically exact correction
     scheme for signal extraction from noisy magnitude MR signals.
-    Journal of Magnetic Resonance), 179(2), 317–22.
+    Journal of Magnetic Resonance), 179(2), 317-22.
 
-    Note
-    -------
-    This function is the same as manually taking the standard deviation of the
-    background and gives one value for the whole 3D array. Since it was
-    developped for T1 imaging. It is expected to perform ok on diffusion MRI data,
-    but might oversmooth some regions and leave others un-denoised if the noise
-    varies spatially (especially near the middle of the image).
-    Consider using piesno instead if you see visual inacuracies
-    with nlmeans and estimate_sigma.
+    [2] Coupe, P., Yger, P., Prima, S., Hellier, P., Kervrann, C., Barillot, C., 2008.
+    An optimized blockwise nonlocal means denoising filter for 3-D magnetic
+    resonance images, IEEE Trans. Med. Imaging 27, 425-41.
     """
-
     k = np.zeros((3, 3, 3), dtype=np.int8)
 
     k[0, 1, 1] = 1
@@ -311,7 +316,8 @@ def estimate_sigma(arr, disable_background_masking=False, N=1):
     if N in correction_factor:
         factor = correction_factor[N]
     else:
-        factor = correction_factor[1]
+        raise ValueError("N = {0} is not supported! Please choose amongst \
+{1}".format(N, sorted(list(correction_factor.keys()))))
 
     if arr.ndim == 3:
         sigma = np.zeros(1, dtype=np.float32)

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -92,12 +92,10 @@ def piesno(data, N, alpha=0.01, l=100, itermax=100, eps=1e-5, return_mask=False)
         mask_noise = np.zeros(data.shape[:-1], dtype=np.bool)
 
         for idx in range(data.shape[-2]):
-            sigma[idx], mask_noise[..., idx] = _piesno_3D(data[..., idx, :], N,
-                                                          alpha=alpha,
-                                                          l=l,
-                                                          itermax=itermax,
-                                                          eps=eps,
-                                                          return_mask=True)
+            sigma[idx], mask_noise[..., idx] = _piesno_3D(data[..., idx, :],
+                                                          N, alpha=alpha,
+                                                          l=l, itermax=itermax,
+                                                          eps=eps, return_mask=True)
 
     else:
         sigma, mask_noise = _piesno_3D(data, N,

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -274,11 +274,11 @@ def estimate_sigma(arr, disable_background_masking=False, N=1):
     -------
     This function is the same as manually taking the standard deviation of the
     background and gives one value for the whole 3D array.
-    It also includes the coil-dependent correction factor of Koay 2006 (see [1], equation 18)
-    with theta = 0
-    Since this function was introduced in [2] T1 imaging, it is expected to
-    perform ok on diffusion MRI data,  but might oversmooth some regions and
-    leave others un-denoised for spatially varying noise profiles.
+    It also includes the coil-dependent correction factor of Koay 2006
+    (see [1], equation 18) with theta = 0.
+    Since this function was introduced in [2] for T1 imaging,
+    it is expected to perform ok on diffusion MRI data, but might oversmooth
+    some regions and leave others un-denoised for spatially varying noise profiles.
     Consider using :func:`piesno` to estimate sigma instead if visual inacuracies
     are apparent in the denoised result.
 

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -46,20 +46,24 @@ def test_estimate_sigma():
 
     arr = np.zeros((3, 3, 3))
     arr[0, 0, 0] = 1
-    sigma = estimate_sigma(arr, disable_background_masking=False)
-    assert_array_almost_equal(sigma, 0.10286889997472792)
+    sigma = estimate_sigma(arr, disable_background_masking=False, N=1)
+    assert_array_almost_equal(sigma, 0.10286889997472792 / np.sqrt(0.42920367320510366))
 
     arr = np.zeros((3, 3, 3, 3))
     arr[0, 0, 0] = 1
-    sigma = estimate_sigma(arr, disable_background_masking=False)
-    assert_array_almost_equal(sigma, np.array([0.10286889997472792, 0.10286889997472792, 0.10286889997472792]))
+    sigma = estimate_sigma(arr, disable_background_masking=False, N=1)
+    assert_array_almost_equal(sigma, np.array([0.10286889997472792 / np.sqrt(0.42920367320510366),
+                                               0.10286889997472792 / np.sqrt(0.42920367320510366),
+                                               0.10286889997472792 / np.sqrt(0.42920367320510366)]))
 
     arr = np.zeros((3, 3, 3))
     arr[0, 0, 0] = 1
-    sigma = estimate_sigma(arr, disable_background_masking=True)
-    assert_array_almost_equal(sigma, 0.46291005)
+    sigma = estimate_sigma(arr, disable_background_masking=True, N=4)
+    assert_array_almost_equal(sigma, 0.46291005 / np.sqrt(0.4834941393603609))
 
     arr = np.zeros((3, 3, 3, 3))
     arr[0, 0, 0] = 1
-    sigma = estimate_sigma(arr, disable_background_masking=True)
-    assert_array_almost_equal(sigma, np.array([0.46291005, 0.46291005, 0.46291005]))
+    sigma = estimate_sigma(arr, disable_background_masking=True, N=12)
+    assert_array_almost_equal(sigma, np.array([0.46291005 / np.sqrt(0.4946862482541263),
+                                               0.46291005 / np.sqrt(0.4946862482541263),
+                                               0.46291005 / np.sqrt(0.4946862482541263)]))

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -104,38 +104,38 @@ def geodesic_anisotropy(evals, axis=-1):
 
     .. math::
 
-        GA = \sqrt{\sum_{i=1}^3 \log^2{\left ( \lambda_i/<\mathbf{D}> \right )}}, 
+        GA = \sqrt{\sum_{i=1}^3 \log^2{\left ( \lambda_i/<\mathbf{D}> \right )}},
         \quad \textrm{where} \quad <\mathbf{D}> = (\lambda_1\lambda_2\lambda_3)^{1/3}
 
-    Note that the notation, $<D>$, is often used as the mean diffusivity (MD) of the diffusion tensor 
-    and can lead to confusions in the literature (see [1]_ versus [2]_ versus [3]_ for example).    
-    Reference [2]_ defines geodesic anisotropy (GA) with $<D>$ as the MD in the denominator of the sum. 
-    This is wrong. The original paper [1]_ defines GA with $<D> = det(D)^{1/3}$, as the 
+    Note that the notation, $<D>$, is often used as the mean diffusivity (MD) of the diffusion tensor
+    and can lead to confusions in the literature (see [1]_ versus [2]_ versus [3]_ for example).
+    Reference [2]_ defines geodesic anisotropy (GA) with $<D>$ as the MD in the denominator of the sum.
+    This is wrong. The original paper [1]_ defines GA with $<D> = det(D)^{1/3}$, as the
     isotropic part of the distance. This might be an explanation for the confusion.
     The isotropic part of the diffusion tensor in Euclidean space is
-    the MD whereas the isotropic part of the tensor in log-Euclidean space is $det(D)^{1/3}$. 
+    the MD whereas the isotropic part of the tensor in log-Euclidean space is $det(D)^{1/3}$.
     The Appendix of [1]_ and log-Euclidean derivations from [3]_ are clear on this.
     Hence, all that to say that $<D> = det(D)^{1/3}$ here for the GA definition and not MD.
 
     References
     ----------
 
-    .. [1] P. G. Batchelor, M. Moakher, D. Atkinson, F. Calamante, A. Connelly, 
-        "A rigorous framework for diffusion tensor calculus", Magnetic Resonance 
+    .. [1] P. G. Batchelor, M. Moakher, D. Atkinson, F. Calamante, A. Connelly,
+        "A rigorous framework for diffusion tensor calculus", Magnetic Resonance
         in Medicine, vol. 53, pp. 221-225, 2005.
 
     .. [2] M. M. Correia, V. F. Newcombe, G.B. Williams.
-        "Contrast-to-noise ratios for indices of anisotropy obtained from diffusion MRI: 
+        "Contrast-to-noise ratios for indices of anisotropy obtained from diffusion MRI:
         a study with standard clinical b-values at 3T". NeuroImage, vol. 57, pp. 1103-1115, 2011.
 
-    .. [3] A. D. Lee, etal, P. M. Thompson.  
-        "Comparison of fractional and geodesic anisotropy in diffusion tensor images 
-        of 90 monozygotic and dizygotic twins". 5th IEEE International Symposium on 
+    .. [3] A. D. Lee, etal, P. M. Thompson.
+        "Comparison of fractional and geodesic anisotropy in diffusion tensor images
+        of 90 monozygotic and dizygotic twins". 5th IEEE International Symposium on
         Biomedical Imaging (ISBI), pp. 943-946, May 2008.
 
-    .. [4] V. Arsigny, P. Fillard, X. Pennec, N. Ayache. 
+    .. [4] V. Arsigny, P. Fillard, X. Pennec, N. Ayache.
         "Log-Euclidean metrics for fast and simple calculus on diffusion tensors."
-        Magnetic Resonance in Medecine, vol 56, pp. 411-421, 2006. 
+        Magnetic Resonance in Medecine, vol 56, pp. 411-421, 2006.
 
     """
 
@@ -146,7 +146,7 @@ def geodesic_anisotropy(evals, axis=-1):
     log2 = np.zeros(ev1.shape)
     log3 = np.zeros(ev1.shape)
     idx = np.nonzero(ev1)
-    
+
     # this is the definition in [1]_
     detD = np.power(ev1 * ev2 * ev3, 1/3.)
     log1[idx] = np.log(ev1[idx] / detD[idx])
@@ -154,7 +154,7 @@ def geodesic_anisotropy(evals, axis=-1):
     log3[idx] = np.log(ev3[idx] / detD[idx])
 
     ga = np.sqrt(log1 ** 2 + log2 ** 2 + log3 ** 2)
-    
+
     return ga
 
 def mean_diffusivity(evals, axis=-1):
@@ -733,7 +733,7 @@ class TensorModel(ReconstModel):
 
     def _min_positive_signal(self, data):
         data = data.ravel()
-        if np.all(data==0):
+        if np.all(data == 0):
             return 0.0001
         else:
             return data[data > 0].min()
@@ -761,12 +761,12 @@ class TensorModel(ReconstModel):
             mask = np.array(mask, dtype=bool, copy=False)
             data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
-        
+
         if self.min_signal is None:
             min_signal = self._min_positive_signal(data)
         else:
             min_signal = self.min_signal
-        
+
         data_in_mask = np.maximum(data_in_mask, min_signal)
         params_in_mask = self.fit_method(self.design_matrix, data_in_mask,
                                          *self.args, **self.kwargs)
@@ -1493,13 +1493,13 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
         # The parameters are the evals and the evecs:
         try:
-            evals,evecs=decompose_tensor(from_lower_triangular(this_tensor[:6]))
+            evals, evecs = decompose_tensor(from_lower_triangular(this_tensor[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
         except np.linalg.LinAlgError:
-            evals,evecs=decompose_tensor(from_lower_triangular(start_params[:6]))
+            evals, evecs = decompose_tensor(from_lower_triangular(start_params[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
 
@@ -1608,26 +1608,26 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True):
                     this_sigma = sigma
 
                 if jac:
-                    this_tensor, status= opt.leastsq(_nlls_err_func,
+                    this_tensor, status = opt.leastsq(_nlls_err_func,
                                                      start_params,
                                                      args=(clean_design,
                                                            clean_sig),
                                                      Dfun=_nlls_jacobian_func)
                 else:
-                    this_tensor, status= opt.leastsq(_nlls_err_func,
+                    this_tensor, status = opt.leastsq(_nlls_err_func,
                                                      start_params,
                                                      args=(clean_design,
                                                            clean_sig))
 
         # The parameters are the evals and the evecs:
         try:
-            evals,evecs=decompose_tensor(from_lower_triangular(this_tensor[:6]))
+            evals, evecs = decompose_tensor(from_lower_triangular(this_tensor[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
         except np.linalg.LinAlgError:
-            evals,evecs=decompose_tensor(from_lower_triangular(start_params[:6]))
+            evals, evecs = decompose_tensor(from_lower_triangular(start_params[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
 


### PR DESCRIPTION
So I added the correction factor for computing the std of magnitude images. Since they do not include any negative value, the variance is lower and the mean is shifted as compared ot a gaussian distribution. This factor corrects that fact and returns a closer estimate of the variance.
I also updated the example to show this fact and changed it to show a slice of diffusion instea,d since b0 images are always relatively clean.

Since estimate_sigma is the same as computing the variance over the background, the correction factor needs an estimate of the local magnitude SNR, but it is zero in that specific case. Hence, the value can be precomputed without using hyp1f1. Next step is to have it on a voxelwise basis with said hyp1f1 function in need of love over here : https://github.com/nipy/dipy/issues/650