### PR TITLE
NF - CSD response from a mask

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -846,8 +846,9 @@ def response_from_mask(gtab, data, mask):
     data : ndarray
         Diffusion data
     mask : ndarray
-        Mask the estimation of the response function. For example a mask of
-        the white matter voxels with FA values higher than 0.7 (see [1]_).
+        Mask to use for the estimation of the response function. For example a
+        mask of the white matter voxels with FA values higher than 0.7
+        (see [1]_).
 
     Returns
     -------
@@ -859,7 +860,7 @@ def response_from_mask(gtab, data, mask):
     Notes
     -----
     See csdeconv.auto_response() or csdeconv.recursive_response() if you don't
-    have a mask for the response function estimation.
+    have a computed mask for the response function estimation.
 
     References
     ----------
@@ -867,12 +868,14 @@ def response_from_mask(gtab, data, mask):
     fiber orientation density function from diffusion-weighted MRI
     data using spherical deconvolution
     """
+
     ten = TensorModel(gtab)
-    indices = mask > 0
+    indices = np.where(mask > 0)
 
     if indices[0].size == 0:
         msg = "No voxel in mask with value > 0 were found."
         warnings.warn(msg, UserWarning)
+        return (np.nan, np.nan), np.nan
 
     tenfit = ten.fit(data[indices])
     lambdas = tenfit.evals[:, :2]

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -838,15 +838,44 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
 
 
 def response_from_mask(gtab, data, mask):
+    """ Estimate the response function from a given mask.
+
+    Parameters
+    ----------
+    gtab : GradientTable
+    data : ndarray
+        Diffusion data
+    mask : ndarray
+        Mask the estimation of the response function. For example a mask of
+        the white matter voxels with FA values higher than 0.7 (see [1]_).
+
+    Returns
+    -------
+    response : tuple, (2,)
+        (`evals`, `S0`)
+    ratio : float
+        The ratio between smallest versus largest eigenvalue of the response.
+
+    Notes
+    -----
+    See csdeconv.auto_response() or csdeconv.recursive_response() if you don't
+    have a mask for the response function estimation.
+
+    References
+    ----------
+    .. [1] Tournier, J.D., et al. NeuroImage 2004. Direct estimation of the
+    fiber orientation density function from diffusion-weighted MRI
+    data using spherical deconvolution
+    """
     ten = TensorModel(gtab)
     indices = mask > 0
-    tenfit = ten.fit(data[indices])
 
     if indices[0].size == 0:
         msg = "No voxel in mask with value > 0 were found."
         warnings.warn(msg, UserWarning)
 
-    lambdas = tenfit.evals[indices][:, :2]
+    tenfit = ten.fit(data[indices])
+    lambdas = tenfit.evals[:, :2]
     S0s = data[indices][:, np.nonzero(gtab.b0s_mask)[0]]
 
     return _get_response(S0s, lambdas)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -114,9 +114,12 @@ def test_response_from_mask():
 
     gtab = gradient_table(bvals, bvecs)
     ten = TensorModel(gtab)
+    tenfit = ten.fit(data)
+    FA = fractional_anisotropy(tenfit.evals)
+    FA[np.isnan(FA)] = 0
     radius = 3
 
-    for fa_thr in np.arange(0, 0.9, 0.1):
+    for fa_thr in np.arange(0, 1, 0.1):
         response_auto, ratio_auto, nvoxels = auto_response(gtab,
                                                            data,
                                                            roi_center=None,
@@ -130,11 +133,7 @@ def test_response_from_mask():
              cj - radius: cj + radius,
              ck - radius: ck + radius] = 1
 
-        tenfit = ten.fit(data)
-        FA = fractional_anisotropy(tenfit.evals)
-        FA[np.isnan(FA)] = 0
-        mask[np.where(FA <= fa_thr)] = 0
-
+        mask[FA <= fa_thr] = 0
         response_mask, ratio_mask = response_from_mask(gtab, data, mask)
 
         assert_equal(int(np.sum(mask)), nvoxels)

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -1,4 +1,5 @@
 import warnings
+import nibabel as nib
 import numpy as np
 import numpy.testing as npt
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
@@ -15,9 +16,12 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    forward_sdeconv_mat,
                                    odf_deconv,
                                    odf_sh_to_sharp,
-                                   auto_response, recursive_response)
+                                   auto_response,
+                                   recursive_response,
+                                   response_from_mask)
 from dipy.reconst.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
+from dipy.reconst.dti import TensorModel, fractional_anisotropy
 from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
                               real_sym_sh_basis, sph_harm_ind_list)
 from dipy.reconst.shm import lazy_index
@@ -102,6 +106,42 @@ def test_recursive_response_calibration():
     assert_almost_equal(FA, FA_gt, 1)
 
 
+def test_response_from_mask():
+    fdata, fbvals, fbvecs = get_data('small_64D')
+    bvals = np.load(fbvals)
+    bvecs = np.load(fbvecs)
+    data = nib.load(fdata).get_data()
+
+    gtab = gradient_table(bvals, bvecs)
+    ten = TensorModel(gtab)
+    radius = 3
+
+    for fa_thr in np.arange(0, 0.9, 0.1):
+        response_auto, ratio_auto, nvoxels = auto_response(gtab,
+                                                           data,
+                                                           roi_center=None,
+                                                           roi_radius=radius,
+                                                           fa_thr=fa_thr,
+                                                           return_number_of_voxels=True)
+
+        ci, cj, ck = np.array(data.shape[:3]) / 2
+        mask = np.zeros(data.shape[:3])
+        mask[ci - radius: ci + radius,
+             cj - radius: cj + radius,
+             ck - radius: ck + radius] = 1
+
+        tenfit = ten.fit(data)
+        FA = fractional_anisotropy(tenfit.evals)
+        FA[np.isnan(FA)] = 0
+        mask[np.where(FA <= fa_thr)] = 0
+
+        response_mask, ratio_mask = response_from_mask(gtab, data, mask)
+
+        assert_equal(int(np.sum(mask)), nvoxels)
+        assert_array_almost_equal(response_mask[0], response_auto[0])
+        assert_almost_equal(response_mask[1], response_auto[1])
+        assert_almost_equal(ratio_mask, ratio_auto)
+
 def test_csdeconv():
     SNR = 100
     S0 = 1
@@ -156,7 +196,7 @@ def test_csdeconv():
                                       roi_radius=3, fa_thr=0.5)
     assert_array_almost_equal(aresponse[0], response[0])
     assert_almost_equal(aresponse[1], 100)
-    assert_almost_equal(aratio, response[0][1]/response[0][0])
+    assert_almost_equal(aratio, response[0][1] / response[0][0])
 
     aresponse2, aratio2 = auto_response(gtab, big_S, roi_radius=3, fa_thr=0.5)
     assert_array_almost_equal(aresponse[0], response[0])


### PR DESCRIPTION
This PR adds a function to compute the csd response from a pre-computed mask. This complements auto_response() and recursive_response() functions. 

