### PR TITLE
NF: Function to sample perpendicular directions relative to a given vector

### DIFF
--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -934,6 +934,8 @@ def perpendicular_directions(v, num=30, half=False):
 
     
     """
+    v = np.array(v)
+
     # Float error used for floats comparison 
     er = np.finfo(v[0]).eps * 1e3  
     
@@ -947,7 +949,7 @@ def perpendicular_directions(v, num=30, half=False):
     sina = np.sin(a)
 
     # Check if vector is not aligned to the x axis. 
-    if v[0] > er:
+    if abs(v[0] - 1) > er:
         sq = np.sqrt(v[1]**2 + v[2]**2)
         psamples = np.array([- sq*sina, (v[0]*v[1]*sina - v[2]*cosa) / sq,
                              (v[0]*v[2]*sina + v[1]*cosa) / sq])

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -1004,7 +1004,7 @@ def perpendicular_directions(v, num=30, half=False):
         psamples = np.array([- sq*sina, (v[0]*v[1]*sina - v[2]*cosa) / sq,
                              (v[0]*v[2]*sina + v[1]*cosa) / sq])
     else:
-        sq = np.sqrt(v[0]**2+v[2]**2)
+        sq = np.sqrt(v[0]**2 + v[2]**2)
         psamples = np.array([- (v[2]*cosa + v[0]*v[1]*sina) / sq, sina*sq,
                              (v[0]*cosa - v[2]*v[1]*sina) / sq])
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -912,7 +912,7 @@ def compose_transformations(*mats):
 
 
 def perpendicular_directions(v, num=30, half=False):
-    r""" Computes n equaly spaced perpendicular directions relative to a given
+    r""" Computes n evenly spaced perpendicular directions relative to a given
     vector v
 
     Parameters
@@ -922,9 +922,9 @@ def perpendicular_directions(v, num=30, half=False):
     num : int, optional
         Number of perpendicular directions to generate
     half : bool, optional
-        If haph is True, perpendicular directions are sampled on halp of the
-        unit circunference perpendicular to v, otherwive perpendicular
-        directions are sampled on the full circunference. Defaut of half is
+        If half is True, perpendicular directions are sampled on halp of the
+        unit circumference perpendicular to v, otherwive perpendicular
+        directions are sampled on the full circumference. Default of half is
         False
 
     Returns
@@ -934,7 +934,52 @@ def perpendicular_directions(v, num=30, half=False):
 
     Notes
     --------
-    Function is implemented according to:
+    Perpendicular directions are estimated using the following two step
+    procedure:
+    
+        1) the perpendicular directions are first sampled in a unit
+        circumference parallel to the plane normal to the x-axis.
+
+        2) Samples are then rotated and aligned to the plane normal to vector
+        v. The rotational matrix for this rotation is constructed as reference
+        frame basis which axis are the following:
+            - The first axis is vector v
+            - The second axis is defined as the normalized vector given by the
+            cross product between vector v and the unit vector aligned to the
+            x-axis
+            - The third axis is defined as the cross product between the
+            previous computed vector and vector v.
+
+    Following this two steps, coordinates of the final perpendicular directions
+    are given as:
+
+    .. math::
+
+        \left [ -\sin(a_{i}) \sqrt{{v_{y}}^{2}+{v_{z}}^{2}}
+        \; , \;
+        \frac{v_{x}v_{y}\sin(a_{i})-v_{z}\cos(a_{i})}
+        {\sqrt{{v_{y}}^{2}+{v_{z}}^{2}}}
+        \; , \;
+        \frac{v_{x}v_{z}\sin(a_{i})-v_{y}\cos(a_{i})}
+        {\sqrt{{v_{y}}^{2}+{v_{z}}^{2}}} \right  ]
+
+    This procedure has a singularity when vector v is aligned to the x-axis. To
+    solve this singularity, perpendicular directions in procedure's step 1 are
+    defined in the plane normal to y-axis and the second axis of the rotated
+    frame of reference is computed as the normalized vector given by the cross
+    product between vector v and the unit vector aligned to the y-axis. 
+    Following this, the coordinates of the perpendicular directions are given
+    as:
+
+        \left [ -\frac{\left (v_{x}v_{y}\sin(a_{i})+v_{z}\cos(a_{i}) \right )}
+        {\sqrt{{v_{x}}^{2}+{v_{z}}^{2}}}
+        \; , \;
+        \sin(a_{i}) \sqrt{{v_{x}}^{2}+{v_{z}}^{2}}
+        \; , \;
+        \frac{v_{y}v_{z}\sin(a_{i})+v_{x}\cos(a_{i})}
+        {\sqrt{{v_{x}}^{2}+{v_{z}}^{2}}} \right  ]
+
+    For more details see:
 
     http://gsoc2015dipydki.blogspot.it/2015/07/rnh-post-8-computing-perpendicul
     ar.html
@@ -944,11 +989,11 @@ def perpendicular_directions(v, num=30, half=False):
     # Float error used for floats comparison
     er = np.finfo(v[0]).eps * 1e3
 
-    # Define circunference or semi-circunference
+    # Define circumference or semi-circumference
     if half is True:
-        a = np.linspace(0., np.pi, num=num, endpoint=False)
+        a = np.linspace(0., math.pi, num=num, endpoint=False)
     else:
-        a = np.linspace(0., 2 * np.pi, num=num, endpoint=False)
+        a = np.linspace(0., 2 * math.pi, num=num, endpoint=False)
 
     cosa = np.cos(a)
     sina = np.sin(a)

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -906,3 +906,54 @@ def compose_transformations(*mats):
 
     return prev
 
+
+def perpendicular_directions(v, num=30, half=False):
+    r""" Computes n equaly spaced perpendicular directions relative to a given
+    vector v
+
+    Parameters
+    -----------
+    v : array (3,)
+        Array containing the three cartesian coordinates of vector v
+    num : int, optional
+        Number of perpendicular directions to generate
+    half : bool, optional
+        If haph is True, perpendicular directions are sampled on halp of the
+        unit circunference perpendicular to v, otherwive perpendicular
+        directions are sampled on the full circunference. Defaut of half is
+        False
+    
+    Returns
+    -------
+    psamples : array (n, 3)
+        array of vectors perpendicular to v
+    
+    Notes
+    --------
+    Function is implemented according to:
+
+    
+    """
+    # Float error used for floats comparison 
+    er = np.finfo(v[0]).eps * 1e3  
+    
+    # Define circunference or semi-circunference
+    if half == True:
+        a = np.linspace(0., np.pi, num=num, endpoint=False)
+    else:
+        a = np.linspace(0., 2 * np.pi, num=num, endpoint=False)
+
+    cosa = np.cos(a)
+    sina = np.sin(a)
+
+    # Check if vector is not aligned to the x axis. 
+    if v[0] > er:
+        sq = np.sqrt(v[1]**2 + v[2]**2)
+        psamples = np.array([- sq*sina, (v[0]*v[1]*sina - v[2]*cosa) / sq,
+                             (v[0]*v[2]*sina + v[1]*cosa) / sq])
+    else:
+        sq = np.sqrt(v[0]**2+v[2]**2);
+        psamples = np.array([- (v[2]*cosa + v[0]*v[1]*sina) / sq, sina*sq,
+                             (v[0]*cosa - v[2]*v[1]*sina) / sq])
+
+    return psamples.T

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -979,8 +979,7 @@ def perpendicular_directions(v, num=30, half=False):
         \frac{v_{y}v_{z}\sin(a_{i})+v_{x}\cos(a_{i})}
         {\sqrt{{v_{x}}^{2}+{v_{z}}^{2}}} \right  ]
 
-    For more details `click here <http://gsoc2015dipydki.blogspot.it/2015/07/
-    rnh-post-8-computing-perpendicular.html>`_.
+    For more details on this calculation, see ` here <http://gsoc2015dipydki.blogspot.it/2015/07/rnh-post-8-computing-perpendicular.html>`_.
     """
     v = np.array(v, dtype=float)
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -984,7 +984,7 @@ def perpendicular_directions(v, num=30, half=False):
     http://gsoc2015dipydki.blogspot.it/2015/07/rnh-post-8-computing-perpendicul
     ar.html
     """
-    v = np.array(v)
+    v = np.array(v, dtype=float)
 
     # Float error used for floats comparison
     er = np.finfo(v[0]).eps * 1e3
@@ -999,7 +999,7 @@ def perpendicular_directions(v, num=30, half=False):
     sina = np.sin(a)
 
     # Check if vector is not aligned to the x axis
-    if abs(v[0] - 1) > er:
+    if abs(v[0] - 1.) > er:
         sq = np.sqrt(v[1]**2 + v[2]**2)
         psamples = np.array([- sq*sina, (v[0]*v[1]*sina - v[2]*cosa) / sq,
                              (v[0]*v[2]*sina + v[1]*cosa) / sq])

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -501,7 +501,8 @@ def lambert_equal_area_projection_polar(theta, phi):
        planar coordinates of points following mapping by Lambert's EAP.
     """
 
