### PR TITLE
Add RTOP, RTAP and RTPP and the relative test

### DIFF
--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -10,6 +10,7 @@ from ..utils.optpkg import optional_package
 
 cvxopt, have_cvxopt, _ = optional_package("cvxopt")
 
+
 class MapmriModel(ReconstModel):
 
     r"""Mean Apparent Propagator MRI (MAPMRI) [1]_ of the diffusion signal.
@@ -167,7 +168,7 @@ class MapmriModel(ReconstModel):
         if self.eap_cons:
             if not have_cvxopt:
                 raise ValueError(
-                'CVXOPT package needed to enforce constraints')
+                    'CVXOPT package needed to enforce constraints')
             w_s = "The implementation of MAPMRI depends on CVXOPT "
             w_s += " (http://cvxopt.org/). This software is licensed "
             w_s += "under the GPL (see: http://cvxopt.org/copyright.html) "
@@ -268,6 +269,65 @@ class MapmriFit(ReconstFit):
         I_s = mapmri_odf_matrix(self.radial_order, self.mu, s, v)
         odf = np.dot(I_s, self._mapmri_coef)
         return odf
+
+    def rtpp(self):
+        r""" Calculates the analytical return to the plane probability (RTPP)
+        [1]_.
+
+        References
+        ----------
+        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        diffusion imaging method for mapping tissue microstructure",
+        NeuroImage, 2013.
+        """
+        Bm = self.model.Bm
+        rtpp = 0
+        const = 1 / (np.sqrt(2 * np.pi) * self.mu[0])
+        for i in range(self.ind_mat.shape[0]):
+            if Bm[i] > 0.0:
+                rtpp += (-1.0) ** (self.ind_mat[i, 0] /
+                                   2.0) * self._mapmri_coef[i] * Bm[i]
+        return const * rtpp
+
+    def rtap(self):
+        r""" Calculates the analytical return to the axis probability (RTAP)
+        [1]_.
+
+        References
+        ----------
+        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        diffusion imaging method for mapping tissue microstructure",
+        NeuroImage, 2013.
+        """
+        Bm = self.model.Bm
+        rtap = 0
+        const = 1 / (2 * np.pi * self.mu[1] * self.mu[2])
+        for i in range(self.ind_mat.shape[0]):
+            if Bm[i] > 0.0:
+                rtap += (-1.0) ** (
+                    (self.ind_mat[i, 1] + self.ind_mat[i, 2]) / 2.0) * self._mapmri_coef[i] * Bm[i]
+        return const * rtap
+
+    def rtop(self):
+        r""" Calculates the analytical return to the origin probability (RTOP)
+        [1]_.
+
+        References
+        ----------
+        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        diffusion imaging method for mapping tissue microstructure",
+        NeuroImage, 2013.
+        """
+        Bm = self.model.Bm
+        rtop = 0
+        const = 1 / \
+            np.sqrt(
+                8 * np.pi ** 3 * (self.mu[0] ** 2 * self.mu[1] ** 2 * self.mu[2] ** 2))
+        for i in range(self.ind_mat.shape[0]):
+            if Bm[i] > 0.0:
+                rtop += (-1.0) ** ((self.ind_mat[i, 0] + self.ind_mat[i, 1] + self.ind_mat[
+                    i, 2]) / 2.0) * self._mapmri_coef[i] * Bm[i]
+        return const * rtop
 
     def predict(self, gtab, S0=1.0):
         """

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -148,9 +148,6 @@ class MapmriModel(ReconstModel):
         tenfit = self.tenmodel.fit(data[self.ind])
         evals = tenfit.evals
         R = tenfit.evecs
-        ind_evals = np.argsort(evals)[::-1]
-        evals = evals[ind_evals]
-        R = R[:, ind_evals]
         evals = np.clip(evals, self.eigenvalue_threshold, evals.max())
         if self.anisotropic_scaling:
             mu = np.sqrt(evals * 2 * self.tau)

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -150,7 +150,7 @@ class MapmriModel(ReconstModel):
         R = tenfit.evecs
         ind_evals = np.argsort(evals)[::-1]
         evals = evals[ind_evals]
