### PR TITLE
Fix compilation error caused by inline functions 

### DIFF
--- a/dipy/align/vector_fields.pxd
+++ b/dipy/align/vector_fields.pxd
@@ -1,10 +1,52 @@
+#!python
+#cython: boundscheck=False
+#cython: wraparound=False
+#cython: cdivision=True
+
 cdef inline double _apply_affine_3d_x0(double x0, double x1, double x2,
-                                       double h, double[:, :] aff) nogil
+                                       double h, double[:, :] aff) nogil:
+    r"""Multiplies aff by (x0, x1, x2, h), returns the 1st element of product
+
+    Returns the first component of the product of the homogeneous matrix aff by
+    (x0, x1, x2, h)
+    """
+    return aff[0, 0] * x0 + aff[0, 1] * x1 + aff[0, 2] * x2 + h*aff[0, 3]
+
+
 cdef inline double _apply_affine_3d_x1(double x0, double x1, double x2,
-                                       double h, double[:, :] aff) nogil
+                                       double h, double[:, :] aff) nogil:
+    r"""Multiplies aff by (x0, x1, x2, h), returns the 2nd element of product
+
+    Returns the first component of the product of the homogeneous matrix aff by
+    (x0, x1, x2, h)
+    """
+    return aff[1, 0] * x0 + aff[1, 1] * x1 + aff[1, 2] * x2 + h*aff[1, 3]
+
+
 cdef inline double _apply_affine_3d_x2(double x0, double x1, double x2,
-                                       double h, double[:, :] aff) nogil
+                                       double h, double[:, :] aff) nogil:
+    r"""Multiplies aff by (x0, x1, x2, h), returns the 3d element of product
+
+    Returns the first component of the product of the homogeneous matrix aff by
+    (x0, x1, x2, h)
+    """
+    return aff[2, 0] * x0 + aff[2, 1] * x1 + aff[2, 2] * x2 + h*aff[2, 3]
+
+
 cdef inline double _apply_affine_2d_x0(double x0, double x1, double h,
-                                       double[:, :] aff) nogil
+                                       double[:, :] aff) nogil:
+    r"""Multiplies aff by (x0, x1, h), returns the 1st element of product
+    Returns the first component of the product of the homogeneous matrix aff by
+    (x0, x1, h)
+    """
+    return aff[0, 0] * x0 + aff[0, 1] * x1 + h*aff[0, 2]
+
+
 cdef inline double _apply_affine_2d_x1(double x0, double x1, double h,
-                                       double[:, :] aff) nogil
+                                       double[:, :] aff) nogil:
+    r"""Multiplies aff by (x0, x1, h), returns the 2nd element of product
+
+    Returns the first component of the product of the homogeneous matrix aff by
+    (x0, x1, h)
+    """
+    return aff[1, 0] * x0 + aff[1, 1] * x1 + h*aff[1, 2]

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -11,54 +11,6 @@ cdef extern from "dpy_math.h" nogil:
     double floor(double)
     double sqrt(double)
 
-cdef inline double _apply_affine_3d_x0(double x0, double x1, double x2,
-                                       double h, double[:, :] aff) nogil:
-    r"""Multiplies aff by (x0, x1, x2, h), returns the 1st element of product
-
-    Returns the first component of the product of the homogeneous matrix aff by
-    (x0, x1, x2, h)
-    """
-    return aff[0, 0] * x0 + aff[0, 1] * x1 + aff[0, 2] * x2 + h*aff[0, 3]
-
-
-cdef inline double _apply_affine_3d_x1(double x0, double x1, double x2,
-                                       double h, double[:, :] aff) nogil:
-    r"""Multiplies aff by (x0, x1, x2, h), returns the 2nd element of product
-
-    Returns the first component of the product of the homogeneous matrix aff by
-    (x0, x1, x2, h)
-    """
-    return aff[1, 0] * x0 + aff[1, 1] * x1 + aff[1, 2] * x2 + h*aff[1, 3]
-
-
-cdef inline double _apply_affine_3d_x2(double x0, double x1, double x2,
-                                       double h, double[:, :] aff) nogil:
-    r"""Multiplies aff by (x0, x1, x2, h), returns the 3d element of product
-
-    Returns the first component of the product of the homogeneous matrix aff by
-    (x0, x1, x2, h)
-    """
-    return aff[2, 0] * x0 + aff[2, 1] * x1 + aff[2, 2] * x2 + h*aff[2, 3]
-
-
-cdef inline double _apply_affine_2d_x0(double x0, double x1, double h,
-                                       double[:, :] aff) nogil:
-    r"""Multiplies aff by (x0, x1, h), returns the 1st element of product
-    Returns the first component of the product of the homogeneous matrix aff by
-    (x0, x1, h)
-    """
-    return aff[0, 0] * x0 + aff[0, 1] * x1 + h*aff[0, 2]
-
-
-cdef inline double _apply_affine_2d_x1(double x0, double x1, double h,
-                                       double[:, :] aff) nogil:
-    r"""Multiplies aff by (x0, x1, h), returns the 2nd element of product
-
-    Returns the first component of the product of the homogeneous matrix aff by
-    (x0, x1, h)
-    """
-    return aff[1, 0] * x0 + aff[1, 1] * x1 + h*aff[1, 2]
-
 
 def is_valid_affine(double[:, :] M, int dim):
     if M is None:


### PR DESCRIPTION
If inline functions are just declared in the pxd, cython attempts to declare inline pointers to them, which is invalid since variables cannot be declared inline. According to this:
http://docs.cython.org/src/tutorial/pxd_files.html
inline functions should be defined, not just declared in the pxd.
Unfortunately, right now I don't have access to the buildbots to try this, but in theory this should fix the issue.
