### PR TITLE
RF: use masks in predictions and cross-validation

### DIFF
--- a/dipy/reconst/cross_validation.py
+++ b/dipy/reconst/cross_validation.py
@@ -68,17 +68,20 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
         The type of the model to use for prediction. The corresponding Fit
         object must have a `predict` function implementd One of the following:
         `reconst.dti.TensorModel` or
-        `reconst.csdeconv.ConstrainedSphericalDeconvModel`. 
+        `reconst.csdeconv.ConstrainedSphericalDeconvModel`.
     data : ndarray
         Diffusion MRI data acquired with the GradientTable of the model. Shape
         will typically be `(x, y, z, b)` where `xyz` are spatial dimensions and
-        b is the number of bvals/bvecs in the GradientTable. 
+        b is the number of bvals/bvecs in the GradientTable.
     folds : int
         The number of divisions to apply to the data
     model_args : list
         Additional arguments to the model initialization
     model_kwargs : dict
-        Additional key-word arguments to the model initialization
+        Additional key-word arguments to the model initialization. If contains
+        the kwarg `mask`, this will be used as a key-word argument to the `fit`
+        method of the model object, rather than being used in the initialization
+        of the model object
 
     Notes
     -----
@@ -133,9 +136,9 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
                                                  nz_bval[~fold_mask]]),
                                       np.concatenate([gtab.bvecs[gtab.b0s_mask],
                                                  nz_bvec[~fold_mask]]))
-
+        mask = model_kwargs.pop('mask', None)
         this_model = model.__class__(this_gtab, *model_args, **model_kwargs)
-        this_fit = this_model.fit(this_data)
+        this_fit = this_model.fit(this_data, mask=mask)
         if not hasattr(this_fit, 'predict'):
             err_str = "Models of type: %s "%this_model.__class__
             err_str += "do not have an implementation of model prediction"

--- a/dipy/reconst/cross_validation.py
+++ b/dipy/reconst/cross_validation.py
@@ -122,6 +122,8 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
     nz_bval = gtab.bvals[~gtab.b0s_mask]
     nz_bvec = gtab.bvecs[~gtab.b0s_mask]
 
+    # Pop the mask, if there is one, out here for use in every fold:
+    mask = model_kwargs.pop('mask', None)
     for k in range(folds):
         fold_mask = np.ones(data_b.shape[-1], dtype=bool)
         fold_idx = order[k*n_in_fold:(k+1)*n_in_fold]
@@ -136,7 +138,6 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
                                                  nz_bval[~fold_mask]]),
                                       np.concatenate([gtab.bvecs[gtab.b0s_mask],
                                                  nz_bvec[~fold_mask]]))
-        mask = model_kwargs.pop('mask', None)
         this_model = model.__class__(this_gtab, *model_args, **model_kwargs)
         this_fit = this_model.fit(this_data, mask=mask)
         if not hasattr(this_fit, 'predict'):

--- a/dipy/reconst/cross_validation.py
+++ b/dipy/reconst/cross_validation.py
@@ -48,10 +48,10 @@ def coeff_of_determination(data, model, axis=-1):
     ss_err = np.sum(residuals ** 2, axis=axis)
 
     demeaned_data = data - np.mean(data, axis=axis)[..., np.newaxis]
-    ss_tot = np.sum(demeaned_data **2, axis=axis)
+    ss_tot = np.sum(demeaned_data ** 2, axis=axis)
 
     # Don't divide by 0:
-    if np.all(ss_tot==0.0):
+    if np.all(ss_tot == 0.0):
         return np.nan
 
     return 100 * (1 - (ss_err/ss_tot))
@@ -80,8 +80,8 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
     model_kwargs : dict
         Additional key-word arguments to the model initialization. If contains
         the kwarg `mask`, this will be used as a key-word argument to the `fit`
-        method of the model object, rather than being used in the initialization
-        of the model object
+        method of the model object, rather than being used in the
+        initialization of the model object
 
     Notes
     -----
@@ -104,12 +104,12 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
     # dipy.reconst.base.ReconstModel:
     gtab = model.gtab
     data_b = data[..., ~gtab.b0s_mask]
-    div_by_folds =  np.mod(data_b.shape[-1], folds)
+    div_by_folds = np.mod(data_b.shape[-1], folds)
     # Make sure that an equal number of samples get left out in each fold:
-    if div_by_folds!= 0:
+    if div_by_folds != 0:
         msg = "The number of folds must divide the diffusion-weighted "
         msg += "data equally, but "
-        msg = "np.mod(%s, %s) is %s"%(data_b.shape[-1], folds, div_by_folds)
+        msg = "np.mod(%s, %s) is %s" % (data_b.shape[-1], folds, div_by_folds)
         raise ValueError(msg)
 
     data_0 = data[..., gtab.b0s_mask]
@@ -124,31 +124,33 @@ def kfold_xval(model, data, folds, *model_args, **model_kwargs):
 
     # Pop the mask, if there is one, out here for use in every fold:
     mask = model_kwargs.pop('mask', None)
+    gtgt = gt.gradient_table  # Shorthand
     for k in range(folds):
         fold_mask = np.ones(data_b.shape[-1], dtype=bool)
         fold_idx = order[k*n_in_fold:(k+1)*n_in_fold]
         fold_mask[fold_idx] = False
         this_data = np.concatenate([data_0, data_b[..., fold_mask]], -1)
 
-        this_gtab = gt.gradient_table(np.hstack([gtab.bvals[gtab.b0s_mask],
-                                                 nz_bval[fold_mask]]),
-                                      np.concatenate([gtab.bvecs[gtab.b0s_mask],
-                                                 nz_bvec[fold_mask]]))
-        left_out_gtab = gt.gradient_table(np.hstack([gtab.bvals[gtab.b0s_mask],
-                                                 nz_bval[~fold_mask]]),
-                                      np.concatenate([gtab.bvecs[gtab.b0s_mask],
-                                                 nz_bvec[~fold_mask]]))
+        this_gtab = gtgt(np.hstack([gtab.bvals[gtab.b0s_mask],
+                                    nz_bval[fold_mask]]),
+                         np.concatenate([gtab.bvecs[gtab.b0s_mask],
+                                         nz_bvec[fold_mask]]))
+        left_out_gtab = gtgt(np.hstack([gtab.bvals[gtab.b0s_mask],
+                                        nz_bval[~fold_mask]]),
+                             np.concatenate([gtab.bvecs[gtab.b0s_mask],
+                                             nz_bvec[~fold_mask]]))
         this_model = model.__class__(this_gtab, *model_args, **model_kwargs)
         this_fit = this_model.fit(this_data, mask=mask)
         if not hasattr(this_fit, 'predict'):
-            err_str = "Models of type: %s "%this_model.__class__
+            err_str = "Models of type: %s " % this_model.__class__
             err_str += "do not have an implementation of model prediction"
             err_str += " and do not support cross-validation"
             raise ValueError(err_str)
         this_predict = S0[..., None] * this_fit.predict(left_out_gtab, S0=1)
 
         idx_to_assign = np.where(~gtab.b0s_mask)[0][~fold_mask]
-        prediction[..., idx_to_assign]=this_predict[..., np.sum(gtab.b0s_mask):]
+        prediction[..., idx_to_assign] =\
+            this_predict[..., np.sum(gtab.b0s_mask):]
 
     # For the b0 measurements
     prediction[..., gtab.b0s_mask] = S0[..., None]

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -3,9 +3,10 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from dipy.reconst.dti import (TensorFit, mean_diffusivity,
-                              from_lower_triangular, lower_triangular,
-                              decompose_tensor, _min_positive_signal)
+from dipy.reconst.dti import (TensorFit, mean_diffusivity, axial_diffusivity,
+                              radial_diffusivity, from_lower_triangular,
+                              lower_triangular, decompose_tensor,
+                              _min_positive_signal)
 
 from dipy.reconst.utils import dki_design_matrix as design_matrix
 from dipy.utils.six.moves import range