-        R = R[ind_evals, :]
+        R = R[:, ind_evals]
         evals = np.clip(evals, self.eigenvalue_threshold, evals.max())
         if self.anisotropic_scaling:
             mu = np.sqrt(evals * 2 * self.tau)

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -9,11 +9,14 @@ from scipy.special import gamma
 from scipy.misc import factorial
 from dipy.data import get_sphere
 
+
 def int_func(n):
-    f =np.sqrt(2)*factorial(n)/float(((gamma(1+n/2.0)) * np.sqrt(2**(n+1)*factorial(n))))
+    f = np.sqrt(2) * factorial(n) / float(((gamma(1 + n / 2.0))
+                                           * np.sqrt(2**(n + 1) * factorial(n))))
     return f
 
-def test_shore_metrics():
+
+def test_mapmri_metrics():
     gtab = get_gtab_taiwan_dsi()
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
@@ -21,12 +24,13 @@ def test_shore_metrics():
     S, sticks = MultiTensor(gtab, mevals, S0=100.0, angles=angl,
                             fractions=[50, 50], snr=None)
 
-    # since we are testing without noise we can use higher order and lower lambdas, with respect to the default.
+    # since we are testing without noise we can use higher order and lower
+    # lambdas, with respect to the default.
     radial_order = 6
     lambd = 1e-8
 
     # test mapmri_indices
-    indices =  mapmri_index_matrix(radial_order)
+    indices = mapmri_index_matrix(radial_order)
     n_c = indices.shape[0]
     F = radial_order / 2
     n_gt = np.round(1 / 6.0 * (F + 1) * (F + 2) * (4 * F + 3))
@@ -34,9 +38,9 @@ def test_shore_metrics():
 
     # test MAPMRI fitting
 
-    mapm= MapmriModel(gtab, radial_order=radial_order, lambd=lambd)
+    mapm = MapmriModel(gtab, radial_order=radial_order, lambd=lambd)
     mapfit = mapm.fit(S)
-    c_map=mapfit.mapmri_coeff
+    c_map = mapfit.mapmri_coeff
 
     R = mapfit.mapmri_R
     mu = mapfit.mapmri_mu
@@ -51,7 +55,7 @@ def test_shore_metrics():
     # test if the analytical integral of the pdf is equal to one
     integral = 0
     for i in range(indices.shape[0]):
-        n1,n2,n3 = indices[i]
+        n1, n2, n3 = indices[i]
         integral += c_map[i] * int_func(n1) * int_func(n2) * int_func(n3)
 
     assert_almost_equal(integral, 1.0, 3)
@@ -63,14 +67,37 @@ def test_shore_metrics():
     radius = 10e-3
     r_points = v * radius
     pdf_mt = multi_tensor_pdf(r_points, mevals=mevals,
-                              angles=angl, fractions= [50, 50])
-
+                              angles=angl, fractions=[50, 50])
 
     pdf_map = mapmri_EAP(r_points, radial_order, c_map, mu, R)
 
-
     nmse_pdf = np.sqrt(np.sum((pdf_mt - pdf_map) ** 2)) / (pdf_mt.sum())
     assert_almost_equal(nmse_pdf, 0.0, 2)
