### PR TITLE
Fixed deprecation warning in skimage

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -8,7 +8,7 @@ from dipy.reconst.dti import fractional_anisotropy, color_fa
 
 from scipy.ndimage.filters import median_filter
 try:
-    from skimage.filter import threshold_otsu as otsu
+    from skimage.filters import threshold_otsu as otsu
 except:
     from .threshold import otsu
 


### PR DESCRIPTION
Try 
from dipy.segment.mask import median_otsu

with scikit-image installed, so that it uses the local version, and you get

/home/samuel/.local/lib/python2.7/site-packages/skimage/filter/__init__.py:6: skimage_deprecation: The `skimage.filter` module has been renamed to `skimage.filters`.  This placeholder module will be removed in v0.13.
  warn(skimage_deprecation('The `skimage.filter` module has been renamed '

So now it's fixed. It should also use the local copy in case the user has an old version.