--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -2,20 +2,10 @@
 """ Classes and functions for fitting the diffusion kurtosis model """
 from __future__ import division, print_function, absolute_import
 
-import warnings
-
 import numpy as np
-
-import scipy.optimize as opt
-
-from dipy.reconst.dti import (TensorFit, fractional_anisotropy,
-                              geodesic_anisotropy, mean_diffusivity,
-                              axial_diffusivity, radial_diffusivity, trace,
-                              color_fa, determinant, isotropic, deviatoric,
-                              norm, mode, linearity, planarity, sphericity,
-                              apparent_diffusion_coef, from_lower_triangular,
-                              lower_triangular, decompose_tensor,
-                              _min_positive_signal)
+from dipy.reconst.dti import (TensorFit, mean_diffusivity,
+                              from_lower_triangular, lower_triangular,
+                              decompose_tensor, _min_positive_signal)
 
 from dipy.reconst.utils import dki_design_matrix as design_matrix
 from dipy.utils.six.moves import range

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1601,13 +1601,17 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True):
                     this_tensor, status = opt.leastsq(_nlls_err_func,
                                                       start_params,
                                                       args=(clean_design,
-                                                            clean_sig),
+                                                            clean_sig,
+                                                            'sigma',
+                                                            this_sigma),
                                                       Dfun=_nlls_jacobian_func)
                 else:
                     this_tensor, status = opt.leastsq(_nlls_err_func,
                                                       start_params,
                                                       args=(clean_design,
-                                                            clean_sig))
+                                                            clean_sig,
+                                                            'sigma',
+                                                            this_sigma))
 
         # The parameters are the evals and the evecs:
         try:

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1739,7 +1739,6 @@ def decompose_tensor(tensor, min_diffusivity=0):
         eigenvals = eigenvals[xi, order]
         eigenvecs = eigenvecs.reshape(shape + (3, 3))
         eigenvals = eigenvals.reshape(shape + (3, ))
-
     eigenvals = eigenvals.clip(min=min_diffusivity)
     # eigenvecs: each vector is columnar
 
@@ -1790,7 +1789,7 @@ def quantize_evecs(evecs, odf_vertices=None):
     IN : ndarray
     """
     max_evecs = evecs[..., :, 0]
-    if odf_vertices == None:
+    if odf_vertices is None:
         odf_vertices = get_sphere('symmetric362').vertices
     tup = max_evecs.shape[:-1]
     mec = max_evecs.reshape(np.prod(np.array(tup)), 3)
@@ -1828,6 +1827,6 @@ common_fit_methods = {'WLS': wls_fit_tensor,
                       'OLS': ols_fit_tensor,
                       'NLLS': nlls_fit_tensor,
                       'RT': restore_fit_tensor,
-                      'restore':restore_fit_tensor,
-                      'RESTORE':restore_fit_tensor
-                     }
+                      'restore': restore_fit_tensor,
+                      'RESTORE': restore_fit_tensor
+                      }

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -566,7 +566,7 @@ def planarity(evals, axis=-1):
 
     Notes
     --------
-    Linearity is calculated with the following equation:
+    Planarity is calculated with the following equation:
 
     .. math::
 
@@ -602,7 +602,7 @@ def sphericity(evals, axis=-1):
 
     Notes
     --------
-    Linearity is calculated with the following equation:
+    Sphericity is calculated with the following equation:
 
     .. math::
 

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -16,7 +16,7 @@ from ..core.geometry import vector_norm
 from ..core.sphere import Sphere
 from .vec_val_sum import vec_val_vect
 from ..core.onetime import auto_attr
-from .base import ReconstModel, ReconstFit
+from .base import ReconstModel
 
 
 def _roll_evals(evals, axis=-1):
@@ -100,8 +100,10 @@ def fractional_anisotropy(evals, axis=-1):
     # Make sure not to get nans
     all_zero = (evals == 0).all(axis=0)
     ev1, ev2, ev3 = evals
-    fa = np.sqrt(0.5 * ((ev1 - ev2) ** 2 + (ev2 - ev3) ** 2 + (ev3 - ev1) ** 2)
-                  / ((evals * evals).sum(0) + all_zero))
+    fa = np.sqrt(0.5 * ((ev1 - ev2) ** 2 +
+                 (ev2 - ev3) ** 2 +
+                 (ev3 - ev1) ** 2) /
+                 ((evals * evals).sum(0) + all_zero))
 
     return fa
 
@@ -798,7 +800,6 @@ class TensorModel(ReconstModel):
             dti_params[mask, :] = params_in_mask
 
         return TensorFit(self, dti_params)
-
 
     def predict(self, dti_params, S0=1):
         """

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -130,38 +130,43 @@ def geodesic_anisotropy(evals, axis=-1):
 
     .. math::
 
-        GA = \sqrt{\sum_{i=1}^3 \log^2{\left ( \lambda_i/<\mathbf{D}> \right )}},
-        \quad \textrm{where} \quad <\mathbf{D}> = (\lambda_1\lambda_2\lambda_3)^{1/3}
+        GA = \sqrt{\sum_{i=1}^3
+        \log^2{\left ( \lambda_i/<\mathbf{D}> \right )}},
+        \quad \textrm{where} \quad <\mathbf{D}> =
+        (\lambda_1\lambda_2\lambda_3)^{1/3}
 
-    Note that the notation, $<D>$, is often used as the mean diffusivity (MD) of the diffusion tensor
-    and can lead to confusions in the literature (see [1]_ versus [2]_ versus [3]_ for example).
-    Reference [2]_ defines geodesic anisotropy (GA) with $<D>$ as the MD in the denominator of the sum.
-    This is wrong. The original paper [1]_ defines GA with $<D> = det(D)^{1/3}$, as the
-    isotropic part of the distance. This might be an explanation for the confusion.
-    The isotropic part of the diffusion tensor in Euclidean space is
-    the MD whereas the isotropic part of the tensor in log-Euclidean space is $det(D)^{1/3}$.
-    The Appendix of [1]_ and log-Euclidean derivations from [3]_ are clear on this.
-    Hence, all that to say that $<D> = det(D)^{1/3}$ here for the GA definition and not MD.
+    Note that the notation, $<D>$, is often used as the mean diffusivity (MD)
+    of the diffusion tensor and can lead to confusions in the literature
+    (see [1]_ versus [2]_ versus [3]_ for example). Reference [2]_ defines
+    geodesic anisotropy (GA) with $<D>$ as the MD in the denominator of the
+    sum. This is wrong. The original paper [1]_ defines GA with
+    $<D> = det(D)^{1/3}$, as the isotropic part of the distance. This might be
+    an explanation for the confusion. The isotropic part of the diffusion
+    tensor in Euclidean space is the MD whereas the isotropic part of the
+    tensor in log-Euclidean space is $det(D)^{1/3}$. The Appendix of [1]_ and
+    log-Euclidean derivations from [3]_ are clear on this. Hence, all that to
+    say that $<D> = det(D)^{1/3}$ here for the GA definition and not MD.
 
     References
     ----------
 
-    .. [1] P. G. Batchelor, M. Moakher, D. Atkinson, F. Calamante, A. Connelly,
-        "A rigorous framework for diffusion tensor calculus", Magnetic Resonance
-        in Medicine, vol. 53, pp. 221-225, 2005.
+    .. [1] P. G. Batchelor, M. Moakher, D. Atkinson, F. Calamante,
+        A. Connelly, "A rigorous framework for diffusion tensor calculus",
+        Magnetic Resonance in Medicine, vol. 53, pp. 221-225, 2005.
 
     .. [2] M. M. Correia, V. F. Newcombe, G.B. Williams.
-        "Contrast-to-noise ratios for indices of anisotropy obtained from diffusion MRI:
-        a study with standard clinical b-values at 3T". NeuroImage, vol. 57, pp. 1103-1115, 2011.
+        "Contrast-to-noise ratios for indices of anisotropy obtained from
+        diffusion MRI: a study with standard clinical b-values at 3T".
+        NeuroImage, vol. 57, pp. 1103-1115, 2011.
 
     .. [3] A. D. Lee, etal, P. M. Thompson.
