### PR TITLE
NF - random seeds from mask

### DIFF
--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -106,6 +106,9 @@ class LocalTracking(object):
         for s in self.seeds:
             s = np.dot(lin, s) + offset
             directions = dg.initial_direction(s)
+            if directions.size == 0 and self.return_all:
+                # only the seed position
+                yield [s]
             directions = directions[:max_cross]
             for first_step in directions:
                 stepsF, tissue_class = local_tracker(dg, tc, s, first_step,

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -516,25 +516,37 @@ def test_seeds_from_mask():
 def test_random_seeds_from_mask():
 
     mask = np.random.random_integers(0, 1, size=(4, 6, 3))
-    seeds = random_seeds_from_mask(mask, seeds_count=24, is_seed_per_voxel=True)
+    seeds = random_seeds_from_mask(mask,
+                                   seeds_count=24,
+                                   seed_count_per_voxel=True)
     assert_equal(mask.sum() * 24, len(seeds))
-    seeds = random_seeds_from_mask(mask, seeds_count=0, is_seed_per_voxel=True)
+    seeds = random_seeds_from_mask(mask,
+                                   seeds_count=0,
+                                   seed_count_per_voxel=True)
     assert_equal(0, len(seeds))
 
     mask[:] = False
     mask[2, 2, 2] = True
-    seeds = random_seeds_from_mask(mask, seeds_count=8, is_seed_per_voxel=True)
+    seeds = random_seeds_from_mask(mask,
+                                   seeds_count=8,
+                                   seed_count_per_voxel=True)
     assert_equal(mask.sum() * 8, len(seeds))
     assert_true(np.all((seeds > 1.5) & (seeds < 2.5)))
 
-    seeds = random_seeds_from_mask(mask, seeds_count=24, is_seed_per_voxel=False)
+    seeds = random_seeds_from_mask(mask,
+                                   seeds_count=24,
+                                   seed_count_per_voxel=False)
     assert_equal(24, len(seeds))
-    seeds = random_seeds_from_mask(mask, seeds_count=0, is_seed_per_voxel=False)
+    seeds = random_seeds_from_mask(mask,
+                                   seeds_count=0,
+                                   seed_count_per_voxel=False)
     assert_equal(0, len(seeds))
 
     mask[:] = False
     mask[2, 2, 2] = True
-    seeds = random_seeds_from_mask(mask, seeds_count=100, is_seed_per_voxel=False)
+    seeds = random_seeds_from_mask(mask,
+                                   seeds_count=100,
+                                   seed_count_per_voxel=False)
     assert_equal(100, len(seeds))
     assert_true(np.all((seeds > 1.5) & (seeds < 2.5)))
 

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -9,7 +9,8 @@ from dipy.tracking.utils import (affine_for_trackvis, connectivity_matrix,
                                  density_map, length, move_streamlines,
                                  ndbincount, reduce_labels,
                                  reorder_voxels_affine, seeds_from_mask,
-                                 random_seeds_from_mask, target,
+                                 random_seeds_from_mask_per_voxel,
+                                 random_seeds_from_mask_total, target,
                                  _rmi, unique_rows, near_roi,
                                  reduce_rois)
 from dipy.tracking._utils import _to_voxel_coordinates
@@ -516,14 +517,28 @@ def test_seeds_from_mask():
 def test_random_seeds_from_mask():
 
     mask = np.random.random_integers(0, 1, size=(4, 6, 3))
-    seeds = random_seeds_from_mask(mask, seeds_per_voxel=24)
+    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=24)
     assert_equal(mask.sum() * 24, len(seeds))
+    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=0)
+    assert_equal(0, len(seeds))
 
     mask[:] = False
     mask[2, 2, 2] = True
-    seeds = random_seeds_from_mask(mask, seeds_per_voxel=8)
+    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=8)
     assert_equal(mask.sum() * 8, len(seeds))
     assert_true(np.all((seeds > 1.5) & (seeds < 2.5)))