-    return 2 * np.repeat(np.sin(theta / 2), 2).reshape((theta.shape[0], 2)) * np.column_stack((np.cos(phi), np.sin(phi)))
+    return 2 * np.repeat(np.sin(theta / 2), 2).reshape((theta.shape[0], 2)) * \
+        np.column_stack((np.cos(phi), np.sin(phi)))
 
 
 def lambert_equal_area_projection_cart(x, y, z):
@@ -617,7 +618,8 @@ def euler_matrix(ai, aj, ak, axes='sxyz'):
     return M
 
 
-def compose_matrix(scale=None, shear=None, angles=None, translate=None, perspective=None):
+def compose_matrix(scale=None, shear=None, angles=None, translate=None,
+                   perspective=None):
     """Return 4x4 transformation matrix from sequence of
     transformations.
 
@@ -687,8 +689,8 @@ def compose_matrix(scale=None, shear=None, angles=None, translate=None, perspect
 def decompose_matrix(matrix):
     """Return sequence of transformations from transformation matrix.
 
-    Code modified from the excellent work of Christoph Gohlke link provided here
-    http://www.lfd.uci.edu/~gohlke/code/transformations.py.html
+    Code modified from the excellent work of Christoph Gohlke link provided
+    here: http://www.lfd.uci.edu/~gohlke/code/transformations.py.html
 
     Parameters
     ------------
