### PR TITLE
BF: Make buildbot Pyhon26-32 happy

### DIFF
--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -174,7 +174,7 @@ def test_metric_cosine():
             if metric.are_compatible(f1.shape, f2.shape):
                 distance = metric.dist(f1, f2)
                 if np.all(f1 == f2):
-                    assert_equal(distance, 0.)
+                    assert_almost_equal(distance, 0.)
 
                 assert_almost_equal(distance, dipymetric.dist(metric, s1, s2))
                 assert_true(distance >= 0.)


### PR DESCRIPTION
Replaced an `assert_equal` with an `assert_almost_equal`.
http://nipy.bic.berkeley.edu/builders/dipy-py2.6-32/builds/551/steps/shell_6/logs/stdio