-        "Comparison of fractional and geodesic anisotropy in diffusion tensor images
-        of 90 monozygotic and dizygotic twins". 5th IEEE International Symposium on
-        Biomedical Imaging (ISBI), pp. 943-946, May 2008.
+        "Comparison of fractional and geodesic anisotropy in diffusion tensor
+        images of 90 monozygotic and dizygotic twins". 5th IEEE International
+        Symposium on Biomedical Imaging (ISBI), pp. 943-946, May 2008.
 
     .. [4] V. Arsigny, P. Fillard, X. Pennec, N. Ayache.
-        "Log-Euclidean metrics for fast and simple calculus on diffusion tensors."
-        Magnetic Resonance in Medecine, vol 56, pp. 411-421, 2006.
+        "Log-Euclidean metrics for fast and simple calculus on diffusion
+        tensors." Magnetic Resonance in Medecine, vol 56, pp. 411-421, 2006.
 
     """
 
@@ -395,8 +400,6 @@ def isotropic(q_form):
         2006.
     """
     tr_A = q_form[..., 0, 0] + q_form[..., 1, 1] + q_form[..., 2, 2]
-    n_dims = len(q_form.shape)
-    add_dims = n_dims - 2  # These are the last two (the 3,3):
     my_I = np.eye(3)
     tr_AI = (tr_A.reshape(tr_A.shape + (1, 1)) * my_I)
     return (1 / 3.0) * tr_AI
@@ -567,7 +570,8 @@ def planarity(evals, axis=-1):
 
     .. math::
 
