### PR TITLE
Test DTI eigenvectors

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -853,7 +853,7 @@ class TensorFit(object):
     @property
     def evecs(self):
         """
-        Returns the eigenvectors of the tensor as an array
+        Returns the eigenvectors of the tensor as an array, columnwise
         """
         evecs = self.model_params[..., 3:12]
         return evecs.reshape(self.shape + (3, 3))

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -112,8 +112,8 @@ def test_tensor_model():
     # Check that eigenvalues and eigenvectors are properly sorted through
     # that previous operation:
     for i in range(3):
-        assert_array_equal(np.dot(tensor, evecs[:, i]),
-                           evals[i] * evecs[:, i])
+        assert_array_almost_equal(np.dot(tensor, evecs[:, i]),
+                                  evals[i] * evecs[:, i])
     # Design Matrix
     X = dti.design_matrix(gtab)
     # Signals

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -136,8 +136,8 @@ def test_tensor_model():
             # so we need to allow for sign flips. One of the following should
             # always be true:
             assert_(
-            np.all(np.abs(tensor_fit.evecs[0][:, 0] - evecs[:, 0]) < 10e-6) or
-            np.all(np.abs(-tensor_fit.evecs[0][:, 0] - evecs[:, 0]) < 10e-6 ))
+            np.all(np.abs(tensor_fit.evecs[0][:, i] - evecs[:, i]) < 10e-6) or
+            np.all(np.abs(-tensor_fit.evecs[0][:, i] - evecs[:, i]) < 10e-6 ))
             # We set a fixed tolerance of 10e-6, similar to array_almost_equal
 
         assert_array_almost_equal(tensor_fit.quadratic_form[0], tensor,

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -106,7 +106,7 @@ def test_tensor_model():
     tensor = from_lower_triangular(D)
     A_squiggle = tensor - (1 / 3.0) * np.trace(tensor) * np.eye(3)
     mode = 3 * np.sqrt(6) * np.linalg.det(A_squiggle / np.linalg.norm(A_squiggle))
-    evals_eigh, evecs_eigh = np.linalg.eigh(tensor.T)
+    evals_eigh, evecs_eigh = np.linalg.eigh(tensor)
     # Sort according to eigen-value from large to small:
     evecs = evecs_eigh[:, np.argsort(evals_eigh)[::-1]]
     # Check that eigenvalues and eigenvectors are properly sorted through

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -131,7 +131,7 @@ def test_tensor_model():
         assert_equal(tensor_fit.shape, Y.shape[:-1])
         assert_array_almost_equal(tensor_fit.evals[0], evals)
         # Test that the eigenvectors are correct, one-by-one:
-        for vv in range(3):
+        for i in range(3):
             # Eigenvectors have intrinsic sign ambiguity (see http://prod.sandia.gov/techlib/access-control.cgi/2007/076422.pdf)
             # so we need to allow for sign flips. One of the following should
             # always be true:

--- a/dipy/reconst/tests/test_shore_metrics.py
+++ b/dipy/reconst/tests/test_shore_metrics.py
@@ -74,6 +74,7 @@ def test_shore_metrics():
     pdf_shore = asmfit.pdf(v * radius)
     pdf_mt = multi_tensor_pdf(v * radius, mevals=mevals,
                               angles=angl, fractions= [50, 50])
+
     nmse_pdf = np.sqrt(np.sum((pdf_mt - pdf_shore) ** 2)) / (pdf_mt.sum())
     assert_almost_equal(nmse_pdf, 0.0, 2)
 

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -146,6 +146,7 @@ def test_snr():
 def test_all_tensor_evecs():
     e0 = np.array([1/np.sqrt(2), 1/np.sqrt(2), 0])
 
+    # Vectors are returned column-wise!
     desired = np.array([[1/np.sqrt(2), 1/np.sqrt(2), 0],
                         [-1/np.sqrt(2), 1/np.sqrt(2), 0],
                         [0, 0, 1]]).T

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -204,7 +204,7 @@ def single_tensor(gtab, S0=1, evals=None, evecs=None, snr=None):
     evecs : (3, 3) ndarray
         Eigenvectors of the tensor.  You can also think of this as a rotation
         matrix that transforms the direction of the tensor. The eigenvectors
-        needs to be column wise.
+        need to be column wise.
     snr : float
         Signal to noise ratio, assuming Rician noise.  None implies no noise.
 
@@ -545,9 +545,9 @@ def single_tensor_odf(r, evals=None, evecs=None):
         Eigenvalues of diffusion tensor.  By default, use values typical for
         prolate white matter.
     evecs : (3, 3) ndarray
-        Eigenvectors of the tensor.  You can also think of these as the
-        rotation matrix that determines the orientation of the diffusion
-        tensor.
+        Eigenvectors of the tensor, written column-wise.  You can also think
+        of these as the rotation matrix that determines the orientation of
+        the diffusion tensor.
 
     Returns
     -------
@@ -594,13 +594,14 @@ def all_tensor_evecs(e0):
     Returns
     -------
     evecs : (3,3) ndarray
-        Tensor eigenvectors.
+        Tensor eigenvectors, arranged column-wise.
 
     """
     axes = np.eye(3)
     mat = vec2vec_rotmat(axes[0], e0)
     e1 = np.dot(mat, axes[1])
     e2 = np.dot(mat, axes[2])
+    # Return the eigenvectors column-wise:
     return np.array([e0, e1, e2]).T
 
 


### PR DESCRIPTION
As pointed out by @RafaelNH here: https://github.com/nipy/dipy/pull/582, there seems to be some inconsistency about whether eigenvectors of tensors should be arranged column-wise or row-wise in 3-by-3 arrays. I am trying to enforce something uniform here. At the moment, this triggers several other test failures, but I wonder whether these are because of patching around this inconsistency, and would just require some additional fixing to make all parts consistent. I am continuing to investigate.