+
+    # test MAPMRI metrics
+    tau = 1 / (4 * np.pi ** 2)
+    angl = [(0, 0), (0, 0)]
+    S, sticks = MultiTensor(gtab, mevals, S0=100.0, angles=angl,
+                            fractions=[50, 50], snr=None)
+
+    mapm = MapmriModel(gtab, radial_order=radial_order, lambd=lambd)
+    mapfit = mapm.fit(S)
+
+    # RTOP
+    gt_rtop = 1.0 / np.sqrt((4 * np.pi * tau)**3 *
+                            mevals[0, 0] * mevals[0, 1] * mevals[0, 2])
+    rtop = mapfit.rtop()
+    assert_almost_equal(rtop, gt_rtop, 6)
+
+    # RTAP
+    gt_rtap = 1.0 / np.sqrt((4 * np.pi * tau)**2 * mevals[0, 1] * mevals[0, 2])
+    rtap = mapfit.rtap()
+    assert_almost_equal(rtap, gt_rtap, 6)
+
+    # RTPP
+    gt_rtpp = 1.0 / np.sqrt((4 * np.pi * tau) * mevals[0, 0])
+    rtpp = mapfit.rtpp()
+    assert_almost_equal(rtpp, gt_rtpp, 6)
 
 
 if __name__ == '__main__':

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -87,17 +87,17 @@ def test_mapmri_metrics():
     gt_rtop = 1.0 / np.sqrt((4 * np.pi * tau)**3 *
                             mevals[0, 0] * mevals[0, 1] * mevals[0, 2])
     rtop = mapfit.rtop()
-    assert_almost_equal(rtop, gt_rtop, 6)
+    assert_almost_equal(rtop, gt_rtop, 4)
 
     # RTAP
     gt_rtap = 1.0 / np.sqrt((4 * np.pi * tau)**2 * mevals[0, 1] * mevals[0, 2])
     rtap = mapfit.rtap()
-    assert_almost_equal(rtap, gt_rtap, 6)
+    assert_almost_equal(rtap, gt_rtap, 4)
 
     # RTPP
     gt_rtpp = 1.0 / np.sqrt((4 * np.pi * tau) * mevals[0, 0])
     rtpp = mapfit.rtpp()
-    assert_almost_equal(rtpp, gt_rtpp, 6)
+    assert_almost_equal(rtpp, gt_rtpp, 4)
 
 
 if __name__ == '__main__':

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -32,8 +32,7 @@ For this example we select only the shell with b-values equal to the one of the
 Human Connectome Project (HCP).
 """
 bvals = [1000, 2000, 3000]
-
-gtab, img = read_cenir_multib(bvals)
+img, gtab = read_cenir_multib(bvals)
 data = img.get_data()
 data_small = data[40:65, 50:51, 35:60]
 

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -12,24 +12,30 @@ First import the necessary modules:
 
 from dipy.reconst.mapmri import MapmriModel
 from dipy.viz import fvtk
-from dipy.data import fetch_sherbrooke_3shell, read_sherbrooke_3shell, get_sphere
+from dipy.data import fetch_cenir_multib, read_cenir_multib, get_sphere
 from dipy.core.gradients import gradient_table
+import matplotlib.pyplot as plt
 
 """
 Download and read the data for this tutorial.
 
-fetch_isbi2013_2shell() provides data from the ISBI HARDI contest 2013 acquired 
-for two shells at b-values 1500 and 2500.
-
-The six parameters of these two functions define the ROI where to reconstruct
-the data. They respectively correspond to (xmin,xmax,ymin,ymax,zmin,zmax)
-with x, y, z and the three axis defining the spatial positions of the voxels.
+MAPMRI requires multi-shell data, to properly fit the radial part of the basis.
+The total size of the downloaded data is 1760 MBytes, however you only need to
+fetch it once. Parameter ``with_raw`` of function ``fetch_cenir_multib`` is set
+to ``False`` to only download eddy-current/motion corrected data:.
 """
 
-fetch_sherbrooke_3shell()
-img, gtab = read_sherbrooke_3shell()
+fetch_cenir_multib(with_raw=False)
+
+"""
+For this example we select only the shell with b-values equal to the one of the
+Human Connectome Project (HCP).
+"""
+bvals = [1000, 2000, 3000]
+
+gtab, img = read_cenir_multib(bvals)
 data = img.get_data()
-data_small = data[50:80,64:65,25:50]
+data_small = data[40:65, 50:51, 35:60]
 
 print('data.shape (%d, %d, %d, %d)' % data.shape)
 
@@ -46,7 +52,8 @@ For details regarding the parameters see [Ozarslan2013]_.
 """
 
 radial_order = 4
