### PR TITLE
Optimize dipy.align.reslice

### DIFF
--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -32,7 +32,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     cval : float
         Value used for points outside the boundaries of the input if
         mode='constant'.
-    num_processes: int
+    num_processes : int
         Split the calculation to a pool of children processes. This only
         applies to 4D `data` arrays. If a positive integer then it defines
         the size of the multiprocessing pool that will be used. If 0, then

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -56,22 +56,16 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
     """
     R = np.array(new_zooms) / np.array(zooms)
     new_shape = np.array(zooms)/np.array(new_zooms) * np.array(data.shape[:3])
-    new_shape = np.round(new_shape).astype('i8')
+    new_shape = tuple(np.round(new_shape).astype('i8'))
     if data.ndim == 3:
-        data2 = affine_transform(input=data, matrix=R, offset=np.zeros(3,),
-                                 output_shape=tuple(new_shape),
+        data2 = affine_transform(input=data, matrix=R, output_shape=new_shape,
                                  order=order, mode=mode, cval=cval)
     if data.ndim == 4:
-        data2l=[]
+        data2 = np.zeros(new_shape+(data.shape[-1],), data.dtype)
         for i in range(data.shape[-1]):
-            tmp = affine_transform(input=data[..., i], matrix=R,
-                                   offset=np.zeros(3,),
-                                   output_shape=tuple(new_shape),
-                                   order=order, mode=mode, cval=cval)
-            data2l.append(tmp)
-        data2 = np.zeros(tmp.shape+(data.shape[-1],), data.dtype)
-        for i in range(data.shape[-1]):
-            data2[..., i] = data2l[i]
+            affine_transform(input=data[..., i], matrix=R,
+                             output=data2[..., i], output_shape=new_shape,
+                             order=order, mode=mode, cval=cval)
 
     Rx = np.eye(4)
     Rx[:3, :3] = np.diag(R)

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -54,7 +54,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
     >>> data2.shape
     (77, 77, 40)
     """
-    R = np.diag(np.array(new_zooms)/np.array(zooms))
+    R = np.array(new_zooms) / np.array(zooms)
     new_shape = np.array(zooms)/np.array(new_zooms) * np.array(data.shape[:3])
     new_shape = np.round(new_shape).astype('i8')
     if data.ndim == 3:
@@ -74,6 +74,6 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
             data2[..., i] = data2l[i]
 
     Rx = np.eye(4)
-    Rx[:3, :3] = R
+    Rx[:3, :3] = np.diag(R)
     affine2 = np.dot(affine, Rx)
     return data2, affine2

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -1,8 +1,15 @@
+from multiprocessing import Pool, cpu_count
+
 import numpy as np
 from scipy.ndimage import affine_transform
 
 
-def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
+def _affine_transform(kwargs):
+    return affine_transform(**kwargs)
+
+
+def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
+            mp=False):
     """Reslice data with new voxel resolution defined by ``new_zooms``
 
     Parameters
@@ -25,6 +32,12 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
     cval : float
         Value used for points outside the boundaries of the input if
         mode='constant'.
+    mp: {bool, int}
+        Split the calculation to a pool of children processes. This only
+        applies to 4D `data` arrays. If False (the default), the calculation is
+        performed in the current thread. If a positive integer then it defines
+        the size of the multiprocessing pool that will be used. If True, then
+        the size of the pool will equal the number of cores available.
 
     Returns
     -------
@@ -57,15 +70,30 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0):
     R = np.array(new_zooms) / np.array(zooms)
     new_shape = np.array(zooms)/np.array(new_zooms) * np.array(data.shape[:3])
     new_shape = tuple(np.round(new_shape).astype('i8'))
+    kwargs = {'matrix': R, 'output_shape': new_shape, 'order': order,
+              'mode': mode, 'cval': cval}
     if data.ndim == 3:
-        data2 = affine_transform(input=data, matrix=R, output_shape=new_shape,
-                                 order=order, mode=mode, cval=cval)
+        data2 = affine_transform(input=data, **kwargs)
     if data.ndim == 4:
         data2 = np.zeros(new_shape+(data.shape[-1],), data.dtype)
-        for i in range(data.shape[-1]):
-            affine_transform(input=data[..., i], matrix=R,
-                             output=data2[..., i], output_shape=new_shape,
-                             order=order, mode=mode, cval=cval)
+        if mp is True:
+            mp = cpu_count()
+        elif not (isinstance(mp, int) and mp > 1):
+            mp = False
+        if not mp:
+            for i in range(data.shape[-1]):
+                affine_transform(input=data[..., i], output=data2[..., i],
+                                 **kwargs)
+        else:
+            params = []
+            for i in range(data.shape[-1]):
+                _kwargs = {'input': data[..., i]}
+                _kwargs.update(kwargs)
+                params.append(_kwargs)
+            pool = Pool(mp)
+            for i, result in enumerate(pool.imap(_affine_transform, params)):
+                data2[..., i] = result
+            pool.close()
 
     Rx = np.eye(4)
     Rx[:3, :3] = np.diag(R)

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -68,6 +68,23 @@ def test_resample():
     assert_(np.all(sigmas > sigmas2))
     assert_(np.all(sigmas2 > sigmas3))
 
+    # check that 4D resampling matches 3D resampling
+    data2, affine2 = reslice(data, affine, zooms, new_zooms)
+    for i in range(data.shape[-1]):
+        _data, _affine = reslice(data[..., i], affine, zooms, new_zooms)
+        assert_almost_equal(data2[..., i], _data)
+        assert_almost_equal(affine2, _affine)
+
+    # check use of multiprocessing pool of specified size
+    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_processes=4)
+    assert_almost_equal(data2, data3)
+    assert_almost_equal(affine2, affine3)
+
+    # check use of multiprocessing pool of autoconfigured size
+    data3, affine3 = reslice(data, affine, zooms, new_zooms, num_processes=0)
+    assert_almost_equal(data2, data3)
+    assert_almost_equal(affine2, affine3)
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
- Using a 1D transformation matrix instead of a 2D diagonal matrix reduces computation time.
- Using the `output` argument in `affine_transform` reduces memory usage.