### PR TITLE
Reorient tracks according to ROI

### DIFF
--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -8,7 +8,7 @@ from dipy.tracking.streamlinespeed import compress_streamlines
 import dipy.tracking.utils as ut
 from dipy.tracking.utils import streamline_near_roi
 from dipy.core.geometry import dist_to_corner
-
+from scipy.spatial.distance import cdist
 
 def unlist_streamlines(streamlines):
     """ Return the streamlines not as a list but as an array and an offset
@@ -251,3 +251,38 @@ def select_by_rois(streamlines, rois, include, mode=None, affine=None,
                                       mode=mode)
         if include & ~exclude:
             yield sl
+
+
+def orient_by_rois(streamlines, roi1, roi2, affine=None):
+    """Orient a set of streamlines according to a pair of ROIs
+
+    Parameters
+    ----------
+    streamlines : list
+        List of 3d arrays. Coordinates of the
+    roi1, roi2 : ndarray
+        Binary masks designating the location of the regions of interest, or
+        coordinate arrays (3d coordinates)
+    affine : ndarray
+        Affine transformation from voxels to streamlines. Default: identity.
+    """
+
+    # If we don't already have coordinates on our hands:
+    if len(roi1.shape) == 3:
+        roi1 = np.asarray(np.where(roi1.astype(bool))).T
+    if len(roi2.shape) == 3:
+        roi2 = np.asarray(np.where(roi2.astype(bool))).T
+
+    if affine is not None:
+        roi1 = apply_affine(affine, roi1)
+        roi2 = apply_affine(affine, roi2)
+
+    for idx, sl in enumerate(streamlines):
+        dist1 = cdist(sl, roi1, 'euclidean')
+        dist2 = cdist(sl, roi2, 'euclidean')
+        min1 = np.argmin(dist1, 0)
+        min2 = np.argmin(dist2, 0)
+        if min1[0] > min2[0]:
+            streamlines[idx] = sl[::-1]
+
+    return streamlines

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -259,10 +259,11 @@ def orient_by_rois(streamlines, roi1, roi2, affine=None):
     Parameters
     ----------
     streamlines : list
-        List of 3d arrays. Coordinates of the
+        List of 3d arrays. Each array contains the xyz coordinates of a single
+        streamline.
     roi1, roi2 : ndarray
         Binary masks designating the location of the regions of interest, or
-        coordinate arrays (3d coordinates)
+        coordinate arrays (n-by-3 array with ROI coordinate in each row).
     affine : ndarray
         Affine transformation from voxels to streamlines. Default: identity.
 

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -265,6 +265,31 @@ def orient_by_rois(streamlines, roi1, roi2, affine=None):
         coordinate arrays (3d coordinates)
     affine : ndarray
         Affine transformation from voxels to streamlines. Default: identity.
+
+    Returns
+    -------
+    streamlines : list
+        The same 3D arrays, but reoriented with respect to the ROIs
+
+    Examples
+    --------
+    >>> streamlines = [np.array([[0, 0., 0],
+    ...                          [1, 0., 0.],
+    ...                          [2, 0., 0.]]),
+    ...                np.array([[2, 0., 0.],
+    ...                          [1, 0., 0],
+    ...                          [0, 0,  0.]])]
+    >>> roi1 = np.zeros((4, 4, 4), dtype=bool)
+    >>> roi2 = np.zeros_like(roi1)
+    >>> roi1[0, 0, 0] = True
+    >>> roi2[1, 0, 0] = True
+    >>> orient_by_rois(streamlines, roi1, roi2)
+    [array([[ 0.,  0.,  0.],
+           [ 1.,  0.,  0.],
+           [ 2.,  0.,  0.]]), array([[ 0.,  0.,  0.],
+           [ 1.,  0.,  0.],
+           [ 2.,  0.,  0.]])]
+
     """
 
     # If we don't already have coordinates on our hands:

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -770,27 +770,34 @@ def test_orient_by_rois():
     mask2_vol = np.zeros_like(mask1_vol)
     mask1_vol[0, 0, 0] = True
     mask2_vol[1, 0, 0] = True
