### PR TITLE
BF: Keep up with changes in scipy 0.16

### DIFF
--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -552,7 +552,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
         w_s = "The Eucldian norm used for interpolation is inaccurate "
         w_s += "and will be deprecated in future versions. Please consider "
         w_s += "using the 'angle' norm instead"
-        warnings.warn(w_s)
+        warnings.warn(w_s, DeprecationWarning)
         norm = euclidean_norm
 
     # Workaround for bug in older versions of SciPy that don't allow

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -552,16 +552,16 @@ def interp_rbf(data, sphere_origin, sphere_target,
         w_s = "The Eucldian norm used for interpolation is inaccurate "
         w_s += "and will be deprecated in future versions. Please consider "
         w_s += "using the 'angle' norm instead"
-        warnings.warning(w_s)
+        warnings.warn(w_s)
         norm = euclidean_norm
 
     # Workaround for bug in older versions of SciPy that don't allow
     # specification of epsilon None:
     if epsilon is not None:
         kwargs = {'function': function,
-                 'epsilon': epsilon,
-                 'smooth' : smooth,
-                 'norm' : norm}
+                  'epsilon': epsilon,
+                  'smooth' : smooth,
+                  'norm' : norm}
     else:
         kwargs = {'function': function,
                   'smooth': smooth,

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -515,7 +515,8 @@ def interp_rbf(data, sphere_origin, sphere_target,
     function : {'multiquadric', 'inverse', 'gaussian'}
         Radial basis function.
     epsilon : float
-        Radial basis function spread parameter. Defaults to approximate average distance between nodes.
+        Radial basis function spread parameter. Defaults to approximate average
+        distance between nodes.
     a good start
     smooth : float
         values greater than zero increase the smoothness of the

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -1,7 +1,5 @@
 from __future__ import division, print_function, absolute_import
 
-__all__ = ['Sphere', 'HemiSphere', 'faces_from_sphere_vertices', 'unique_edges']
-
 import numpy as np
 import warnings
 
@@ -10,6 +8,9 @@ from ..utils.six.moves import xrange
 from dipy.core.geometry import cart2sphere, sphere2cart, vector_norm
 from dipy.core.onetime import auto_attr
 from dipy.reconst.recspeed import remove_similar_vertices
+
+__all__ = ['Sphere', 'HemiSphere', 'faces_from_sphere_vertices',
+           'unique_edges']
 
 
 def _all_specified(*args):
@@ -47,6 +48,7 @@ def faces_from_sphere_vertices(vertices):
         return np.asarray(faces, np.uint16)
     else:
         return faces
+
 
 def unique_edges(faces, return_mapping=False):
     """Extract all unique edges from given triangular faces.
@@ -154,8 +156,8 @@ class Sphere(object):
 
         all_specified = _all_specified(x, y, z) + _all_specified(xyz) + \
                         _all_specified(theta, phi)
-        one_complete = _some_specified(x, y, z) + _some_specified(xyz) + \
-                       _some_specified(theta, phi)
+        one_complete = (_some_specified(x, y, z) + _some_specified(xyz) +
+                        _some_specified(theta, phi))
 
         if not (all_specified == 1 and one_complete == 1):
             raise ValueError("Sphere must be constructed using either "
@@ -347,11 +349,11 @@ class HemiSphere(Sphere):
         vertices = np.vstack([self.vertices, -self.vertices])
 
         edges = np.vstack([self.edges, n + self.edges])
-        _switch_vertex(edges[:,0], edges[:,1], vertices)
+        _switch_vertex(edges[:, 0], edges[:, 1], vertices)
 
         faces = np.vstack([self.faces, n + self.faces])
-        _switch_vertex(faces[:,0], faces[:,1], vertices)
-        _switch_vertex(faces[:,0], faces[:,2], vertices)
+        _switch_vertex(faces[:, 0], faces[:, 1], vertices)
+        _switch_vertex(faces[:, 0], faces[:, 2], vertices)
         return Sphere(xyz=vertices, edges=edges, faces=faces)
 
     @auto_attr
@@ -369,7 +371,6 @@ class HemiSphere(Sphere):
         sphere = self.mirror()
         sphere = sphere.subdivide(n)
         return HemiSphere.from_sphere(sphere)
-
 
     def find_closest(self, xyz):
         """
@@ -429,11 +430,11 @@ def _get_forces(charges):
         potential = 1. / r_mag
 
     d = np.arange(len(charges))
-    force[d,d] = 0
+    force[d, d] = 0
     force = force.sum(0)
     force_r_comp = (charges*force).sum(-1)[:, None]
     f_theta = force - force_r_comp*charges
-    potential[d,d] = 0
+    potential[d, d] = 0
     potential = 2*potential.sum()
     return f_theta, potential
 
@@ -499,7 +500,7 @@ def disperse_charges(hemi, iters, const=.2):
 
 def interp_rbf(data, sphere_origin, sphere_target,
                function='multiquadric', epsilon=None, smooth=0,
-               norm = "euclidean_norm"):
+               norm="euclidean_norm"):
     """Interpolate data on the sphere, using radial basis functions.
 
     Parameters
@@ -557,8 +558,8 @@ def interp_rbf(data, sphere_origin, sphere_target,
 
     kwargs = {'function': function,
               'epsilon': epsilon,
-              'smooth' : smooth,
-              'norm' : norm}
+              'smooth': smooth,
+              'norm': norm}
 
     rbfi = Rbf(sphere_origin.x, sphere_origin.y, sphere_origin.z, data,
                **kwargs)
@@ -607,13 +608,12 @@ def euler_characteristic_check(sphere, chi=2):
 
 
 octahedron_vertices = np.array(
-    [[ 1.0 , 0.0,  0.0],
-     [-1.0,  0.0,  0.0],
-     [ 0.0,  1.0,  0.0],
-     [ 0.0, -1.0,  0.0],
-     [ 0.0,  0.0,  1.0],
-     [ 0.0,  0.0, -1.0],
-    ])
+    [[1.0, 0.0, 0.0],
+     [-1.0, 0.0, 0.0],
+     [0.0, 1.0, 0.0],
+     [0.0, -1.0, 0.0],
+     [0.0,  0.0, 1.0],
+     [0.0,  0.0, -1.0], ])
 octahedron_faces = np.array(
     [[0, 4, 2],
      [1, 5, 3],
@@ -622,47 +622,45 @@ octahedron_faces = np.array(
      [1, 4, 3],
      [0, 5, 2],
      [0, 4, 3],
-     [1, 5, 2],
-    ], dtype='uint16')
+     [1, 5, 2], ], dtype='uint16')
 
 t = (1 + np.sqrt(5)) / 2
 icosahedron_vertices = np.array(
-    [[  t,  1,  0], #  0
-     [ -t,  1,  0], #  1
-     [  t, -1,  0], #  2
-     [ -t, -1,  0], #  3
-     [  1,  0,  t], #  4
-     [  1,  0, -t], #  5
-     [ -1,  0,  t], #  6
-     [ -1,  0, -t], #  7
-     [  0,  t,  1], #  8
-     [  0, -t,  1], #  9
-     [  0,  t, -1], # 10
-     [  0, -t, -1], # 11
-    ])
+    [[t,  1,  0],     # 0
+     [-t,  1,  0],    # 1
+     [t, -1,  0],     # 2
+     [-t, -1,  0],    # 3
+     [1,  0,  t],     # 4
+     [1,  0, -t],     # 5
+     [-1,  0,  t],    # 6
+     [-1,  0, -t],    # 7
+     [0,  t,  1],     # 8
+     [0, -t,  1],     # 9
+     [0,  t, -1],     # 10
+     [0, -t, -1], ])   # 11
+
 icosahedron_vertices /= vector_norm(icosahedron_vertices, keepdims=True)
 icosahedron_faces = np.array(
-    [[ 8,  4,  0],
-     [ 2,  5,  0],
-     [ 2,  5, 11],
-     [ 9,  2, 11],
-     [ 2,  4,  0],
-     [ 9,  2,  4],
+    [[8,  4,  0],
+     [2,  5,  0],
+     [2,  5, 11],
+     [9,  2, 11],
+     [2,  4,  0],
+     [9,  2,  4],
      [10,  8,  1],
      [10,  8,  0],
      [10,  5,  0],
-     [ 6,  3,  1],
-     [ 9,  6,  3],
-     [ 6,  8,  1],
-     [ 6,  8,  4],
-     [ 9,  6,  4],
-     [ 7, 10,  1],
-     [ 7, 10,  5],
-     [ 7,  3,  1],
-     [ 7,  3, 11],
-     [ 9,  3, 11],
-     [ 7,  5, 11],
-    ], dtype='uint16')
+     [6,  3,  1],
+     [9,  6,  3],
+     [6,  8,  1],
+     [6,  8,  4],
+     [9,  6,  4],
+     [7, 10,  1],
+     [7, 10,  5],
+     [7,  3,  1],
+     [7,  3, 11],
+     [9,  3, 11],
+     [7,  5, 11], ], dtype='uint16')
 
 unit_octahedron = Sphere(xyz=octahedron_vertices, faces=octahedron_faces)
 unit_icosahedron = Sphere(xyz=icosahedron_vertices, faces=icosahedron_faces)

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -554,7 +554,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
         # Use a heuristic that seems to work here: take epsilon to be the
         # average distance between the origin points in this norm:
         epsilon = np.mean(norm(sphere_origin.vertices.T[..., :, np.newaxis],
-                          sphere_origin.vertices.T[..., np.newaxis, :]))
+                               sphere_origin.vertices.T[..., np.newaxis, :]))
 
     kwargs = {'function': function,
               'epsilon': epsilon,

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -365,17 +365,14 @@ def test_interp_rbf():
     from dipy.core.subdivide_octahedron import create_unit_hemisphere
     import numpy as np
 
-    s0 = create_unit_hemisphere(2)
-    s1 = create_unit_hemisphere(3)
+    s0 = create_unit_sphere(3)
+    s1 = create_unit_sphere(4)
 
     for a, b in zip([1, 2, 0.5], [1, 0.5, 2]):
         data = data_func(s0, a, b)
         expected = data_func(s1, a, b)
-        interp_data_en = interp_rbf(data, s0, s1, norm = "euclidean_norm")
         interp_data_a = interp_rbf(data, s0, s1, norm = "angle")
-        nt.assert_(np.mean(np.abs(interp_data_en - expected)) < 0.1)
         nt.assert_(np.mean(np.abs(interp_data_a - expected)) < 0.1)
-
 
 if __name__ == "__main__":
     nt.run_module_suite()

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -358,6 +358,9 @@ def test_disperse_charges():
     nt.assert_array_almost_equal(norms, 1)
 
 def test_interp_rbf():
+    def data_func(s, a, b):
+        return a * np.cos(s.theta) + b * np.sin(s.phi)
+
     from dipy.core.sphere import Sphere, interp_rbf
     from dipy.core.subdivide_octahedron import create_unit_hemisphere
     import numpy as np
@@ -365,13 +368,13 @@ def test_interp_rbf():
     s0 = create_unit_hemisphere(2)
     s1 = create_unit_hemisphere(3)
 
-    data = np.cos(s0.theta) + np.sin(s0.phi)
-    expected = np.cos(s1.theta) + np.sin(s1.phi)
-    interp_data_en = interp_rbf(data, s0, s1, norm = "euclidean_norm")
-    interp_data_a = interp_rbf(data, s0, s1, norm = "angle")
-
-    nt.assert_(np.mean(np.abs(interp_data_en - expected)) < 0.1)
-    nt.assert_(np.mean(np.abs(interp_data_a - expected)) < 0.1)
+    for a, b in zip([1, 2, 0.5], [1, 0.5, 2]):
+        data = data_func(s0, a, b)
+        expected = data_func(s1, a, b)
+        interp_data_en = interp_rbf(data, s0, s1, norm = "euclidean_norm")
+        interp_data_a = interp_rbf(data, s0, s1, norm = "angle")
+        nt.assert_(np.mean(np.abs(interp_data_en - expected)) < 0.1)
+        nt.assert_(np.mean(np.abs(interp_data_a - expected)) < 0.1)
 
 
 if __name__ == "__main__":

--- a/dipy/core/tests/test_sphere.py
+++ b/dipy/core/tests/test_sphere.py
@@ -362,17 +362,23 @@ def test_interp_rbf():
         return a * np.cos(s.theta) + b * np.sin(s.phi)
 
     from dipy.core.sphere import Sphere, interp_rbf
-    from dipy.core.subdivide_octahedron import create_unit_hemisphere
     import numpy as np
-
     s0 = create_unit_sphere(3)
     s1 = create_unit_sphere(4)
-
     for a, b in zip([1, 2, 0.5], [1, 0.5, 2]):
         data = data_func(s0, a, b)
         expected = data_func(s1, a, b)
-        interp_data_a = interp_rbf(data, s0, s1, norm = "angle")
+        interp_data_a = interp_rbf(data, s0, s1, norm="angle")
         nt.assert_(np.mean(np.abs(interp_data_a - expected)) < 0.1)
+
+    # Test that using the euclidean norm raises a warning
+    # (following https://docs.python.org/2/library/warnings.html#testing-warnings)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        interp_data_en = interp_rbf(data, s0, s1, norm ="euclidean_norm")
+        nt.assert_(len(w) == 1)
+        nt.assert_(issubclass(w[-1].category, DeprecationWarning))
+        nt.assert_("deprecated" in str(w[-1].message))
 
 if __name__ == "__main__":
     nt.run_module_suite()


### PR DESCRIPTION
Recent changes in scipy use a different heuristic to find the epsilon
parameter used for RBF interpolation, causing for us issue #688. This
should fix it, by using the old heuristic.