### PR TITLE
WIP: Assign streamlines to an existing cluster map via QuickBundles

### DIFF
--- a/dipy/segment/benchmarks/bench_quickbundles.py
+++ b/dipy/segment/benchmarks/bench_quickbundles.py
@@ -92,3 +92,40 @@ def bench_quickbundles():
     assert_equal(len(clusters), expected_nb_clusters)
     assert_array_equal(sizes3, sizes1)
     assert_arrays_equal(indices3, indices1)
+
+
+def bench_quickbundles_assignation():
+    dtype = "float32"
+    repeat = 10
+    nb_points = 18
+
+    streams, hdr = nib.trackvis.read(get_data('fornix'))
+    fornix = [s[0].astype(dtype) for s in streams]
+    fornix = streamline_utils.set_number_of_points(fornix, nb_points)
+
+    #Create eight copies of the fornix to be clustered (one in each octant).
+    streamlines = []
+    streamlines += [s + np.array([100, 100, 100], dtype) for s in fornix]
+    streamlines += [s + np.array([100, -100, 100], dtype) for s in fornix]
+    streamlines += [s + np.array([100, 100, -100], dtype) for s in fornix]
+    streamlines += [s + np.array([100, -100, -100], dtype) for s in fornix]
+    streamlines += [s + np.array([-100, 100, 100], dtype) for s in fornix]
+    streamlines += [s + np.array([-100, -100, 100], dtype) for s in fornix]
+    streamlines += [s + np.array([-100, 100, -100], dtype) for s in fornix]
+    streamlines += [s + np.array([-100, -100, -100], dtype) for s in fornix]
+    streamlines *= 10
+
+    # The expected number of clusters of the fornix using threshold=10 is 4.
+    threshold = 10.
+    print("Timing assignation with QuickBundles ({} streamlines)".format(len(streamlines)))
+
+    qb = QB_New(threshold)
+    qb_time = measure("clusters = qb.cluster(streamlines)", repeat)
+    print("QuickBundles time: {0:.4}sec".format(qb_time))
+
+    clusters = qb.cluster(streamlines)
+    qb_assign_time = measure("new_clusters = qb.assign(clusters, streamlines)", repeat)
+    print("QuickBundles assignation time: {0:.4}sec".format(qb_assign_time))
+
+    new_clusters = qb.assign(clusters, streamlines)
+    assert_equal(len(new_clusters), len(clusters))

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -495,5 +495,11 @@ class QuickBundles(Clustering):
                                    max_nb_clusters=self.max_nb_clusters,
                                    ordering=ordering)
 
-        cluster_map.refdata = streamlines
         return cluster_map
+
+    def assign(self, clusters, streamlines, ordering=None):
+        from dipy.segment.clustering_algorithms import quickbundles_assignment
+        new_clusters = quickbundles_assignment(streamlines, self.metric,
+                                               threshold=self.threshold,
+                                               ordering=ordering)
+        return new_clusters

--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -499,7 +499,7 @@ class QuickBundles(Clustering):
 
     def assign(self, clusters, streamlines, ordering=None):
         from dipy.segment.clustering_algorithms import quickbundles_assignment