-        Planarity = \frac{2 (\lambda_2-\lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
+        Planarity =
+        \frac{2 (\lambda_2-\lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
 
     Notes
     -----
@@ -653,8 +657,9 @@ def tensor_prediction(dti_params, gtab, S0):
     Parameters
     ----------
     dti_params : ndarray
-        Tensor parameters. The last dimension should have 12 tensor parameters: 3
-        eigenvalues, followed by the 3 corresponding eigenvectors
+        Tensor parameters. The last dimension should have 12 tensor
+        parameters: 3 eigenvalues, followed by the 3 corresponding
+        eigenvectors.
 
     gtab : a GradientTable class instance
         The gradient table for this prediction
@@ -714,7 +719,8 @@ class TensorModel(ReconstModel):
                 dti.ols_fit_tensor
             'NLLS' for non-linear least-squares
                 dti.nlls_fit_tensor
-            'RT' or 'restore' or 'RESTORE' for RESTORE robust tensor fitting [3]_
+            'RT' or 'restore' or 'RESTORE' for RESTORE robust tensor
+                fitting [3]_
                 dti.restore_fit_tensor
 
             callable has to have the signature:
@@ -745,11 +751,11 @@ class TensorModel(ReconstModel):
             try:
                 fit_method = common_fit_methods[fit_method]
             except KeyError:
-                raise ValueError('"' + str(fit_method) + '" is not a known fit '
-                                 'method, the fit method should either be a '
-                                 'function or one of the common fit methods')
+                e_s = '"' + str(fit_method) + '" is not a known fit '
+                e_s += 'method, the fit method should either be a '
+                e_s += 'function or one of the common fit methods'
+                raise ValueError(e_s)
         self.fit_method = fit_method
-
         self.design_matrix = design_matrix(self.gtab)
         self.args = args
         self.kwargs = kwargs
@@ -781,7 +787,6 @@ class TensorModel(ReconstModel):
                 raise ValueError("Mask is not the same shape as data.")
             mask = np.array(mask, dtype=bool, copy=False)
             data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
-
 
         if self.min_signal is None:
             min_signal = _min_positive_signal(data)
@@ -993,7 +998,8 @@ class TensorFit(object):
 
         .. math::
 
-            Sphericity = \frac{2 (\lambda2 - \lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
+            Sphericity =
+            \frac{2 (\lambda2 - \lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
 
         Notes
         -----
@@ -1018,7 +1024,8 @@ class TensorFit(object):
 
         .. math::
 
-            Linearity = \frac{\lambda_1-\lambda_2}{\lambda_1+\lambda_2+\lambda_3}
+            Linearity =
+            \frac{\lambda_1-\lambda_2}{\lambda_1+\lambda_2+\lambda_3}
 
         Notes
         -----
@@ -1126,7 +1133,6 @@ class TensorFit(object):
         """
         return apparent_diffusion_coef(self.quadratic_form, sphere)
 
-
     def predict(self, gtab, S0=1):
         r"""
         Given a model fit, predict the signal on the vertices of a sphere
@@ -1203,7 +1209,8 @@ def wls_fit_tensor(design_matrix, data):
 
         y = \mathrm{data} \\
         X = \mathrm{design matrix} \\
-        \hat{\beta}_\mathrm{WLS} = \mathrm{desired regression coefficients (e.g. tensor)}\\
+        \hat{\beta}_\mathrm{WLS} =
+        \mathrm{desired regression coefficients (e.g. tensor)}\\
         \\
         \hat{\beta}_\mathrm{WLS} = (X^T W X)^{-1} X^T W y \\
         \\
@@ -1350,8 +1357,8 @@ def _nlls_err_func(tensor, design_matrix, data, weighting=None,
 
     References
     ----------
-    [1] Chang, L-C, Jones, DK and Pierpaoli, C (2005). RESTORE: robust estimation
-    of tensors by outlier rejection. MRM, 53: 1088-95.
+    [1] Chang, L-C, Jones, DK and Pierpaoli, C (2005). RESTORE: robust
+    estimation of tensors by outlier rejection. MRM, 53: 1088-95.
     """
     # This is the predicted signal given the params:
     y = np.exp(np.dot(design_matrix, tensor))
@@ -1361,16 +1368,16 @@ def _nlls_err_func(tensor, design_matrix, data, weighting=None,
 
     # If we don't want to weight the residuals, we are basically done:
     if weighting is None:
-       # And we return the SSE:
-       return residuals
+        # And we return the SSE:
+        return residuals
     se = residuals ** 2
     # If the user provided a sigma (e.g 1.5267 * std(background_noise), as
     # suggested by Chang et al.) we will use it:
     if weighting == 'sigma':
         if sigma is None:
-             e_s = "Must provide sigma value as input to use this weighting"
-             e_s += " method"
-             raise ValueError(e_s)
+            e_s = "Must provide sigma value as input to use this weighting"
+            e_s += " method"
+            raise ValueError(e_s)
         w = 1/(sigma**2)
 
     elif weighting == 'gmm':
@@ -1438,7 +1445,8 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
     Returns
     -------
-    nlls_params: the eigen-values and eigen-vectors of the tensor in each voxel.
+    nlls_params: the eigen-values and eigen-vectors of the tensor in each
+        voxel.
 
     """
     # Flatten for the iteration over voxels:
@@ -1474,13 +1482,15 @@ def nlls_fit_tensor(design_matrix, data, weighting=None,
 
         # The parameters are the evals and the evecs:
         try:
-            evals, evecs = decompose_tensor(from_lower_triangular(this_tensor[:6]))
+            evals, evecs = decompose_tensor(
+                               from_lower_triangular(this_tensor[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
         except np.linalg.LinAlgError:
-            evals, evecs = decompose_tensor(from_lower_triangular(start_params[:6]))
+            evals, evecs = decompose_tensor(
+                              from_lower_triangular(start_params[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
 
@@ -1524,7 +1534,6 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True):
     of tensors by outlier rejection. MRM, 53: 1088-95.
 
     """
-
     # Flatten for the iteration over voxels:
     flat_data = data.reshape((-1, data.shape[-1]))
     # Use the OLS method parameters as the starting point for the optimization:
@@ -1549,10 +1558,10 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True):
                                               Dfun=_nlls_jacobian_func)
         else:
             this_tensor, status = opt.leastsq(_nlls_err_func, start_params,
-                                             args=(design_matrix,
-                                                   flat_data[vox],
-                                                   'sigma',
-                                                   sigma))
+                                              args=(design_matrix,
+                                                    flat_data[vox],
+                                                    'sigma',
+                                                    sigma))
 
         # Get the residuals:
         pred_sig = np.exp(np.dot(design_matrix, this_tensor))
@@ -1562,18 +1571,18 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True):
         if np.any(np.abs(residuals) > 3 * sigma):
             # Do nlls with GMM-weighting:
             if jac:
-                this_tensor, status= opt.leastsq(_nlls_err_func,
-                                                 start_params,
-                                                 args=(design_matrix,
-                                                       flat_data[vox],
-                                                       'gmm'),
-                                                 Dfun=_nlls_jacobian_func)
+                this_tensor, status = opt.leastsq(_nlls_err_func,
+                                                  start_params,
+                                                  args=(design_matrix,
+                                                        flat_data[vox],
+                                                        'gmm'),
+                                                  Dfun=_nlls_jacobian_func)
             else:
-                this_tensor, status= opt.leastsq(_nlls_err_func,
-                                                 start_params,
-                                                 args=(design_matrix,
-                                                       flat_data[vox],
-                                                       'gmm'))
+                this_tensor, status = opt.leastsq(_nlls_err_func,
+                                                  start_params,
+                                                  args=(design_matrix,
+                                                        flat_data[vox],
+                                                        'gmm'))
 
             # How are you doin' on those residuals?
             pred_sig = np.exp(np.dot(design_matrix, this_tensor))
@@ -1590,34 +1599,33 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True):
 
                 if jac:
                     this_tensor, status = opt.leastsq(_nlls_err_func,
-                                                     start_params,
-                                                     args=(clean_design,
-                                                           clean_sig),
-                                                     Dfun=_nlls_jacobian_func)
+                                                      start_params,
+                                                      args=(clean_design,
+                                                            clean_sig),
+                                                      Dfun=_nlls_jacobian_func)
                 else:
                     this_tensor, status = opt.leastsq(_nlls_err_func,
-                                                     start_params,
-                                                     args=(clean_design,
-                                                           clean_sig))
+                                                      start_params,
+                                                      args=(clean_design,
+                                                            clean_sig))
 
         # The parameters are the evals and the evecs:
         try:
-            evals, evecs = decompose_tensor(from_lower_triangular(this_tensor[:6]))
+            evals, evecs = decompose_tensor(
+                               from_lower_triangular(this_tensor[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
         # If leastsq failed to converge and produced nans, we'll resort to the
         # OLS solution in this voxel:
         except np.linalg.LinAlgError:
-            evals, evecs = decompose_tensor(from_lower_triangular(start_params[:6]))
+            evals, evecs = decompose_tensor(
+                               from_lower_triangular(start_params[:6]))
             dti_params[vox, :3] = evals
             dti_params[vox, 3:] = evecs.ravel()
 
     dti_params.shape = data.shape[:-1] + (12,)
     restore_params = dti_params
     return restore_params
-
-
-
 
 
 _lt_indices = np.array([[0, 1, 3],

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1027,8 +1027,6 @@ class TensorFit(object):
             Linearity =
             \frac{\lambda_1-\lambda_2}{\lambda_1+\lambda_2+\lambda_3}
 
-        Notes
-        -----
         [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz
             F., "Geometrical diffusion measures for MRI from tensor basis
             analysis" in Proc. 5th Annual ISMRM, 1997.

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -80,12 +80,20 @@ class MultiVoxelFit(ReconstFit):
                 return S0
 
         kwargs['S0'] = gimme_S0(S0, ijk)
+        # If we have a mask, we might have some Nones up front, skip those:
+        while self.fit_array[ijk] is None:
+            ijk = next(idx)
+
         first_pred = self.fit_array[ijk].predict(*args, **kwargs)
         result = np.empty(self.fit_array.shape + (first_pred.shape[-1],))
         result[ijk] = first_pred
         for ijk in idx:
             kwargs['S0'] = gimme_S0(S0, ijk)
-            result[ijk] = self.fit_array[ijk].predict(*args, **kwargs)
+            # If it's masked, we predict a 0:
+            if self.fit_array[ijk] is None:
+                result[ijk] *= 0
+            else:
+                result[ijk] = self.fit_array[ijk].predict(*args, **kwargs)
 
         return result
 

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -86,7 +86,7 @@ class MultiVoxelFit(ReconstFit):
             ijk = next(idx)
 
         first_pred = self.fit_array[ijk].predict(*args, **kwargs)
-        result = np.empty(self.fit_array.shape + (first_pred.shape[-1],))
+        result = np.zeros(self.fit_array.shape + (first_pred.shape[-1],))
         result[ijk] = first_pred
         for ijk in idx:
             kwargs['S0'] = gimme_S0(S0, ijk)

--- a/dipy/reconst/multi_voxel.py
+++ b/dipy/reconst/multi_voxel.py
@@ -4,7 +4,7 @@ from numpy.lib.stride_tricks import as_strided
 
 from ..core.ndindex import ndindex
 from .quick_squash import quick_squash as _squash
-from .base import ReconstModel, ReconstFit
+from .base import ReconstFit
 
 
 def multi_voxel_fit(single_voxel_fit):
@@ -73,6 +73,7 @@ class MultiVoxelFit(ReconstFit):
         S0 = kwargs.get('S0', np.ones(self.fit_array.shape))
         idx = ndindex(self.fit_array.shape)
         ijk = next(idx)
+
         def gimme_S0(S0, ijk):
             if isinstance(S0, np.ndarray):
                 return S0[ijk]
@@ -96,6 +97,7 @@ class MultiVoxelFit(ReconstFit):
                 result[ijk] = self.fit_array[ijk].predict(*args, **kwargs)
 
         return result
+
 
 class CallableArray(np.ndarray):
     """An array which can be called like a function"""

--- a/dipy/reconst/tests/test_cross_validation.py
+++ b/dipy/reconst/tests/test_cross_validation.py
@@ -63,6 +63,14 @@ def test_dti_xval():
     cod = xval.coeff_of_determination(S, kf_xval)
     npt.assert_array_almost_equal(cod, np.ones(kf_xval.shape[:-1])*100)
 
+    # Test with 2D data for use of a mask
+    S = np.array([[S, S], [S, S]])
+    mask = np.ones(S.shape[:-1], dtype=bool)
+    mask[1, 1] = 0
+    kf_xval = xval.kfold_xval(dm, S, 2, mask=mask)
+    cod2d = xval.coeff_of_determination(S, kf_xval)
+    npt.assert_array_almost_equal(np.round(cod2d[0, 0]), cod)
+
 
 def test_csd_xval():
     # First, let's see that it works with some data:
@@ -96,6 +104,16 @@ def test_csd_xval():
 
     # We're going to be really lenient here:
     npt.assert_array_almost_equal(np.round(cod), csd_cod)
+    # Test for sD data with more than one voxel for use of a mask:
+    S = np.array([[S, S], [S, S]])
+    mask = np.ones(S.shape[:-1], dtype=bool)
+    mask[1, 1] = 0
+    kf_xval = xval.kfold_xval(sm, S, 2, response, sh_order=2,
+                              mask=mask)
+
+    cod = xval.coeff_of_determination(S, kf_xval)
+    npt.assert_array_almost_equal(np.round(cod[0]), csd_cod)
+
 
 
 def test_no_predict():
@@ -107,11 +125,11 @@ def test_no_predict():
         def __init__(self, gtab):
             base.ReconstModel.__init__(self, gtab)
 
-        def fit(self, data):
-            return NoPredictFit(self, data)
+        def fit(self, data, mask=None):
+            return NoPredictFit(self, data, mask=mask)
 
     class NoPredictFit(base.ReconstFit):
-        def __init__(self, model, data):
+        def __init__(self, model, data, mask=None):
             base.ReconstFit.__init__(self, model, data)
 
     gtab = gt.gradient_table(fbval, fbvec)

--- a/dipy/reconst/tests/test_cross_validation.py
+++ b/dipy/reconst/tests/test_cross_validation.py
@@ -14,11 +14,11 @@ import dipy.core.gradients as gt
 import dipy.sims.voxel as sims
 import dipy.reconst.csdeconv as csd
 import dipy.reconst.base as base
-import dipy.reconst.shm as shm
 
 
 # We'll set these globally:
-fdata, fbval, fbvec  = dpd.get_data('small_64D')
+fdata, fbval, fbvec = dpd.get_data('small_64D')
+
 
 def test_coeff_of_determination():
     """
@@ -52,16 +52,14 @@ def test_dti_xval():
     bvals[0] = 0
     gtab = gt.gradient_table(bvals, bvecs)
     mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
-    mevecs = [ np.array( [ [1, 0, 0], [0, 1, 0], [0, 0, 1] ] ),
-               np.array( [ [0, 0, 1], [0, 1, 0], [1, 0, 0] ] ) ]
-    S = sims.single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None )
+    mevecs = [np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+              np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])]
+    S = sims.single_tensor(gtab, 100, mevals[0], mevecs[0], snr=None)
 
     dm = dti.TensorModel(gtab, 'LS')
-    dmfit = dm.fit(S)
-
     kf_xval = xval.kfold_xval(dm, S, 2)
     cod = xval.coeff_of_determination(S, kf_xval)
-    npt.assert_array_almost_equal(cod, np.ones(kf_xval.shape[:-1])*100)
+    npt.assert_array_almost_equal(cod, np.ones(kf_xval.shape[:-1]) * 100)
 
     # Test with 2D data for use of a mask
     S = np.array([[S, S], [S, S]])
@@ -88,19 +86,18 @@ def test_csd_xval():
     bvals[0] = 0
     gtab = gt.gradient_table(bvals, bvecs)
     mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
-    mevecs = [ np.array( [ [1, 0, 0], [0, 1, 0], [0, 0, 1] ] ),
-               np.array( [ [0, 0, 1], [0, 1, 0], [1, 0, 0] ] ) ]
+    mevecs = [np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+              np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])]
     S0 = 100
-    S = sims.single_tensor( gtab, S0, mevals[0], mevecs[0], snr=None )
+    S = sims.single_tensor(gtab, S0, mevals[0], mevecs[0], snr=None)
     sm = csd.ConstrainedSphericalDeconvModel(gtab, response)
-    smfit = sm.fit(S)
     np.random.seed(12345)
     response = ([0.0015, 0.0003, 0.0001], S0)
     kf_xval = xval.kfold_xval(sm, S, 2, response, sh_order=2)
     # Because of the regularization, COD is not going to be perfect here:
     cod = xval.coeff_of_determination(S, kf_xval)
     # We'll just test for regressions:
-    csd_cod = 97 # pre-computed by hand for this random seed
+    csd_cod = 97  # pre-computed by hand for this random seed
 
     # We're going to be really lenient here:
     npt.assert_array_almost_equal(np.round(cod), csd_cod)
@@ -113,7 +110,6 @@ def test_csd_xval():
 
     cod = xval.coeff_of_determination(S, kf_xval)
     npt.assert_array_almost_equal(np.round(cod[0]), csd_cod)
-
 
 
 def test_no_predict():

--- a/dipy/reconst/tests/test_dki.py
+++ b/dipy/reconst/tests/test_dki.py
@@ -3,33 +3,22 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-
 import random
-
 import dipy.reconst.dki as dki
-
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_almost_equal)
-
 from nose.tools import assert_raises
-
 from dipy.sims.voxel import multi_tensor_dki
-
 from dipy.io.gradients import read_bvals_bvecs
-
 from dipy.core.gradients import gradient_table
-
 from dipy.data import get_data
-
 from dipy.reconst.dti import (from_lower_triangular, decompose_tensor)
-
 from dipy.reconst.dki import (mean_kurtosis, carlson_rf,  carlson_rd,
                               axial_kurtosis, radial_kurtosis, _positive_evals)
 
 from dipy.core.sphere import Sphere
 
 from dipy.core.geometry import perpendicular_directions
-
 
 fimg, fbvals, fbvecs = get_data('small_64D')
 bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
@@ -159,8 +148,12 @@ def test_dki_predict():
 
     # check the function predict of the DiffusionKurtosisFit object
     dkiF = dkiM.fit(DWI)
-    pred_multi = dkiF.predict(gtab, S0=100)
-    assert_array_almost_equal(pred_multi, DWI[:, :, :, :65])
+    pred_multi = dkiF.predict(gtab_2s, S0=100)
+    assert_array_almost_equal(pred_multi, DWI)
+
+    dkiF = dkiM.fit(pred_multi)
+    pred_from_fit = dkiF.predict(dkiM.gtab, S0=100)
+    assert_array_almost_equal(pred_from_fit, DWI)
 
 
 def test_carlson_rf():

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -675,7 +675,6 @@ def test_predict():
     assert_equal(p.shape, data.shape)
 
 
-
 def test_eig_from_lo_tri():
     psphere = get_sphere('symmetric362')
     bvecs = np.concatenate(([[0, 0, 0]], psphere.vertices))

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -7,27 +7,29 @@ import numpy as np
 from nose.tools import (assert_true, assert_equal,
                         assert_almost_equal, assert_raises)
 import numpy.testing as npt
-from numpy.testing import assert_array_equal, assert_array_almost_equal, assert_
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_)
 import nibabel as nib
 
 import scipy.optimize as opt
 
 import dipy.reconst.dti as dti
 from dipy.reconst.dti import (axial_diffusivity, color_fa,
-                              fractional_anisotropy, from_lower_triangular, geodesic_anisotropy,
-                              lower_triangular, mean_diffusivity,
-                              radial_diffusivity, TensorModel, trace,
-                              linearity, planarity, sphericity)
+                              fractional_anisotropy, from_lower_triangular,
+                              geodesic_anisotropy, lower_triangular,
+                              mean_diffusivity, radial_diffusivity,
+                              TensorModel, trace, linearity, planarity,
+                              sphericity)
 
 from dipy.io.bvectxt import read_bvec_file
 from dipy.data import get_data, dsi_voxels, get_sphere
 
 from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.reconst.odf import gfa
 import dipy.core.gradients as grad
 import dipy.core.sphere as dps
 
 from dipy.sims.voxel import single_tensor
+
 
 def test_roll_evals():
     """
@@ -74,9 +76,8 @@ def test_tensor_model():
             relative_data = (data[0, 0, 0]/np.mean(data[0, 0, 0,
                                                         gtab.b0s_mask]))
 
-
             dtifit_to_relative = dm_to_relative.fit(relative_data)
-            npt.assert_almost_equal(dtifit.fa[0,0,0], dtifit_to_relative.fa,
+            npt.assert_almost_equal(dtifit.fa[0, 0, 0], dtifit_to_relative.fa,
                                     decimal=3)
 
     # And smoke-test that all these operations return sensibly-shaped arrays:
@@ -91,7 +92,7 @@ def test_tensor_model():
     assert_equal(dtifit.sphericity.shape, data.shape[:3])
 
     # Test for the shape of the mask
-    assert_raises(ValueError, dm.fit, np.ones((10, 10, 3)), np.ones((3,3)))
+    assert_raises(ValueError, dm.fit, np.ones((10, 10, 3)), np.ones((3, 3)))
 
     # Make some synthetic data
     b0 = 1000.
@@ -105,7 +106,8 @@ def test_tensor_model():
     md = evals.mean()
     tensor = from_lower_triangular(D)
     A_squiggle = tensor - (1 / 3.0) * np.trace(tensor) * np.eye(3)
-    mode = 3 * np.sqrt(6) * np.linalg.det(A_squiggle / np.linalg.norm(A_squiggle))
+    mode = (3 * np.sqrt(6) * np.linalg.det(A_squiggle /
+            np.linalg.norm(A_squiggle)))
     evals_eigh, evecs_eigh = np.linalg.eigh(tensor)
     # Sort according to eigen-value from large to small:
     evecs = evecs_eigh[:, np.argsort(evals_eigh)[::-1]]
@@ -132,17 +134,22 @@ def test_tensor_model():
         assert_array_almost_equal(tensor_fit.evals[0], evals)
         # Test that the eigenvectors are correct, one-by-one:
         for i in range(3):
-            # Eigenvectors have intrinsic sign ambiguity (see http://prod.sandia.gov/techlib/access-control.cgi/2007/076422.pdf)
+            # Eigenvectors have intrinsic sign ambiguity
+            # (see
+            # http://prod.sandia.gov/techlib/access-control.cgi/2007/076422.pdf)
             # so we need to allow for sign flips. One of the following should
             # always be true:
             assert_(
-            np.all(np.abs(tensor_fit.evecs[0][:, i] - evecs[:, i]) < 10e-6) or
-            np.all(np.abs(-tensor_fit.evecs[0][:, i] - evecs[:, i]) < 10e-6 ))
+                    np.all(np.abs(tensor_fit.evecs[0][:, i] -
+                                  evecs[:, i]) < 10e-6) or
+                    np.all(np.abs(-tensor_fit.evecs[0][:, i] -
+                                  evecs[:, i]) < 10e-6))
             # We set a fixed tolerance of 10e-6, similar to array_almost_equal
 
+        err_msg = "Calculation of tensor from Y does not compare to "
+        err_msg += "analytical solution"
         assert_array_almost_equal(tensor_fit.quadratic_form[0], tensor,
-                                  err_msg=\
-        "Calculation of tensor from Y does not compare to analytical solution")
+                                  err_msg=err_msg)
 
         assert_almost_equal(tensor_fit.md[0], md)
         assert_array_almost_equal(tensor_fit.mode, mode, decimal=5)
@@ -209,6 +216,7 @@ def test_fa_of_zero():
     fa = fractional_anisotropy(evals)
     assert_array_equal(fa, 0)
 
+
 def test_ga_of_zero():
     evals = np.zeros((4, 3))
     ga = geodesic_anisotropy(evals)
@@ -222,9 +230,9 @@ def test_diffusivities():
     bvals[0] = 0
     gtab = grad.gradient_table(bvals, bvecs)
     mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
-    mevecs = [ np.array( [ [1, 0, 0], [0, 1, 0], [0, 0, 1] ] ),
-               np.array( [ [0, 0, 1], [0, 1, 0], [1, 0, 0] ] ) ]
-    S = single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None )
+    mevecs = [np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+              np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])]
+    S = single_tensor(gtab, 100, mevals[0], mevecs[0], snr=None)
 
     dm = dti.TensorModel(gtab, 'LS')
     dmfit = dm.fit(S)
@@ -255,7 +263,7 @@ def test_color_fa():
 
     fa = np.ones((3, 3, 3))
     # evecs should be of shape (fa, 3, 3)
-    evecs = np.zeros(fa.shape + (3,2))
+    evecs = np.zeros(fa.shape + (3, 2))
     npt.assert_raises(ValueError, color_fa, fa, evecs)
 
     evecs = np.zeros(fa.shape + (3, 3))
@@ -305,39 +313,39 @@ def test_wls_and_ls_fit():
 
     """
 
-    ### Defining Test Voxel (avoid nibabel dependency) ###
+    # Defining Test Voxel (avoid nibabel dependency) ###
 
-    #Recall: D = [Dxx,Dyy,Dzz,Dxy,Dxz,Dyz,log(S_0)] and D ~ 10^-4 mm^2 /s
+    # Recall: D = [Dxx,Dyy,Dzz,Dxy,Dxz,Dyz,log(S_0)] and D ~ 10^-4 mm^2 /s
     b0 = 1000.
     bvec, bval = read_bvec_file(get_data('55dir_grad.bvec'))
     B = bval[1]
-    #Scale the eigenvalues and tensor by the B value so the units match
+    # Scale the eigenvalues and tensor by the B value so the units match
     D = np.array([1., 1., 1., 0., 0., 1., -np.log(b0) * B]) / B
     evals = np.array([2., 1., 0.]) / B
     md = evals.mean()
     tensor = from_lower_triangular(D)
-    #Design Matrix
+    # Design Matrix
     gtab = grad.gradient_table(bval, bvec)
     X = dti.design_matrix(gtab)
-    #Signals
+    # Signals
     Y = np.exp(np.dot(X, D))
     assert_almost_equal(Y[0], b0)
     Y.shape = (-1,) + Y.shape
 
-    ### Testing WLS Fit on Single Voxel ###
+    # Testing WLS Fit on Single Voxel
     # If you do something wonky (passing min_signal<0), you should get an
     # error:
     npt.assert_raises(ValueError, TensorModel, gtab, fit_method='WLS',
                       min_signal=-1)
 
-    #Estimate tensor from test signals
+    # Estimate tensor from test signals
     model = TensorModel(gtab, fit_method='WLS')
     tensor_est = model.fit(Y)
     assert_equal(tensor_est.shape, Y.shape[:-1])
     assert_array_almost_equal(tensor_est.evals[0], evals)
     assert_array_almost_equal(tensor_est.quadratic_form[0], tensor,
                               err_msg="Calculation of tensor from Y does not "
-                                       "compare to analytical solution")
+                                      "compare to analytical solution")
     assert_almost_equal(tensor_est.md[0], md)
 
     # Test that we can fit a single voxel's worth of data (a 1d array)
@@ -395,8 +403,8 @@ def test_fit_method_error():
     bvec, bval = read_bvec_file(get_data('55dir_grad.bvec'))
     gtab = grad.gradient_table_from_bvals_bvecs(bval, bvec.T)
 
-    # This should work
-    tensor_model = TensorModel(gtab, fit_method='WLS')
+    # This should work (smoke-testing!):
+    TensorModel(gtab, fit_method='WLS')
 
     # This should raise an error because there is no such fit_method
     assert_raises(ValueError, TensorModel, gtab, min_signal=1e-9,
@@ -479,15 +487,14 @@ def test_nnls_jacobian_fucn():
     gtab = grad.gradient_table(bval, bvecs)
     B = bval[1]
 
-    #Scale the eigenvalues and tensor by the B value so the units match
+    # Scale the eigenvalues and tensor by the B value so the units match
     D = np.array([1., 1., 1., 0., 0., 1., -np.log(b0) * B]) / B
-    evals = np.array([2., 1., 0.]) / B
 
-    #Design Matrix
+    # Design Matrix
     X = dti.design_matrix(gtab)
 
-    #Signals
-    Y = np.exp(np.dot(X,D))
+    # Signals
+    Y = np.exp(np.dot(X, D))
 
     # Test Jacobian at D
     args = [X, Y]
@@ -506,139 +513,135 @@ def test_nnls_jacobian_fucn():
         approx = opt.approx_fprime(D, dti._nlls_err_func, 1e-8, *args)
         assert_true(np.allclose(approx, analytical[i]))
 
+
 def test_nlls_fit_tensor():
-     """
-     Test the implementation of NLLS and RESTORE
-     """
+    """
+    Test the implementation of NLLS and RESTORE
+    """
 
-     b0 = 1000.
-     bvecs, bval = read_bvec_file(get_data('55dir_grad.bvec'))
-     gtab = grad.gradient_table(bval, bvecs)
-     B = bval[1]
+    b0 = 1000.
+    bvecs, bval = read_bvec_file(get_data('55dir_grad.bvec'))
+    gtab = grad.gradient_table(bval, bvecs)
+    B = bval[1]
 
-     #Scale the eigenvalues and tensor by the B value so the units match
-     D = np.array([1., 1., 1., 0., 0., 1., -np.log(b0) * B]) / B
-     evals = np.array([2., 1., 0.]) / B
-     md = evals.mean()
-     tensor = from_lower_triangular(D)
+    # Scale the eigenvalues and tensor by the B value so the units match
+    D = np.array([1., 1., 1., 0., 0., 1., -np.log(b0) * B]) / B
+    evals = np.array([2., 1., 0.]) / B
+    md = evals.mean()
+    tensor = from_lower_triangular(D)
 
-     #Design Matrix
-     X = dti.design_matrix(gtab)
+    # Design Matrix
+    X = dti.design_matrix(gtab)
 
-     #Signals
-     Y = np.exp(np.dot(X,D))
-     Y.shape = (-1,) + Y.shape
+    # Signals
+    Y = np.exp(np.dot(X, D))
+    Y.shape = (-1,) + Y.shape
 
-     #Estimate tensor from test signals and compare against expected result
-     #using non-linear least squares:
-     tensor_model = dti.TensorModel(gtab, fit_method='NLLS')
-     tensor_est = tensor_model.fit(Y)
-     assert_equal(tensor_est.shape, Y.shape[:-1])
-     assert_array_almost_equal(tensor_est.evals[0], evals)
-     assert_array_almost_equal(tensor_est.quadratic_form[0], tensor)
-     assert_almost_equal(tensor_est.md[0], md)
+    # Estimate tensor from test signals and compare against expected result
+    # using non-linear least squares:
+    tensor_model = dti.TensorModel(gtab, fit_method='NLLS')
+    tensor_est = tensor_model.fit(Y)
+    assert_equal(tensor_est.shape, Y.shape[:-1])
+    assert_array_almost_equal(tensor_est.evals[0], evals)
+    assert_array_almost_equal(tensor_est.quadratic_form[0], tensor)
+    assert_almost_equal(tensor_est.md[0], md)
 
+    # You can also do this without the Jacobian (though it's slower):
+    tensor_model = dti.TensorModel(gtab, fit_method='NLLS', jac=False)
+    tensor_est = tensor_model.fit(Y)
+    assert_equal(tensor_est.shape, Y.shape[:-1])
+    assert_array_almost_equal(tensor_est.evals[0], evals)
+    assert_array_almost_equal(tensor_est.quadratic_form[0], tensor)
+    assert_almost_equal(tensor_est.md[0], md)
 
-     # You can also do this without the Jacobian (though it's slower):
-     tensor_model = dti.TensorModel(gtab, fit_method='NLLS', jac=False)
-     tensor_est = tensor_model.fit(Y)
-     assert_equal(tensor_est.shape, Y.shape[:-1])
-     assert_array_almost_equal(tensor_est.evals[0], evals)
-     assert_array_almost_equal(tensor_est.quadratic_form[0], tensor)
-     assert_almost_equal(tensor_est.md[0], md)
+    # Using the gmm weighting scheme:
+    tensor_model = dti.TensorModel(gtab, fit_method='NLLS', weighting='gmm')
+    tensor_est = tensor_model.fit(Y)
+    assert_equal(tensor_est.shape, Y.shape[:-1])
+    assert_array_almost_equal(tensor_est.evals[0], evals)
+    assert_array_almost_equal(tensor_est.quadratic_form[0], tensor)
+    assert_almost_equal(tensor_est.md[0], md)
 
+    # If you use sigma weighting, you'd better provide a sigma:
+    tensor_model = dti.TensorModel(gtab, fit_method='NLLS', weighting='sigma')
+    npt.assert_raises(ValueError, tensor_model.fit, Y)
 
-     # Using the gmm weighting scheme:
-     tensor_model = dti.TensorModel(gtab, fit_method='NLLS', weighting='gmm')
-     tensor_est = tensor_model.fit(Y)
-     assert_equal(tensor_est.shape, Y.shape[:-1])
-     assert_array_almost_equal(tensor_est.evals[0], evals)
-     assert_array_almost_equal(tensor_est.quadratic_form[0], tensor)
-     assert_almost_equal(tensor_est.md[0], md)
+    # Use NLLS with some actual 4D data:
+    data, bvals, bvecs = get_data('small_25')
+    gtab = grad.gradient_table(bvals, bvecs)
+    tm1 = dti.TensorModel(gtab, fit_method='NLLS')
+    dd = nib.load(data).get_data()
+    tf1 = tm1.fit(dd)
+    tm2 = dti.TensorModel(gtab)
+    tf2 = tm2.fit(dd)
 
-     # If you use sigma weighting, you'd better provide a sigma:
-     tensor_model = dti.TensorModel(gtab, fit_method='NLLS', weighting='sigma')
-     npt.assert_raises(ValueError, tensor_model.fit, Y)
+    assert_array_almost_equal(tf1.fa, tf2.fa, decimal=1)
 
-     # Use NLLS with some actual 4D data:
-     data, bvals, bvecs = get_data('small_25')
-     gtab = grad.gradient_table(bvals, bvecs)
-     tm1 = dti.TensorModel(gtab, fit_method='NLLS')
-     dd = nib.load(data).get_data()
-     tf1 = tm1.fit(dd)
-     tm2 = dti.TensorModel(gtab)
-     tf2 = tm2.fit(dd)
-
-     assert_array_almost_equal(tf1.fa, tf2.fa, decimal=1)
 
 def test_restore():
-     """
-     Test the implementation of the RESTORE algorithm
-     """
-     b0 = 1000.
-     bvecs, bval = read_bvec_file(get_data('55dir_grad.bvec'))
-     gtab = grad.gradient_table(bval, bvecs)
-     B = bval[1]
+    """
+    Test the implementation of the RESTORE algorithm
+    """
+    b0 = 1000.
+    bvecs, bval = read_bvec_file(get_data('55dir_grad.bvec'))
+    gtab = grad.gradient_table(bval, bvecs)
+    B = bval[1]
 
-     #Scale the eigenvalues and tensor by the B value so the units match
-     D = np.array([1., 1., 1., 0., 0., 1., -np.log(b0) * B]) / B
-     evals = np.array([2., 1., 0.]) / B
-     md = evals.mean()
-     tensor = from_lower_triangular(D)
+    # Scale the eigenvalues and tensor by the B value so the units match
+    D = np.array([1., 1., 1., 0., 0., 1., -np.log(b0) * B]) / B
+    evals = np.array([2., 1., 0.]) / B
+    tensor = from_lower_triangular(D)
 
-     #Design Matrix
-     X = dti.design_matrix(gtab)
+    # Design Matrix
+    X = dti.design_matrix(gtab)
 
-     #Signals
-     Y = np.exp(np.dot(X,D))
-     Y.shape = (-1,) + Y.shape
-     for drop_this in range(1, Y.shape[-1]):
-         for jac in [True, False]:
-             # RESTORE estimates should be robust to dropping
-             this_y = Y.copy()
-             this_y[:, drop_this] = 1.0
-             for sigma in [67.0, np.ones(this_y.shape[-1]) *67.0]:
-                 tensor_model = dti.TensorModel(gtab, fit_method='restore',
-                                            jac=jac,
-                                            sigma=67.0)
+    # Signals
+    Y = np.exp(np.dot(X, D))
+    Y.shape = (-1,) + Y.shape
+    for drop_this in range(1, Y.shape[-1]):
+        for jac in [True, False]:
+            # RESTORE estimates should be robust to dropping
+            this_y = Y.copy()
+            this_y[:, drop_this] = 1.0
+            for sigma in [67.0, np.ones(this_y.shape[-1]) * 67.0]:
+                tensor_model = dti.TensorModel(gtab, fit_method='restore',
+                                               jac=jac,
+                                               sigma=67.0)
 
-                 tensor_est = tensor_model.fit(this_y)
-                 assert_array_almost_equal(tensor_est.evals[0], evals, decimal=3)
-                 assert_array_almost_equal(tensor_est.quadratic_form[0], tensor,
-                                       decimal=3)
+                tensor_est = tensor_model.fit(this_y)
+                assert_array_almost_equal(tensor_est.evals[0], evals,
+                                          decimal=3)
+                assert_array_almost_equal(tensor_est.quadratic_form[0], tensor,
+                                          decimal=3)
 
-
-
-     # If sigma is very small, it still needs to work:
-     tensor_model = dti.TensorModel(gtab, fit_method='restore', sigma=0.0001)
-     tensor_model.fit(Y.copy())
+    # If sigma is very small, it still needs to work:
+    tensor_model = dti.TensorModel(gtab, fit_method='restore', sigma=0.0001)
+    tensor_model.fit(Y.copy())
 
 
 def test_adc():
     """
-    Test the implementation of the calculation of apparent diffusion coefficient
+    Test the implementation of the calculation of apparent diffusion
+    coefficient
     """
     data, gtab = dsi_voxels()
     dm = dti.TensorModel(gtab, 'LS')
     mask = np.zeros(data.shape[:-1], dtype=bool)
     mask[0, 0, 0] = True
     dtifit = dm.fit(data)
-    sphere = create_unit_sphere(4)
-
     # The ADC in the principal diffusion direction should be equal to the AD in
     # each voxel:
 
-    pdd0 = dtifit.evecs[0,0,0,0]
+    pdd0 = dtifit.evecs[0, 0, 0, 0]
     sphere_pdd0 = dps.Sphere(x=pdd0[0], y=pdd0[1], z=pdd0[2])
-    assert_array_almost_equal(dtifit.adc(sphere_pdd0)[0,0,0],
-                            dtifit.ad[0,0,0], decimal=5)
-
+    assert_array_almost_equal(dtifit.adc(sphere_pdd0)[0, 0, 0],
+                              dtifit.ad[0, 0, 0], decimal=5)
 
     # Test that it works for cases in which the data is 1D
-    dtifit = dm.fit(data[0,0,0])
+    dtifit = dm.fit(data[0, 0, 0])
     sphere_pdd0 = dps.Sphere(x=pdd0[0], y=pdd0[1], z=pdd0[2])
     assert_array_almost_equal(dtifit.adc(sphere_pdd0),
-                        dtifit.ad, decimal=5)
+                              dtifit.ad, decimal=5)
 
 
 def test_predict():
@@ -651,9 +654,9 @@ def test_predict():
     bvals[0] = 0
     gtab = grad.gradient_table(bvals, bvecs)
     mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
-    mevecs = [ np.array( [ [1, 0, 0], [0, 1, 0], [0, 0, 1] ] ),
-               np.array( [ [0, 0, 1], [0, 1, 0], [1, 0, 0] ] ) ]
-    S = single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None )
+    mevecs = [np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+              np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])]
+    S = single_tensor(gtab, 100, mevals[0], mevecs[0], snr=None)
 
     dm = dti.TensorModel(gtab, 'LS')
     dmfit = dm.fit(S)
@@ -672,6 +675,7 @@ def test_predict():
     assert_equal(p.shape, data.shape)
 
 
+
 def test_eig_from_lo_tri():
     psphere = get_sphere('symmetric362')
     bvecs = np.concatenate(([[0, 0, 0]], psphere.vertices))
@@ -679,10 +683,10 @@ def test_eig_from_lo_tri():
     bvals[0] = 0
     gtab = grad.gradient_table(bvals, bvecs)
     mevals = np.array(([0.0015, 0.0003, 0.0001], [0.0015, 0.0003, 0.0003]))
-    mevecs = [ np.array( [ [1, 0, 0], [0, 1, 0], [0, 0, 1] ] ),
-               np.array( [ [0, 0, 1], [0, 1, 0], [1, 0, 0] ] ) ]
-    S = np.array([[single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None ),
-                 single_tensor( gtab, 100, mevals[0], mevecs[0], snr=None )]])
+    mevecs = [np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+              np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])]
+    S = np.array([[single_tensor(gtab, 100, mevals[0], mevecs[0], snr=None),
+                   single_tensor(gtab, 100, mevals[0], mevecs[0], snr=None)]])
 
     dm = dti.TensorModel(gtab, 'LS')
     dmfit = dm.fit(S)

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -150,7 +150,7 @@ def test_multi_voxel_fit():
     expected = np.ones((2, 3, 4, 12))
     npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
     npt.assert_equal(fit.directions.shape, (2, 3, 4))