@@ -768,7 +770,7 @@ def decompose_matrix(matrix):
         angles[0] = math.atan2(row[1, 2], row[2, 2])
         angles[2] = math.atan2(row[0, 1], row[0, 0])
     else:
-        #angles[0] = math.atan2(row[1, 0], row[1, 1])
+        # angles[0] = math.atan2(row[1, 0], row[1, 1])
         angles[0] = math.atan2(-row[2, 1], row[1, 1])
         angles[2] = 0.0
 
@@ -799,7 +801,8 @@ def circumradius(a, b, c):
     z = np.cross(x, y)
     # test for collinearity
     if np.linalg.norm(z) == 0:
-        return np.sqrt(np.max(np.dot(x, x), np.dot(y, y), np.dot(a - b, a - b))) / 2.
+        return np.sqrt(np.max(np.dot(x, x), np.dot(y, y),
+                              np.dot(a - b, a - b))) / 2.
     else:
         m = np.vstack((x, y, z))
         w = np.dot(np.linalg.inv(m.T), np.array([xx / 2., yy / 2., 0]))
@@ -809,7 +812,8 @@ def circumradius(a, b, c):
 def vec2vec_rotmat(u, v):
     r""" rotation matrix from 2 unit vectors
 
-    u,v being unit 3d vectors return a 3x3 rotation matrix R than aligns u to v.
+    u, v being unit 3d vectors return a 3x3 rotation matrix R than aligns u to
+    v.
 
     In general there are many rotations that will map u to v. If S is any
     rotation using v as an axis then R.S will also map u to v since (S.R)u =
@@ -847,7 +851,7 @@ def vec2vec_rotmat(u, v):
     w = np.cross(u, v)
     wn = np.linalg.norm(w)
 
-    # Check that cross product is OK and vectors 
+    # Check that cross product is OK and vectors
     # u, v are not collinear (norm(w)>0.0)
     if np.isnan(wn) or wn < np.finfo(float).eps:
         norm_u_v = np.linalg.norm(u - v)
@@ -922,25 +926,26 @@ def perpendicular_directions(v, num=30, half=False):
         unit circunference perpendicular to v, otherwive perpendicular
         directions are sampled on the full circunference. Defaut of half is
         False
-    
+
     Returns
     -------
     psamples : array (n, 3)
         array of vectors perpendicular to v
-    
+
     Notes
     --------
     Function is implemented according to:
 
-    
+    http://gsoc2015dipydki.blogspot.it/2015/07/rnh-post-8-computing-perpendicul
+    ar.html
     """
     v = np.array(v)
 