+
+    seeds = random_seeds_from_mask_total(mask, seeds_count=24)
+    assert_equal(24, len(seeds))
+    seeds = random_seeds_from_mask_total(mask, seeds_count=0)
+    assert_equal(0, len(seeds))
+
+    mask[:] = False
+    mask[2, 2, 2] = True
+    seeds = random_seeds_from_mask_total(mask, seeds_count=100)
+    assert_equal(100, len(seeds))
+    assert_true(np.all((seeds > 1.5) & (seeds < 2.5)))
+
 
 
 def test_connectivity_matrix_shape():

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -9,7 +9,6 @@ from dipy.tracking.utils import (affine_for_trackvis, connectivity_matrix,
                                  density_map, length, move_streamlines,
                                  ndbincount, reduce_labels,
                                  reorder_voxels_affine, seeds_from_mask,
-                                 random_seeds_from_mask,
                                  random_seeds_from_mask, target,
                                  _rmi, unique_rows, near_roi,
                                  reduce_rois)

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -9,8 +9,8 @@ from dipy.tracking.utils import (affine_for_trackvis, connectivity_matrix,
                                  density_map, length, move_streamlines,
                                  ndbincount, reduce_labels,
                                  reorder_voxels_affine, seeds_from_mask,
-                                 random_seeds_from_mask_per_voxel,
-                                 random_seeds_from_mask_total, target,
+                                 random_seeds_from_mask,
+                                 random_seeds_from_mask, target,
                                  _rmi, unique_rows, near_roi,
                                  reduce_rois)
 from dipy.tracking._utils import _to_voxel_coordinates
@@ -517,25 +517,25 @@ def test_seeds_from_mask():
 def test_random_seeds_from_mask():
 
     mask = np.random.random_integers(0, 1, size=(4, 6, 3))
-    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=24)
+    seeds = random_seeds_from_mask(mask, seeds_count=24, is_seed_per_voxel=True)
     assert_equal(mask.sum() * 24, len(seeds))
-    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=0)
+    seeds = random_seeds_from_mask(mask, seeds_count=0, is_seed_per_voxel=True)
     assert_equal(0, len(seeds))
 
     mask[:] = False
     mask[2, 2, 2] = True
-    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=8)
+    seeds = random_seeds_from_mask(mask, seeds_count=8, is_seed_per_voxel=True)
     assert_equal(mask.sum() * 8, len(seeds))
     assert_true(np.all((seeds > 1.5) & (seeds < 2.5)))
 
-    seeds = random_seeds_from_mask_total(mask, seeds_count=24)
+    seeds = random_seeds_from_mask(mask, seeds_count=24, is_seed_per_voxel=False)
     assert_equal(24, len(seeds))
-    seeds = random_seeds_from_mask_total(mask, seeds_count=0)
+    seeds = random_seeds_from_mask(mask, seeds_count=0, is_seed_per_voxel=False)
     assert_equal(0, len(seeds))
 
     mask[:] = False
     mask[2, 2, 2] = True
-    seeds = random_seeds_from_mask_total(mask, seeds_count=100)
+    seeds = random_seeds_from_mask(mask, seeds_count=100, is_seed_per_voxel=False)
     assert_equal(100, len(seeds))
     assert_true(np.all((seeds > 1.5) & (seeds < 2.5)))
 

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -370,7 +370,8 @@ def seeds_from_mask(mask, density=[1, 1, 1], voxel_size=None, affine=None):
 
     See Also
     --------
-    random_seeds_from_mask
+    random_seeds_from_mask_per_voxel
+    random_seeds_from_mask_total
 
     Raises
     ------
@@ -437,6 +438,54 @@ def seeds_from_mask(mask, density=[1, 1, 1], voxel_size=None, affine=None):
 
 
 def random_seeds_from_mask(mask, seeds_per_voxel=1, affine=None):