-    S0 = np.random.randn()
+    S0 = 100.
     npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
     # Test with a mask

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -153,10 +153,12 @@ def test_multi_voxel_fit():
     S0 = np.random.randn()
     npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
 
-
     # Test with a mask
-    mask = np.eye(3).astype('bool')
-    data = np.zeros((3, 3, 64))
+    mask = np.zeros((3, 3, 3)).astype('bool')
+    mask[0, 0] = 1
+    mask[1, 1] = 1
+    mask[2, 2] = 1
+    data = np.zeros((3, 3, 3, 64))
     fit = model.fit(data, mask)
     npt.assert_array_equal(fit.model_attr, np.eye(3) * 2)
     odf = fit.odf(unit_icosahedron)

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -111,12 +111,16 @@ def test_multi_voxel_fit():
 
         @multi_voxel_fit
         def fit(self, data, mask=None):
-            return SillyFit(model)
+            return SillyFit(model, data)
+
+        def predict(self, S0):
+            return np.ones(10) * S0
 
     class SillyFit(object):
 
-        def __init__(self, model):
+        def __init__(self, model, data):
             self.model = model
+            self.data = data
 
         model_attr = 2.
 
@@ -127,6 +131,9 @@ def test_multi_voxel_fit():
         def directions(self):
             n = np.random.randint(0, 10)
             return np.zeros((n, 3))