-    # Float error used for floats comparison 
-    er = np.finfo(v[0]).eps * 1e3  
-    
+    # Float error used for floats comparison
+    er = np.finfo(v[0]).eps * 1e3
+
     # Define circunference or semi-circunference
-    if half == True:
+    if half is True:
         a = np.linspace(0., np.pi, num=num, endpoint=False)
     else:
         a = np.linspace(0., 2 * np.pi, num=num, endpoint=False)
@@ -948,13 +953,13 @@ def perpendicular_directions(v, num=30, half=False):
     cosa = np.cos(a)
     sina = np.sin(a)
 
-    # Check if vector is not aligned to the x axis. 
+    # Check if vector is not aligned to the x axis
     if abs(v[0] - 1) > er:
         sq = np.sqrt(v[1]**2 + v[2]**2)
         psamples = np.array([- sq*sina, (v[0]*v[1]*sina - v[2]*cosa) / sq,
                              (v[0]*v[2]*sina + v[1]*cosa) / sq])
     else:
-        sq = np.sqrt(v[0]**2+v[2]**2);
+        sq = np.sqrt(v[0]**2+v[2]**2)
         psamples = np.array([- (v[2]*cosa + v[0]*v[1]*sina) / sq, sina*sq,
                              (v[0]*cosa - v[2]*v[1]*sina) / sq])
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -979,10 +979,8 @@ def perpendicular_directions(v, num=30, half=False):
         \frac{v_{y}v_{z}\sin(a_{i})+v_{x}\cos(a_{i})}
         {\sqrt{{v_{x}}^{2}+{v_{z}}^{2}}} \right  ]
 
