### PR TITLE
Fix syn-3d example

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -54,6 +54,7 @@ from .parzenhist import (ParzenJointHistogram,
                          compute_parzen_mi)
 from .imwarp import (get_direction_and_spacings, ScaleSpace)
 from .scalespace import IsotropicScaleSpace
+from warnings import warn
 
 _interp_options = ['nearest', 'linear']
 _transform_method = {}
@@ -795,20 +796,20 @@ class AffineRegistration(object):
         if starting_affine is None:
             self.starting_affine = np.eye(self.dim + 1)
         elif starting_affine == 'mass':
-            affine_map = align_centers_of_mass(static,
-                                               static_grid2world,
-                                               moving,
-                                               moving_grid2world)
+            affine_map = transform_centers_of_mass(static,
+                                                   static_grid2world,
+                                                   moving,
+                                                   moving_grid2world)
             self.starting_affine = affine_map.affine
         elif starting_affine == 'voxel-origin':
-            affine_map = align_origins(static, static_grid2world,
-                                       moving, moving_grid2world)
+            affine_map = transform_origins(static, static_grid2world,
+                                           moving, moving_grid2world)
             self.starting_affine = affine_map.affine
         elif starting_affine == 'centers':
-            affine_map = align_geometric_centers(static,
-                                                 static_grid2world,
-                                                 moving,
-                                                 moving_grid2world)
+            affine_map = transform_geometric_centers(static,
+                                                     static_grid2world,
+                                                     moving,
+                                                     moving_grid2world)
             self.starting_affine = affine_map.affine
         elif (isinstance(starting_affine, np.ndarray) and
               starting_affine.shape >= (self.dim, self.dim + 1)):
@@ -972,6 +973,33 @@ class AffineRegistration(object):
 
 def align_centers_of_mass(static, static_grid2world,
                           moving, moving_grid2world):
+    msg = "This function is deprecated please use"
+    msg += " dipy.align.imaffine.transform_centers_of_mass instead."
+    warn(msg)
+    return transform_centers_of_mass(static, static_grid2world,
+                                       moving, moving_grid2world)
+
+
+def align_geometric_centers(static, static_grid2world,
+                            moving, moving_grid2world):
+    msg = "This function is deprecated please use"
+    msg += " dipy.align.imaffine.transform_geometric_centers instead."
+    warn(msg)
+    return transform_geometric_centers(static, static_grid2world,
+                                       moving, moving_grid2world)
+
+
+def align_origins(static, static_grid2world,
+                  moving, moving_grid2world):
+    msg = "This function is deprecated please use"
+    msg += " dipy.align.imaffine.transform_origins instead."
+    warn(msg)
+    return transform_origins(static, static_grid2world,
+                                       moving, moving_grid2world)
+
+
+def transform_centers_of_mass(static, static_grid2world,
+                              moving, moving_grid2world):
     r""" Transformation to align the center of mass of the input images
 
     Parameters
@@ -1009,8 +1037,8 @@ def align_centers_of_mass(static, static_grid2world,
     return affine_map
 
 
-def align_geometric_centers(static, static_grid2world,
-                            moving, moving_grid2world):
+def transform_geometric_centers(static, static_grid2world,
+                                moving, moving_grid2world):
     r""" Transformation to align the geometric center of the input images
 
     With "geometric center" of a volume we mean the physical coordinates of