+
+        def predict(self, S0):
+            return np.ones(self.data.shape) * S0
 
     # Test the single voxel case
     model = SillyModel()
@@ -143,6 +150,9 @@ def test_multi_voxel_fit():
     expected = np.ones((2, 3, 4, 12))
     npt.assert_array_equal(fit.odf(unit_icosahedron), expected)
     npt.assert_equal(fit.directions.shape, (2, 3, 4))
+    S0 = np.random.randn()
+    npt.assert_equal(fit.predict(S0=S0), np.ones(many_voxels.shape) * S0)
+
 
     # Test with a mask
     mask = np.eye(3).astype('bool')
@@ -153,6 +163,9 @@ def test_multi_voxel_fit():
     npt.assert_equal(odf.shape, (3, 3, 12))
     npt.assert_array_equal(odf[~mask], 0)
     npt.assert_array_equal(odf[mask], 1)
+    predicted = np.zeros(data.shape)
+    predicted[mask] = S0
+    npt.assert_equal(fit.predict(S0=S0), predicted)
 
     # Test fit.shape
     npt.assert_equal(fit.shape, (3, 3))

--- a/dipy/reconst/tests/test_multi_voxel.py
+++ b/dipy/reconst/tests/test_multi_voxel.py
@@ -160,9 +160,13 @@ def test_multi_voxel_fit():
     mask[2, 2] = 1
     data = np.zeros((3, 3, 3, 64))
     fit = model.fit(data, mask)