-    For more details see:
-
-    http://gsoc2015dipydki.blogspot.it/2015/07/rnh-post-8-computing-perpendicul
-    ar.html
+    For more details `click here <http://gsoc2015dipydki.blogspot.it/2015/07/
+    rnh-post-8-computing-perpendicular.html>`_.
     """
     v = np.array(v, dtype=float)
 

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -922,7 +922,7 @@ def perpendicular_directions(v, num=30, half=False):
     num : int, optional
         Number of perpendicular directions to generate
     half : bool, optional
-        If half is True, perpendicular directions are sampled on halp of the
+        If half is True, perpendicular directions are sampled on half of the
         unit circumference perpendicular to v, otherwive perpendicular
         directions are sampled on the full circumference. Default of half is
         False

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -283,7 +283,7 @@ def test_perpendicular_directions():
         # check if directions are sampled by multiples of 2*pi / num
         delta_a = 2 * np.pi / num
         for d in pd:
-            angle = math.arccos(np.dot(pd[0], d))
+            angle = math.acos(np.dot(pd[0], d))
             rest = angle % delta_a
             if rest > delta_a * 0.99:  # To correct cases of negative error
                 rest = rest - delta_a

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -6,8 +6,6 @@ import numpy as np
 
 import random
 
-import math
-
 from dipy.core.geometry import (sphere2cart, cart2sphere,
                                 nearest_pos_semi_def,
                                 sphere_distance,
@@ -283,7 +281,7 @@ def test_perpendicular_directions():
         # check if directions are sampled by multiples of 2*pi / num
         delta_a = 2 * np.pi / num
         for d in pd:
-            angle = math.arccos(np.dot(pd[0], d))
+            angle = np.arccos(np.dot(pd[0], d))
             rest = angle % delta_a
             if rest > delta_a * 0.99:  # To correct cases of negative error
                 rest = rest - delta_a

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -52,8 +52,8 @@ def test_sphere_cart():
     yield assert_array_almost_equal, rs, 10.4
     xyz = sphere2cart(rs, thetas, phis)
     yield assert_array_almost_equal, xyz, big_sph_pts.T, 6
-    #test that result shapes match
-    x, y, z =  big_sph_pts.T
+    # test that result shapes match
+    x, y, z = big_sph_pts.T
     r, theta, phi = cart2sphere(x[:1], y[:1], z)
     yield assert_equal, r.shape, theta.shape
     yield assert_equal, r.shape, phi.shape
@@ -70,47 +70,51 @@ def test_sphere_cart():
     x, y, z = sphere2cart(*cart2sphere(0., 0., 0.))
     yield assert_array_equal, (x, y, z), (0., 0., 0.)
 
+
 def test_invert_transform():
     n = 100.
-    theta = np.arange(n)/n * np.pi   # Limited to 0,pi
-    phi = (np.arange(n)/n - .5) * 2 * np.pi # Limited to 0,2pi
-    x, y, z = sphere2cart(1, theta, phi)  # Let's assume they're all unit vectors
+    theta = np.arange(n)/n * np.pi  # Limited to 0,pi
+    phi = (np.arange(n)/n - .5) * 2 * np.pi  # Limited to 0,2pi
+    x, y, z = sphere2cart(1, theta, phi)  # Let's assume they're all unit vecs
     r, new_theta, new_phi = cart2sphere(x, y, z)  # Transform back
 
     yield assert_array_almost_equal, theta, new_theta
     yield assert_array_almost_equal, phi, new_phi
 
+
 def test_nearest_pos_semi_def():
-    B = np.diag(np.array([1,2,3]))
+    B = np.diag(np.array([1, 2, 3]))
     yield assert_array_almost_equal, B, nearest_pos_semi_def(B)
-    B = np.diag(np.array([0,2,3]))
+    B = np.diag(np.array([0, 2, 3]))
     yield assert_array_almost_equal, B, nearest_pos_semi_def(B)
-    B = np.diag(np.array([0,0,3]))
+    B = np.diag(np.array([0, 0, 3]))
     yield assert_array_almost_equal, B, nearest_pos_semi_def(B)
-    B = np.diag(np.array([-1,2,3]))
-    Bpsd = np.array([[0.,0.,0.],[0.,1.75,0.],[0.,0.,2.75]])
+    B = np.diag(np.array([-1, 2, 3]))
+    Bpsd = np.array([[0., 0., 0.], [0., 1.75, 0.], [0., 0., 2.75]])
     yield assert_array_almost_equal, Bpsd, nearest_pos_semi_def(B)
-    B = np.diag(np.array([-1,-2,3]))
-    Bpsd = np.array([[0.,0.,0.],[0.,0.,0.],[0.,0.,2.]])
+    B = np.diag(np.array([-1, -2, 3]))
+    Bpsd = np.array([[0., 0., 0.], [0., 0., 0.], [0., 0., 2.]])
     yield assert_array_almost_equal, Bpsd, nearest_pos_semi_def(B)
-    B = np.diag(np.array([-1.e-11,0,1000]))
-    Bpsd = np.array([[0.,0.,0.],[0.,0.,0.],[0.,0.,1000.]])
+    B = np.diag(np.array([-1.e-11, 0, 1000]))
+    Bpsd = np.array([[0., 0., 0.], [0., 0., 0.], [0., 0., 1000.]])
     yield assert_array_almost_equal, Bpsd, nearest_pos_semi_def(B)
-    B = np.diag(np.array([-1,-2,-3]))
-    Bpsd = np.array([[0.,0.,0.],[0.,0.,0.],[0.,0.,0.]])
+    B = np.diag(np.array([-1, -2, -3]))
+    Bpsd = np.array([[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]])
     yield assert_array_almost_equal, Bpsd, nearest_pos_semi_def(B)
+
 
 def test_cart_distance():
     a = [0, 1]
     b = [1, 0]
     yield assert_array_almost_equal, cart_distance(a, b), np.sqrt(2)
-    yield assert_array_almost_equal, cart_distance([1,0], [-1,0]), 2
+    yield assert_array_almost_equal, cart_distance([1, 0], [-1, 0]), 2
     pts1 = [2, 1, 0]
     pts2 = [0, 1, -2]
     yield assert_array_almost_equal, cart_distance(pts1, pts2), np.sqrt(8)
     pts2 = [[0, 1, -2],
             [-2, 1, 0]]
     yield assert_array_almost_equal, cart_distance(pts1, pts2), [np.sqrt(8), 4]
+
 
 def test_sphere_distance():
     # make a circle, go around...
@@ -130,25 +134,27 @@ def test_sphere_distance():
     # concatenated with distances from pi to 0 again
     cdists = np.r_[0, csums, csums[-2::-1]]
     # check approximation close to calculated
-    sph_d = sphere_distance([0,radius], np.c_[x, y])
+    sph_d = sphere_distance([0, radius], np.c_[x, y])
     yield assert_array_almost_equal, cdists, sph_d
     # Now check with passed radius
-    sph_d = sphere_distance([0,radius], np.c_[x, y], radius=radius)
+    sph_d = sphere_distance([0, radius], np.c_[x, y], radius=radius)
     yield assert_array_almost_equal, cdists, sph_d
     # Check points not on surface raises error when asked for
     yield assert_raises, ValueError, sphere_distance, [1, 0], [0, 2]
     # Not when check is disabled
-    sph_d = sphere_distance([1, 0], [0,2], None, False)
+    sph_d = sphere_distance([1, 0], [0, 2], None, False)
     # Error when radii don't match passed radius
     yield assert_raises, ValueError, sphere_distance, [1, 0], [0, 1], 2.0
+
 
 def test_vector_cosine():
     a = [0, 1]
     b = [1, 0]
     yield assert_array_almost_equal, vector_cosine(a, b), 0
-    yield assert_array_almost_equal, vector_cosine([1,0], [-1,0]), -1
-    yield assert_array_almost_equal, vector_cosine([1,0], [1,1]), 1/np.sqrt(2)
-    yield assert_array_almost_equal, vector_cosine([2,0], [-4,0]), -1
+    yield assert_array_almost_equal, vector_cosine([1, 0], [-1, 0]), -1
+    yield assert_array_almost_equal, vector_cosine([1, 0], [1, 1]), \
+        1/np.sqrt(2)
+    yield assert_array_almost_equal, vector_cosine([2, 0], [-4, 0]), -1
     pts1 = [2, 1, 0]
     pts2 = [-2, -1, 0]
     yield assert_array_almost_equal, vector_cosine(pts1, pts2), -1
@@ -159,7 +165,7 @@ def test_vector_cosine():
     # not the same if non-zero vector mean
     a = np.random.uniform(size=(100,))
     b = np.random.uniform(size=(100,))
-    cc = np.corrcoef(a, b)[0,1]
+    cc = np.corrcoef(a, b)[0, 1]
     vcos = vector_cosine(a, b)
     yield assert_false, np.allclose(cc, vcos)
     # is the same if zero vector mean
@@ -168,34 +174,41 @@ def test_vector_cosine():
     vcos = vector_cosine(a_dm, b_dm)
     yield assert_array_almost_equal, cc, vcos
 
+
 def test_lambert_equal_area_projection_polar():
 
-    theta = np.repeat(np.pi/3,10)
-    phi = np.linspace(0,2*np.pi,10)
+    theta = np.repeat(np.pi/3, 10)
+    phi = np.linspace(0, 2*np.pi, 10)
     # points sit on circle with co-latitude pi/3 (60 degrees)
-    leap = lambert_equal_area_projection_polar(theta,phi)
-    yield assert_array_almost_equal, np.sqrt(np.sum(leap**2,axis=1)), \
-          np.array([ 1.,1.,1.,1.,1.,1.,1.,1.,1.,1.])
+    leap = lambert_equal_area_projection_polar(theta, phi)
+    yield \
+        assert_array_almost_equal, np.sqrt(np.sum(leap**2, axis=1)), \
+        np.array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])
     # points map onto the circle of radius 1
+
 
 def test_lambert_equal_area_projection_cart():
 
-    xyz = np.array([[1,0,0],[0,1,0],[0,0,1],[-1,0,0],[0,-1,0],[0,0,-1]])
+    xyz = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [-1, 0, 0], [0, -1, 0],
+                    [0, 0, -1]])
     # points sit on +/-1 on all 3 axes
 
-    r,theta,phi = cart2sphere(*xyz.T)
+    r, theta, phi = cart2sphere(*xyz.T)
 
-    leap = lambert_equal_area_projection_polar(theta,phi)
+    leap = lambert_equal_area_projection_polar(theta, phi)
     r2 = np.sqrt(2)
-    yield assert_array_almost_equal, np.sqrt(np.sum(leap**2,axis=1)), \
-          np.array([ r2,r2,0,r2,r2,2])
+    yield assert_array_almost_equal, np.sqrt(np.sum(leap**2, axis=1)), \
+        np.array([r2, r2, 0, r2, r2, 2])
     # x and y =+/-1 map onto circle of radius sqrt(2)
     # z=1 maps to origin, and z=-1 maps to (an arbitrary point on) the
     # outer circle of radius 2
 
+
 def test_circumradius():
 
-    yield assert_array_almost_equal, np.sqrt(0.5), circumradius(np.array([0,2,0]),np.array([2,0,0]),np.array([0,0,0]))
+    yield assert_array_almost_equal, np.sqrt(0.5), \
+        circumradius(np.array([0, 2, 0]), np.array([2, 0, 0]),
+                     np.array([0, 0, 0]))
 
 
 def test_vec2vec_rotmat():
@@ -253,7 +266,7 @@ def test_perpendicular_directions():
     for d in pd:
         cos_angle = np.dot(d, vector_v)
         assert_almost_equal(cos_angle, 0)
-    
+
     # check if directions are sampled by multiples of 2*pi / num
     delta_a = 2 * np.pi / num
     for d in pd:
@@ -262,7 +275,7 @@ def test_perpendicular_directions():
         if rest > delta_a * 0.99:  # To correct cases of negative error
             rest = rest - delta_a
         assert_almost_equal(rest, 0)
-    
+
     # check case of vector_v is aligned to x_axis
     vector_v = [1., 0., 0.]
     pd = perpendicular_directions(vector_v, num=num, half=False)
@@ -280,4 +293,3 @@ def test_perpendicular_directions():
 if __name__ == '__main__':
 
     run_module_suite()
-

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -283,7 +283,7 @@ def test_perpendicular_directions():
         # check if directions are sampled by multiples of 2*pi / num
         delta_a = 2 * np.pi / num
         for d in pd:
-            angle = math.acos(np.dot(pd[0], d))
+            angle = math.arccos(np.dot(pd[0], d))
             rest = angle % delta_a
             if rest > delta_a * 0.99:  # To correct cases of negative error
                 rest = rest - delta_a

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -6,6 +6,8 @@ import numpy as np
 
 import random
 
+import math
+
 from dipy.core.geometry import (sphere2cart, cart2sphere,
                                 nearest_pos_semi_def,
                                 sphere_distance,
@@ -281,7 +283,7 @@ def test_perpendicular_directions():
         # check if directions are sampled by multiples of 2*pi / num
         delta_a = 2 * np.pi / num
         for d in pd:
-            angle = np.arccos(np.dot(pd[0], d))
+            angle = math.arccos(np.dot(pd[0], d))
             rest = angle % delta_a
             if rest > delta_a * 0.99:  # To correct cases of negative error
                 rest = rest - delta_a

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -261,11 +261,11 @@ def test_perpendicular_directions():
 
     vectors_v = np.zeros((4, 3))
 
-    for v in range(3):
+    for v in range(4):
         theta = random.uniform(0, np.pi)
         phi = random.uniform(0, 2*np.pi)
         vectors_v[v] = sphere2cart(1., theta, phi)
-    vectors_v[3] = [1., 0., 0.]
+    vectors_v[3] = [1, 0, 0]
 
     for vector_v in vectors_v:
         pd = perpendicular_directions(vector_v, num=num, half=False)
@@ -279,8 +279,8 @@ def test_perpendicular_directions():
             assert_almost_equal(cos_angle, 0)
 
         # check if directions are sampled by multiples of 2*pi / num
-        delta_a = 2 * np.pi / num
-        for d in pd:
+        delta_a = 2. * np.pi / num
+        for d in pd[1:]:
             angle = np.arccos(np.dot(pd[0], d))
             rest = angle % delta_a
             if rest > delta_a * 0.99:  # To correct cases of negative error

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -264,8 +264,8 @@ def test_perpendicular_directions():
     for v in range(3):
         theta = random.uniform(0, np.pi)
         phi = random.uniform(0, 2*np.pi)
-        vectors_v[v] = sphere2cart(1, theta, phi)
-    vectors_v[3] = [1, 0, 0]
+        vectors_v[v] = sphere2cart(1., theta, phi)
+    vectors_v[3] = [1., 0., 0.]
 
     for vector_v in vectors_v:
         pd = perpendicular_directions(vector_v, num=num, half=False)

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -4,6 +4,8 @@
 
 import numpy as np
 
+import random
+
 from dipy.core.geometry import (sphere2cart, cart2sphere,
                                 nearest_pos_semi_def,
                                 sphere_distance,
@@ -256,38 +258,34 @@ def test_compose_decompose_matrix():
 
 def test_perpendicular_directions():
     num = 35
-    vector_v = sphere2cart(1, np.pi/4, np.pi/4)
-    pd = perpendicular_directions(vector_v, num=num, half=False)
 
-    # see if length of pd is equal to the number of intendend samples
-    assert_equal(num, len(pd))
+    vectors_v = np.zeros((4, 3))
 
-    # check if all directions are perpendicular to vector v
-    for d in pd:
-        cos_angle = np.dot(d, vector_v)
-        assert_almost_equal(cos_angle, 0)
+    for v in range(3):
+        theta = random.uniform(0, np.pi)
+        phi = random.uniform(0, 2*np.pi)
+        vectors_v[v] = sphere2cart(1, theta, phi)
+    vectors_v[3] = [1, 0, 0]
 
-    # check if directions are sampled by multiples of 2*pi / num
-    delta_a = 2 * np.pi / num
-    for d in pd:
-        angle = np.arccos(np.dot(pd[0], d))
-        rest = angle % delta_a
-        if rest > delta_a * 0.99:  # To correct cases of negative error
-            rest = rest - delta_a
-        assert_almost_equal(rest, 0)
+    for vector_v in vectors_v:
+        pd = perpendicular_directions(vector_v, num=num, half=False)
 
-    # check case of vector_v is aligned to x_axis
-    vector_v = [1., 0., 0.]
-    pd = perpendicular_directions(vector_v, num=num, half=False)
-    for d in pd:
-        cos_angle = np.dot(d, vector_v)
-        assert_almost_equal(cos_angle, 0)
-    for d in pd:
-        angle = np.arccos(np.dot(pd[0], d))
-        rest = angle % delta_a
-        if rest > delta_a * 0.99:  # To correct cases of negative error
-            rest = rest - delta_a
-        assert_almost_equal(rest, 0)
+        # see if length of pd is equal to the number of intendend samples
+        assert_equal(num, len(pd))
+
+        # check if all directions are perpendicular to vector v
+        for d in pd:
+            cos_angle = np.dot(d, vector_v)
+            assert_almost_equal(cos_angle, 0)
+
+        # check if directions are sampled by multiples of 2*pi / num
+        delta_a = 2 * np.pi / num
+        for d in pd:
+            angle = np.arccos(np.dot(pd[0], d))
+            rest = angle % delta_a
+            if rest > delta_a * 0.99:  # To correct cases of negative error
+                rest = rest - delta_a
+            assert_almost_equal(rest, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello!

I implemented a function to sample perpendicular directions relative to a given vector. I will need this function for the future steps of the development of the diffusion kurtosis module (work in progress at #664), however since this function is quite general and might be useful for other techniques, I decided to submit it in a different pull request. I am suggesting to have this function in dipy.core.geometry. The function is being tested in the relevant testing file.

For the math details of the function, you can see the following post:

http://gsoc2015dipydki.blogspot.it/2015/07/rnh-post-8-computing-perpendicular.html  