+    mask1_coords = np.array(np.where(mask1_vol)).T
+    mask2_coords = np.array(np.where(mask2_vol)).T
 
     # If there is an affine, we'll use it:
     affine = np.eye(4)
     affine[:, 3] = [-1, 100, -20, 1]
     # Transform the streamlines:
     x_streamlines = [sl + affine[:3, 3] for sl in streamlines]
-    mask1_coords = np.array([[0, 0, 0]])
-    mask2_coords = np.array([[1, 0, 0]])
 
-    for sl, affine in zip([streamlines, x_streamlines], [None, affine]):
-        for mask1, mask2 in \
-          zip([mask1_vol, mask1_coords], [mask2_vol, mask2_coords]):
-            new_streamlines = orient_by_rois(sl, mask1, mask2, affine)
-            flipped_sl = [np.array([[0, 0., 0],
-                                    [1, 0., 0.],
-                                    [2, 0., 0.]]),
-                          np.array([[0., 0., 0.],
-                                    [1., 0., 0],
-                                    [2., 0,  0.]])]
+    for copy in [True, False]:
+        for sl, affine in zip([streamlines, x_streamlines], [None, affine]):
+            for mask1, mask2 in \
+              zip([mask1_vol, mask1_coords], [mask2_vol, mask2_coords]):
+                new_streamlines = orient_by_rois(sl, mask1, mask2,
+                                                 affine=affine, copy=copy)
+                if copy:
+                    flipped_sl = [sl[0], sl[1][::-1]]
+                else:
+                    flipped_sl = [np.array([[0, 0., 0],
+                                            [1, 0., 0.],
+                                            [2, 0., 0.]]),
+                                  np.array([[0, 0., 0.],
+                                            [1, 0., 0],
+                                            [2, 0,  0.]])]
+                    if affine is not None:
+                        flipped_sl = [s + affine[:3, 3] for s in flipped_sl]
 
-            npt.assert_equal(new_streamlines, flipped_sl)
+                npt.assert_equal(new_streamlines, flipped_sl)
 
 
 if __name__ == '__main__':

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -771,20 +771,26 @@ def test_orient_by_rois():
     mask1_vol[0, 0, 0] = True
     mask2_vol[1, 0, 0] = True
 
+    # If there is an affine, we'll use it:
+    affine = np.eye(4)
+    affine[:, 3] = [-1, 100, -20, 1]
+    # Transform the streamlines:
+    x_streamlines = [sl + affine[:3, 3] for sl in streamlines]
     mask1_coords = np.array([[0, 0, 0]])
     mask2_coords = np.array([[1, 0, 0]])
 
-    for mask1, mask2 in \
-      zip([mask1_vol, mask1_coords], [mask2_vol, mask2_coords]):
-        new_streamlines = orient_by_rois(streamlines, mask1, mask2)
-        flipped_sl = [np.array([[0, 0., 0],
-                                [1, 0., 0.],
-                                [2, 0., 0.]]),
-                      np.array([[0., 0., 0.],
-                                [1., 0., 0],
-                                [2., 0,  0.]])]
+    for sl, affine in zip([streamlines, x_streamlines], [None, affine]):
+        for mask1, mask2 in \
+          zip([mask1_vol, mask1_coords], [mask2_vol, mask2_coords]):
+            new_streamlines = orient_by_rois(sl, mask1, mask2, affine)
+            flipped_sl = [np.array([[0, 0., 0],
+                                    [1, 0., 0.],
+                                    [2, 0., 0.]]),
+                          np.array([[0., 0., 0.],
+                                    [1., 0., 0],
+                                    [2., 0,  0.]])]
 