-    npt.assert_array_equal(fit.model_attr, np.eye(3) * 2)
+    expected = np.zeros((3,3,3))
+    expected[0, 0] = 2
+    expected[1, 1] = 2
+    expected[2, 2] = 2
+    npt.assert_array_equal(fit.model_attr, expected)
     odf = fit.odf(unit_icosahedron)
-    npt.assert_equal(odf.shape, (3, 3, 12))
+    npt.assert_equal(odf.shape, (3, 3, 3, 12))
     npt.assert_array_equal(odf[~mask], 0)
     npt.assert_array_equal(odf[mask], 1)
     predicted = np.zeros(data.shape)
@@ -170,8 +174,8 @@ def test_multi_voxel_fit():
     npt.assert_equal(fit.predict(S0=S0), predicted)
 
     # Test fit.shape
-    npt.assert_equal(fit.shape, (3, 3))
+    npt.assert_equal(fit.shape, (3, 3, 3))
 
     # Test indexing into a fit
-    npt.assert_equal(type(fit[0, 0]), SillyFit)
-    npt.assert_equal(fit[:2, :2].shape, (2, 2))
+    npt.assert_equal(type(fit[0, 0, 0]), SillyFit)
+    npt.assert_equal(fit[:2, :2, :2].shape, (2, 2, 2))


### PR DESCRIPTION
This is an improvement on the previous API, which did not allow using masks for multi-voxel predictions, making predictions for cross-validation un-necessarily slow.