+    msg = "This function is deprecated please use"
+    msg += " dipy.tracking.utils.random_seeds_from_mask_per_voxel."
+    warn(msg)
+    return random_seeds_from_mask_per_voxel(mask, seeds_per_voxel, affine)
+
+
+def random_seeds_from_mask_total(mask, seeds_count, affine=None):
+    """Creates randomly placed seeds for fiber tracking from a binary mask.
+
+    Seeds points are placed randomly distributed in all voxels of ``mask``
+    which are ``True``. This function is similar to
+    ``random_seeds_from_mask_per_voxel()``, with the difference that
+    instead of returning a number of seeds per voxel, it returns total
+    number of seeds placed in the ``mask``.
+
+    Parameters
+    ----------
+    mask : binary 3d array_like
+        A binary array specifying where to place the seeds for fiber tracking.
+    seeds_count : int
+        Specifies the total number of seeds to place in the mask.
+    affine : array, (4, 4)
+        The mapping between voxel indices and the point space for seeds. A
+        seed point at the center the voxel ``[i, j, k]`` will be represented as
+        ``[x, y, z]`` where ``[x, y, z, 1] == np.dot(affine, [i, j, k , 1])``.
+
+    See Also
+    --------
+    seeds_from_mask
+    random_seeds_from_mask_per_voxel
+
+    Raises
+    ------
+    ValueError
+        When ``mask`` is not a three-dimensional array
+    """
+    mask = np.array(mask, dtype=bool, copy=False, ndmin=3)
+    if mask.ndim != 3:
+        raise ValueError('mask cannot be more than 3d')
+
+    num_voxels = np.count_nonzero(mask)
+    seeds_per_voxel = seeds_count // num_voxels + 1
+    seeds = random_seeds_from_mask_per_voxel(mask, seeds_per_voxel, affine)
+    np.random.shuffle(seeds)
+    return seeds[:seeds_count]
+
+
+def random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=1, affine=None):
     """Creates randomly placed seeds for fiber tracking from a binary mask.
 
     Seeds points are placed randomly distributed in all voxels of ``mask``
@@ -459,6 +508,7 @@ def random_seeds_from_mask(mask, seeds_per_voxel=1, affine=None):
     See Also
     --------
     seeds_from_mask
+    random_seeds_from_mask_total
 
     Raises
     ------
@@ -471,10 +521,10 @@ def random_seeds_from_mask(mask, seeds_per_voxel=1, affine=None):
     >>> mask[0,0,0] = 1
 
     >>> np.random.seed(1)
-    >>> random_seeds_from_mask(mask, seeds_per_voxel=1)
+    >>> random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=1)
     array([[-0.082978  ,  0.22032449, -0.49988563]])
 
-    >>> random_seeds_from_mask(mask, seeds_per_voxel=6)
+    >>> random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=6)
     array([[-0.19766743, -0.35324411, -0.40766141],
            [-0.31373979, -0.15443927, -0.10323253],
            [ 0.03881673, -0.08080549,  0.1852195 ],
@@ -482,7 +532,7 @@ def random_seeds_from_mask(mask, seeds_per_voxel=1, affine=None):
            [ 0.17046751, -0.0826952 ,  0.05868983],
            [-0.35961306, -0.30189851,  0.30074457]])
     >>> mask[0,1,2] = 1
-    >>> random_seeds_from_mask(mask, seeds_per_voxel=2)
+    >>> random_seeds_from_mask_per_voxel(mask, seeds_per_voxel=2)
     array([[ 0.46826158, -0.18657582,  0.19232262],
            [ 0.37638915,  0.39460666, -0.41495579],
            [-0.46094522,  0.66983042,  2.3781425 ],

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -436,12 +436,12 @@ def seeds_from_mask(mask, density=[1, 1, 1], voxel_size=None, affine=None):
     return seeds
 
 
-def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=None):
+def random_seeds_from_mask(mask, seeds_count=1, seed_count_per_voxel=True, affine=None):
     """Creates randomly placed seeds for fiber tracking from a binary mask.
 
     Seeds points are placed randomly distributed in voxels of ``mask``
     which are ``True``.
-    If ``is_seed_per_voxel`` is ``True``, this function is
+    If ``seed_count_per_voxel`` is ``True``, this function is
     similar to ``seeds_from_mask()``, with the difference that instead of evenly
     distributing the seeds, it randomly places the seeds within the voxels
     specified by the ``mask``.
@@ -451,10 +451,10 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
     mask : binary 3d array_like
         A binary array specifying where to place the seeds for fiber tracking.
     seeds_count : int
-        The number of seeds to generate. If ``is_seed_per_voxel`` is True,
+        The number of seeds to generate. If ``seed_count_per_voxel`` is True,
         specifies the number of seeds to place in each voxel. Otherwise,
         specifies the total number of seeds to place in the mask.
-    is_seed_per_voxel: bool
+    seed_count_per_voxel: bool
         If True, seeds_count is per voxel, else seeds_count is the total number
         of seeds.
     affine : array, (4, 4)
@@ -477,10 +477,10 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
     >>> mask[0,0,0] = 1
 
     >>> np.random.seed(1)
-    >>> random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True)
+    >>> random_seeds_from_mask(mask, seeds_count=1, seed_count_per_voxel=True)
     array([[-0.082978  ,  0.22032449, -0.49988563]])
 
-    >>> random_seeds_from_mask(mask, seeds_count=6, is_seed_per_voxel=True)
+    >>> random_seeds_from_mask(mask, seeds_count=6, seed_count_per_voxel=True)
     array([[-0.19766743, -0.35324411, -0.40766141],
            [-0.31373979, -0.15443927, -0.10323253],
            [ 0.03881673, -0.08080549,  0.1852195 ],
@@ -488,7 +488,7 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
            [ 0.17046751, -0.0826952 ,  0.05868983],
            [-0.35961306, -0.30189851,  0.30074457]])
     >>> mask[0,1,2] = 1
