### PR TITLE
Added installation of python-tk package for VTK travis bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
       sudo apt-get update;
       sudo apt-get install -y python-vtk;
       sudo apt-get install -y xvfb;
+      sudo apt-get install -y python-tk;
       python -c "import vtk";
       fi
 install:


### PR DESCRIPTION
@arokem we need also python-tk. For some reason it is not installed by default in the bot. Can you merge this PR first? 