-        new_clusters = quickbundles_assignment(streamlines, self.metric,
+        new_clusters = quickbundles_assignment(clusters, streamlines, self.metric,
                                                threshold=self.threshold,
                                                ordering=ordering)
         return new_clusters

--- a/dipy/segment/clustering_algorithms.pyx
+++ b/dipy/segment/clustering_algorithms.pyx
@@ -6,7 +6,7 @@ import numpy as np
 
 from cythonutils cimport Data2D, shape2tuple
 from metricspeed cimport Metric
-from clusteringspeed cimport ClustersCentroid, Centroid, QuickBundles
+from clusteringspeed cimport Clusters, ClustersCentroid, Centroid, QuickBundles
 from dipy.segment.clustering import ClusterMapCentroid, ClusterCentroid
 
 cdef extern from "stdlib.h" nogil:
@@ -112,4 +112,81 @@ def quickbundles(streamlines, Metric metric, double threshold, long max_nb_clust
         # of after all streamlines have been assigned like k-means algorithm.
         qb.update_step(cluster_id)
 
-    return clusters_centroid2clustermap_centroid(qb.clusters)
+    clusters = clusters_centroid2clustermap_centroid(qb.clusters)
+    clusters.refdata = streamlines
+    return clusters
+
+
+def quickbundles_assignment(clusters, streamlines, Metric metric, double threshold, ordering=None):
+    """ Assigns streamlines to nearest clusters.
+
+    Parameters
+    ----------
+    clusters : `ClusterMapCentroid` object
+        Clusters for which the streamlines will be assigned to.
+    streamlines : list of 2D arrays
+        List of streamlines to cluster.
+    metric : `Metric` object
+        Tells how to compute the distance between two streamlines.
+    threshold : double
+        The maximum distance from a cluster for a streamline to be still
+        considered as part of it.
+    ordering : iterable of indices, optional
+        Iterate through `data` using the given ordering.
+
+    Returns
+    -------
+    `ClusterMapCentroid` object
+        Update version of the `clusters`.
+    """
+    # Threshold of np.inf is not supported, set it to 'biggest_double'
+    threshold = min(threshold, BIGGEST_DOUBLE)
+    # Threshold of -np.inf is not supported, set it to 0
+    threshold = max(threshold, 0)
+
+    if ordering is None:
+        ordering = xrange(len(streamlines))
+
+    # Check if `ordering` or `streamlines` are empty.
+    first_idx, ordering = peek(ordering)
+    if first_idx is None or len(streamlines) == 0:
+        return clusters
+
+    max_nb_clusters = len(clusters)  # We don't want to create new clusters.
+    features_shape = shape2tuple(metric.feature.c_infer_shape(streamlines[first_idx].astype(DTYPE)))
+    cdef QuickBundles qb = QuickBundles(features_shape, metric, threshold, max_nb_clusters)
+    cdef int idx, i, n, d
+
+    # Add already existing clusters from `clusters`.
+    for i, cluster in enumerate(clusters):
+        qb.clusters.c_create_cluster()
+        for n in range(features_shape[0]):
+            for d in range(features_shape[1]):
+                qb.clusters.centroids[i].features[n][d] = cluster.centroid[n, d]
+
+        # Add previous indices
+        for idx in cluster.indices:
+            Clusters.c_assign(qb.clusters, i, idx, None)
+
+    for idx in ordering:
+        streamline = streamlines[idx]
+        if not streamline.flags.writeable or streamline.dtype != DTYPE:
+            streamline = streamline.astype(DTYPE)
+
+        cluster_id = qb.assignment_step(streamline, idx)
+        # The update step is performed right after the assignement step instead
+        # of after all streamlines have been assigned like k-means algorithm.
+        qb.update_step(cluster_id)
+
+    new_clusters = clusters_centroid2clustermap_centroid(qb.clusters)
+    new_clusters.refdata = streamlines
+
+    # If not the same refdata, append the new one to the old one.
+    if clusters.refdata is not new_clusters.refdata:
+        offset = len(clusters.refdata)
+        new_clusters.refdata += clusters.refdata
+        for new_cluster, old_cluster in zip(new_clusters, clusters):
+            for i in range(len(old_cluster), len(new_cluster)):
+                new_cluster.indices[i] += offset
+
+    return new_clusters

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -131,9 +131,7 @@ def test_quickbundles_assignment_2D():
 
     far_away_data = data * 10
 
-    clusters_truth = [[0, 15], [1, 2, 16, 17], [3, 4, 5, 18, 19, 20],
-                      [6, 7, 8, 9, 21, 22, 23, 24],
-                      [10, 11, 12, 13, 14, 25, 26, 27, 28, 29]]
+    clusters_truth = [[0], [1, 2], [3, 4, 5], [6, 7, 8, 9], [10, 11, 12, 13, 14]]
 
     # # Uncomment the following to visualize this test
     # import pylab as plt
@@ -174,8 +172,6 @@ def test_quickbundles_assignment_2D():
     # Test assigning the data used for the initial clustering but with a different ordering.
     ordering = np.arange(len(data))
     rng.shuffle(ordering)
-    clusters_truth = [[0, 0], [1, 2, 1, 2], [3, 4, 5, 3, 4, 5], [6, 7, 8, 9, 6, 7, 8, 9],
-                      [10, 11, 12, 13, 14, 10, 11, 12, 13, 14]]
     new_clusters = quickbundles_assignment(clusters, data, metric, threshold, ordering)
 
     # No cluster should have been created (assignments only).
@@ -225,7 +221,7 @@ def test_quickbundles_assignment_streamlines():
     assert_equal(new_clusters.refdata, rdata)
 
     # Because we assign the same streamlines that the one used for the initial clusters.
-    clusters_truth = [[0, 1, 0, 1], [2, 4, 2, 4], [3, 3]]
+    clusters_truth = [[0, 1], [2, 4], [3]]
 
     # Set `refdata` to return indices instead of actual data points.
     new_clusters.refdata = None

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -213,6 +213,21 @@ def test_quickbundles_streamlines():
         assert_equal(clusters.centroids[0].dtype, np.float32)
 
 
+def test_quickbundles_assignment_streamlines():
+    rdata = streamline_utils.set_number_of_points(data, 10)
+    qb = QuickBundles(threshold=2*threshold)
+
+    clusters = qb.cluster(rdata)
+    # By default `refdata` refers to data being clustered.
+    assert_equal(clusters.refdata, rdata)
+    # Set `refdata` to return indices instead of actual data points.
+    clusters.refdata = None
+    assert_array_equal(list(itertools.chain(*clusters)), list(itertools.chain(*clusters_truth)))
+
+    clusters = qb.cluster(rdata)
+    new_clusters = qb.assign(clusters, rdata)
+
+
 def test_quickbundles_with_not_order_invariant_metric():
     metric = dipymetric.AveragePointwiseEuclideanMetric()
     qb = QuickBundles(threshold=np.inf, metric=metric)

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -218,14 +218,18 @@ def test_quickbundles_assignment_streamlines():
     qb = QuickBundles(threshold=2*threshold)
 
     clusters = qb.cluster(rdata)
-    # By default `refdata` refers to data being clustered.
-    assert_equal(clusters.refdata, rdata)
-    # Set `refdata` to return indices instead of actual data points.
-    clusters.refdata = None
-    assert_array_equal(list(itertools.chain(*clusters)), list(itertools.chain(*clusters_truth)))
-
-    clusters = qb.cluster(rdata)
     new_clusters = qb.assign(clusters, rdata)
+
+    # `refdata` should be the same as the `clusters` one.
+    assert_equal(new_clusters.refdata, clusters.refdata)
+    assert_equal(new_clusters.refdata, rdata)
+
+    # Because we assign the same streamlines that the one used for the initial clusters.
+    clusters_truth = [[0, 1, 0, 1], [2, 4, 2, 4], [3, 3]]
+
+    # Set `refdata` to return indices instead of actual data points.
+    new_clusters.refdata = None
+    assert_array_equal(list(itertools.chain(*new_clusters)), list(itertools.chain(*clusters_truth)))
 
 
 def test_quickbundles_with_not_order_invariant_metric():

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -102,7 +102,7 @@ def test_quickbundles_2D():
     # Cluster each cluster again using a small threshold
     for cluster in clusters:
         subclusters = quickbundles(data, metric, threshold=0, ordering=cluster.indices)
-        assert_equal(len(subclusters), len(cluster))
+        subclusters.refdata = None  # Use indices instead
         assert_equal(sorted(itertools.chain(*subclusters)), sorted(cluster.indices))
 
     # A very large threshold should produce only 1 cluster


### PR DESCRIPTION
When there are just too many streamlines, you might want to only cluster a subset of those then assign the rest to their nearest cluster. To do so, we needed a way to assign streamlines to an existing `cluster_map` object (i.e. what QuickBundles.cluster returns).