-map_model = MapmriModel(gtab, radial_order=radial_order,lambd=2e-1, eap_cons=True)
+map_model = MapmriModel(gtab, radial_order=radial_order,
+                        lambd=2e-1, eap_cons=False)
 
 """
 Fit the MAPMRI model to the data
@@ -75,7 +82,6 @@ r = fvtk.ren()
 sfu = fvtk.sphere_funcs(odf, sphere, colormap='jet')
 sfu.RotateX(-90)
 fvtk.add(r, sfu)
-fvtk.show(r)
 fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
 
 """
@@ -83,7 +89,45 @@ fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
    :align: center
 
    **Orientation distribution functions**.
-   
+
+With MAPMRI it is also possible to extract the Return To the Origin Probability
+(RTOP), the Return To the Axis Probability (RTAP), and the Return To the Plane
+Probability (RTPP). These ensemble average propagator (EAP) features directly
+reflects microstructural properties of the underlying tissues [Ozarslan2013]_. 
+"""
+
+rtop = mapfit.rtop()
+rtap = mapfit.rtap()
+rtpp = mapfit.rtpp()
+
+"""
+Show the maps and save them in MAPMRI_maps.png.
+"""
+
+fig = plt.figure(figsize=(6, 6))
+ax1 = fig.add_subplot(2, 2, 1, title=r'$\sqrt[3]{RTOP}$')
+ax1.set_axis_off()
+ind = ax1.imshow((rtop[:, 0, :]**(1.0 / 3)).T,
+                 interpolation='nearest', origin='lower', cmap=plt.cm.gray)
+plt.colorbar(ind, shrink = 0.8)
+ax2 = fig.add_subplot(2, 2, 2, title=r'$\sqrt{RTAP}$')
+ax2.set_axis_off()
+ind = ax2.imshow((rtap[:, 0, :]**0.5).T,
+                 interpolation='nearest', origin='lower', cmap=plt.cm.gray)
+plt.colorbar(ind, shrink = 0.8)
+ax3 = fig.add_subplot(2, 2, 3, title=r'$RTPP$')
+ax3.set_axis_off()
+ind = ax3.imshow(rtpp[:, 0, :].T, interpolation='nearest',
+                 origin='lower', cmap=plt.cm.gray)
+plt.colorbar(ind, shrink = 0.8)
+plt.savefig('MAPMRI_maps.png')
+
+"""
+.. figure:: MAPMRI_maps.png
+   :align: center
+
+   **RTOP, RTAP, and RTPP calculated using MAPMRI**.
+
 .. [Ozarslan2013] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
                diffusion imaging method for mapping tissue microstructure",
                NeuroImage, 2013.

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -5,7 +5,9 @@ Continuous and analytical diffusion signal modelling with MAPMRI
 
 We show how to model the diffusion signal as a linear combination
 of continuous functions from the MAPMRI basis [Ozarslan2013]_.
-We also compute the analytical Orientation Distribution Function (ODF).
+We also compute the analytical Orientation Distribution Function (ODF),
+the the Return To the Origin Probability (RTOP), the Return To the Axis
+Probability (RTAP), and the Return To the Plane Probability (RTPP).
 
 First import the necessary modules:
 """


### PR DESCRIPTION
This is the second part of the MAPMRI pull request, which add RTOP, RTAP and RTPP, three microstructural EAP indices introduced in  Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: a novel diffusion imaging method for mapping tissue microstructure", NeuroImage, 2013.

p.s. The example is still missing, which dataset do you think I should use? The DSI data that I use as an example for the SHORE? Or do we have better multi-shell data? 