### PR TITLE
BF: added tolerance for negative streamline coordinates checks

### DIFF
--- a/dipy/tracking/_utils.py
+++ b/dipy/tracking/_utils.py
@@ -60,7 +60,7 @@ def _to_voxel_coordinates(streamline, lin_T, offset):
     raises an error for negative voxel values."""
     inds = np.dot(streamline, lin_T)
     inds += offset
-    if inds.min() < 0:
+    if inds.min().round(decimals=6) < 0:
         raise IndexError('streamline has points that map to negative voxel'
                          ' indices')
     return inds.astype(int)


### PR DESCRIPTION
In some case, tracts can be generated exactly on the border of the image volume. When mapped back to voxel coordinates, due to numerical imprecisions, they may have a coordinate with a value like -5.96046447754e-08, which trips up the negative coordinates test in _to_voxel_coordinates.

I added a tolerance to avoid rejecting valid points. Using a very small threshold so that genuinely invalid points still end up raising the error.