@@ -1051,8 +1079,8 @@ def align_geometric_centers(static, static_grid2world,
     return affine_map
 
 
-def align_origins(static, static_grid2world,
-                  moving, moving_grid2world):
+def transform_origins(static, static_grid2world,
+                      moving, moving_grid2world):
     r""" Transformation to align the origins of the input images
 
     With "origin" of a volume we mean the physical coordinates of

--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -36,7 +36,7 @@ factors = {('TRANSLATION', 2): (2.0, 0.35, np.array([2.3, 4.5])),
                                                 -0.07, 0.10,  0.99, -1.4]))}
 
 
-def test_align_centers_of_mass_3d():
+def test_transform_centers_of_mass_3d():
     np.random.seed(1246592)
     shape = (64, 64, 64)
     rm = 8
@@ -79,12 +79,12 @@ def test_align_centers_of_mass_3d():
             expected[:3, 3] = c_moving - c_static
 
             # Implementation under test
-            actual = imaffine.align_centers_of_mass(static, static_grid2world,
-                                                    moving, moving_grid2world)
+            actual = imaffine.transform_centers_of_mass(static, static_grid2world,
+                                                        moving, moving_grid2world)
             assert_array_almost_equal(actual.affine, expected)
 
 
-def test_align_geometric_centers_3d():
+def test_transform_geometric_centers_3d():
     # Create arbitrary image-to-space transforms
     axis = np.array([.5, 2.0, 1.5])
     t = 0.15 #translation factor
@@ -124,12 +124,12 @@ def test_align_geometric_centers_3d():
                     expected[:3, 3] = c_moving - c_static
 
                     # Implementation under test
-                    actual = imaffine.align_geometric_centers(static,
+                    actual = imaffine.transform_geometric_centers(static,
                         static_grid2world, moving, moving_grid2world)
                     assert_array_almost_equal(actual.affine, expected)
 
 
-def test_align_origins_3d():
+def test_transform_origins_3d():
     # Create arbitrary image-to-space transforms
     axis = np.array([.5, 2.0, 1.5])
     t = 0.15 #translation factor
@@ -165,7 +165,7 @@ def test_align_origins_3d():
                     expected[:3, 3] = c_moving - c_static
 
                     # Implementation under test
-                    actual = imaffine.align_origins(static, static_grid2world,
+                    actual = imaffine.transform_origins(static, static_grid2world,
                                                     moving, moving_grid2world)
                     assert_array_almost_equal(actual.affine, expected)
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,19 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+Dipy 0.10 Changes
+----------------
+
+**Registration**
+
+The following utilty functions from ``vector_fields`` module were renamed:
+
+``warp_2d_affine`` is now ``transform_2d_affine``
+``warp_2d_affine_nn`` is now ``transform_2d_affine_nn``
+``warp_3d_affine`` is now ``transform_3d_affine``
+``warp_3d_affine_nn`` is now ``transform_3d_affine_nn``
+
+
 Dipy 0.9 Changes
 ----------------
 

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -11,7 +11,7 @@ import numpy as np
 from dipy.viz import regtools
 from dipy.data import fetch_stanford_hardi, read_stanford_hardi
 from dipy.data.fetcher import fetch_syn_data, read_syn_data
-from dipy.align.imaffine import (align_centers_of_mass,
+from dipy.align.imaffine import (transform_centers_of_mass,
                                  AffineMap,
                                  MutualInformationMetric,
                                  AffineRegistration)
@@ -74,8 +74,8 @@ We can obtain a very rough (and fast) registration by just aligning the centers
 of mass of the two images
 """
 
-c_of_mass = align_centers_of_mass(static, static_grid2world,
-                                  moving, moving_grid2world)
+c_of_mass = transform_centers_of_mass(static, static_grid2world,
+                                      moving, moving_grid2world)
 
 """
 We can now transform the moving image and draw it on top of the static image,

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -64,16 +64,16 @@ pre_align = np.array([[1.02783543e+00, -4.83019053e-02, -6.07735639e-02, -2.5765
 As we did in the 2D example, we would like to visualize (some slices of) the two
 volumes by overlapping them over two channels of a color image. To do that we
 need them to be sampled on the same grid, so let's first re-sample the moving
-image on the static grid
+image on the static grid. We create an AffineMap to transform the moving image
+towards the static image
 """
 
-import dipy.align.vector_fields as vfu
+from dipy.align.imaffine import AffineMap
+affine_map = AffineMap(pre_align,
+                       static.shape, static_affine,
+                       moving.shape, moving_affine)
 
-transform = np.linalg.inv(moving_affine).dot(pre_align.dot(static_affine))
-resampled = vfu.warp_3d_affine(moving.astype(np.float32), 
-                                   np.asarray(static.shape, dtype=np.int32), 
-                                   transform)
-resampled = np.asarray(resampled)
+resampled = affine_map.transform(moving)
 
 """
 plot the overlapped middle slices of the volumes


### PR DESCRIPTION
We recently renamed some utility functions (those that apply affine transforms) from 'warp...' to 'transform...', but did not update the tutorial appropriately. Here we use AffineMap instead of directly calling the utility function to make the code a bit cleaner.