-        npt.assert_equal(new_streamlines, flipped_sl)
+            npt.assert_equal(new_streamlines, flipped_sl)
 
 
 if __name__ == '__main__':

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -17,7 +17,8 @@ from dipy.tracking.streamline import (set_number_of_points,
                                       transform_streamlines,
                                       select_random_set_of_streamlines,
                                       compress_streamlines,
-                                      select_by_rois)
+                                      select_by_rois,
+                                      orient_by_rois)
 
 
 streamline = np.array([[82.20181274,  91.36505890,  43.15737152],
@@ -754,6 +755,33 @@ def test_select_by_rois():
                                tol=1.0)
     npt.assert_array_equal(list(selection), [streamlines[0],
                            streamlines[1]])
+
+def test_orient_by_rois():
+    streamlines = [np.array([[0, 0., 0],
+                             [1, 0., 0.],
+                             [2, 0., 0.]]),
+                   np.array([[2, 0., 0.],
+                             [1, 0., 0],
+                             [0, 0,  0.]])]
+
+    # Make two ROIs:
+    mask1 = np.zeros((4, 4, 4), dtype=bool)
+    mask2 = np.zeros_like(mask1)
+    mask1[0, 0, 0] = True
+    mask1[1, 1, 1] = True
+    mask2[1, 0, 0] = True
+    mask2[2, 2, 2] = True
+
+    new_streamlines = orient_by_rois(streamlines, mask1, mask2)
+    flipped_sl = [np.array([[0, 0., 0],
+                            [1, 0., 0.],
+                            [2, 0., 0.]]),
+                  np.array([[0., 0., 0.],
+                            [1., 0., 0],
+                            [2., 0,  0.]])]
+
+    npt.assert_equal(new_streamlines, flipped_sl)
+
 
 
 if __name__ == '__main__':

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -756,6 +756,7 @@ def test_select_by_rois():
     npt.assert_array_equal(list(selection), [streamlines[0],
                            streamlines[1]])
 
+
 def test_orient_by_rois():
     streamlines = [np.array([[0, 0., 0],
                              [1, 0., 0.],
@@ -779,7 +780,6 @@ def test_orient_by_rois():
                             [2., 0,  0.]])]
 
     npt.assert_equal(new_streamlines, flipped_sl)
-
 
 
 if __name__ == '__main__':

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -768,9 +768,7 @@ def test_orient_by_rois():
     mask1 = np.zeros((4, 4, 4), dtype=bool)
     mask2 = np.zeros_like(mask1)
     mask1[0, 0, 0] = True
-    mask1[1, 1, 1] = True
     mask2[1, 0, 0] = True
-    mask2[2, 2, 2] = True
 
     new_streamlines = orient_by_rois(streamlines, mask1, mask2)
     flipped_sl = [np.array([[0, 0., 0],

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -766,20 +766,25 @@ def test_orient_by_rois():
                              [0, 0,  0.]])]
 
     # Make two ROIs:
-    mask1 = np.zeros((4, 4, 4), dtype=bool)
-    mask2 = np.zeros_like(mask1)
-    mask1[0, 0, 0] = True
-    mask2[1, 0, 0] = True
+    mask1_vol = np.zeros((4, 4, 4), dtype=bool)
+    mask2_vol = np.zeros_like(mask1_vol)
+    mask1_vol[0, 0, 0] = True
+    mask2_vol[1, 0, 0] = True
 
-    new_streamlines = orient_by_rois(streamlines, mask1, mask2)
-    flipped_sl = [np.array([[0, 0., 0],
-                            [1, 0., 0.],
-                            [2, 0., 0.]]),
-                  np.array([[0., 0., 0.],
-                            [1., 0., 0],
-                            [2., 0,  0.]])]
+    mask1_coords = np.array([[0, 0, 0]])
+    mask2_coords = np.array([[1, 0, 0]])
 
-    npt.assert_equal(new_streamlines, flipped_sl)
+    for mask1, mask2 in \
+      zip([mask1_vol, mask1_coords], [mask2_vol, mask2_coords]):
+        new_streamlines = orient_by_rois(streamlines, mask1, mask2)
+        flipped_sl = [np.array([[0, 0., 0],
+                                [1, 0., 0.],
+                                [2, 0., 0.]]),
+                      np.array([[0., 0., 0.],
+                                [1., 0., 0],
+                                [2., 0,  0.]])]
+
+        npt.assert_equal(new_streamlines, flipped_sl)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is important in order to correctly pull out a core of a bundle based on a median operation on the coordinates. For details, see: 

https://github.com/arokem/AFQ-notebooks/blob/08ac2fc66d1ded0234eec898438d0c7f8380cafc/AFQ-registration-callosum.ipynb