-    >>> random_seeds_from_mask(mask, seeds_count=2, is_seed_per_voxel=True)
+    >>> random_seeds_from_mask(mask, seeds_count=2, seed_count_per_voxel=True)
     array([[ 0.46826158, -0.18657582,  0.19232262],
            [ 0.37638915,  0.39460666, -0.41495579],
            [-0.46094522,  0.66983042,  2.3781425 ],
@@ -502,7 +502,7 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
     where = np.argwhere(mask)
     num_voxels = len(where)
 
-    if not is_seed_per_voxel:
+    if not seed_count_per_voxel:
         # Generate enough seeds per voxel
         seeds_per_voxel = seeds_count // num_voxels + 1
     else:
@@ -515,7 +515,7 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
     seeds = where + grid - .5
     seeds = asarray(seeds)
 
-    if not is_seed_per_voxel:
+    if not seed_count_per_voxel:
         # Randomize the seeds and select the requested amount
         np.random.shuffle(seeds)
         seeds = seeds[:seeds_count]

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -444,7 +444,8 @@ def random_seeds_from_mask(mask, seeds_count=1, seed_count_per_voxel=True, affin
     If ``seed_count_per_voxel`` is ``True``, this function is
     similar to ``seeds_from_mask()``, with the difference that instead of evenly
     distributing the seeds, it randomly places the seeds within the voxels
-    specified by the ``mask``.
+    specified by the ``mask``. The initial random conditions can be set using
+    ``numpy.random.seed(...)``, prior to call this function.
 
     Parameters
     ----------

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -451,7 +451,9 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
     mask : binary 3d array_like
         A binary array specifying where to place the seeds for fiber tracking.
     seeds_count : int
-        Specifies the number of seeds to place in each voxel.
+        The number of seeds to generate. If ``is_seed_per_voxel`` is True,
+        specifies the number of seeds to place in each voxel. Otherwise,
+        specifies the total number of seeds to place in the mask.
     is_seed_per_voxel: bool
         If True, seeds_count is per voxel, else seeds_count is the total number
         of seeds.
@@ -475,10 +477,10 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
     >>> mask[0,0,0] = 1
 
     >>> np.random.seed(1)
-    >>> random_seeds_from_mask(mask, seeds_count=1)
+    >>> random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True)
     array([[-0.082978  ,  0.22032449, -0.49988563]])
 
-    >>> random_seeds_from_mask(mask, seeds_count=6)
+    >>> random_seeds_from_mask(mask, seeds_count=6, is_seed_per_voxel=True)
     array([[-0.19766743, -0.35324411, -0.40766141],
            [-0.31373979, -0.15443927, -0.10323253],
            [ 0.03881673, -0.08080549,  0.1852195 ],
@@ -486,7 +488,7 @@ def random_seeds_from_mask(mask, seeds_count=1, is_seed_per_voxel=True, affine=N
            [ 0.17046751, -0.0826952 ,  0.05868983],
            [-0.35961306, -0.30189851,  0.30074457]])
     >>> mask[0,1,2] = 1
-    >>> random_seeds_from_mask(mask, seeds_count=2)
+    >>> random_seeds_from_mask(mask, seeds_count=2, is_seed_per_voxel=True)
     array([[ 0.46826158, -0.18657582,  0.19232262],
            [ 0.37638915,  0.39460666, -0.41495579],
            [-0.46094522,  0.66983042,  2.3781425 ],

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -445,7 +445,7 @@ def random_seeds_from_mask(mask, seeds_count=1, seed_count_per_voxel=True, affin
     similar to ``seeds_from_mask()``, with the difference that instead of evenly
     distributing the seeds, it randomly places the seeds within the voxels
     specified by the ``mask``. The initial random conditions can be set using
-    ``numpy.random.seed(...)``, prior to call this function.
+    ``numpy.random.seed(...)``, prior to calling this function.
 
     Parameters
     ----------

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -450,7 +450,7 @@ def random_seeds_from_mask_total(mask, seeds_count, affine=None):
     Seeds points are placed randomly distributed in all voxels of ``mask``
     which are ``True``. This function is similar to
     ``random_seeds_from_mask_per_voxel()``, with the difference that
-    instead of returning a number of seeds per voxel, it returns total
+    instead of returning a number of seeds per voxel, it returns a total
     number of seeds placed in the ``mask``.
 
     Parameters


### PR DESCRIPTION
- This PR adds the fct ``random_seeds_from_mask_total`` to generate N seeds given a mask. This complements the fct ``random_seeds_from_mask_per_voxel`` that already generates seeds given a mask. This is useful when you want N streamlines per region, with regions of various size.

- It also fixes a small bug. If N seeds were sent to ``LocalTracking`` with ``return_all==True``, the returned streamlines excluded all seeds with no valid initial direction. Now, if a seed has no valid initial direction, it return a streamline containing only the seed position.


