### PR TITLE
DOC: Use the `identity` variable in the resampling transformation.

### DIFF
--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -47,7 +47,7 @@ the moving image using an identity transform
 """
 
 identity = np.eye(4)
-affine_map = AffineMap(None,
+affine_map = AffineMap(identity,
                        static.shape, static_grid2world,
                        moving.shape, moving_grid2world)
 resampled = affine_map.transform(moving)


### PR DESCRIPTION
One-word fix (which is probably a no-op anyway), but would help clarify the example a tiny bit. 