### PR TITLE
BF: Fixed memory leak in QuickBundles.

### DIFF
--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -120,6 +120,9 @@ cdef class ClustersCentroid(Clusters):
         cdef cnp.npy_intp i
         for i in range(self._nb_clusters):
             free(&(self.centroids[i].features[0, 0]))
+            free(&(self._updated_centroids[i].features[0, 0]))
+            self.centroids[i].features = None  # Necessary to decrease refcount
+            self._updated_centroids[i].features = None  # Necessary to decrease refcount
 
         free(self.centroids)
         self.centroids = NULL

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -1,14 +1,17 @@
 import numpy as np
 import itertools
 
+
+from nose.tools import assert_equal, assert_raises
+from numpy.testing import assert_array_equal, run_module_suite
+from dipy.testing.memory import get_type_refcount
+
 from dipy.segment.clustering import QuickBundles
 
 import dipy.segment.metric as dipymetric
 from dipy.segment.clustering_algorithms import quickbundles
 import dipy.tracking.streamline as streamline_utils
 
-from nose.tools import assert_equal, assert_raises
-from numpy.testing import assert_array_equal, run_module_suite
 
 dtype = "float32"
 threshold = 7
@@ -149,6 +152,17 @@ def test_quickbundles_with_not_order_invariant_metric():
     clusters = qb.cluster(streamlines)
     assert_equal(len(clusters), 1)
     assert_array_equal(clusters[0].centroid, streamline)
+
+
+def test_quickbundles_memory_leaks():
+    qb = QuickBundles(threshold=2*threshold)
+
+    type_name_pattern = "memoryview"
+    initial_types_refcount = get_type_refcount(type_name_pattern)
+
+    qb.cluster(data)
+    # At this point, all memoryviews created during clustering should be freed.
+    assert_equal(get_type_refcount(type_name_pattern), initial_types_refcount)
 
 
 if __name__ == '__main__':

--- a/dipy/testing/memory.py
+++ b/dipy/testing/memory.py
@@ -1,0 +1,28 @@
+import gc
+from collections import defaultdict
+
+
+def get_type_refcount(pattern=None):
+    """
+    Retrieves refcount of types for which their name matches `pattern`.
+
+    Parameters
+    ----------
+    pattern : str
+        Consider only types that have `pattern` in their name.
+
+    Returns
+    -------
+    dict
+        The key is the type name and the value is the refcount.
+    """
+    gc.collect()
+
+    refcounts_per_type = defaultdict(int)
+    for obj in gc.get_objects():
+        obj_type_name = type(obj).__name__
+        # If `pattern` is not None, keep only matching types.
+        if pattern is None or pattern in obj_type_name:
+            refcounts_per_type[obj_type_name] += 1
+
+    return refcounts_per_type

--- a/dipy/testing/tests/test_memory.py
+++ b/dipy/testing/tests/test_memory.py
@@ -1,0 +1,11 @@
+from nose.tools import assert_equal
+
+from dipy.testing.memory import get_type_refcount
+
+
+def test_get_type_refcount():
+    list_ref_count = get_type_refcount("list")
+    A = list()
+    assert_equal(get_type_refcount("list")["list"], list_ref_count["list"]+1)
+    del A
+    assert_equal(get_type_refcount("list")["list"], list_ref_count["list"])


### PR DESCRIPTION
This PR fixes a memory leak that was present in `ClusterCentroid` used by the QuickBundles algorithm. The `__dealloc__` function was missing a free statement for a variable. In addition to that, references count of `memoryview` objects were not decremented automatically/correctly when freeing the allocated memory. I found that assigning them to `None` (before freeing the memory) works.

This PR also add a testing tool that retrieves the refcount of a given object type. This tool is used in the new unit test function that check there are no memory leaks in QuickBundles.