### PR TITLE
Saving DiffeomorphicMap with pickle

### DIFF
--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -1434,4 +1434,6 @@ class SymmetricDiffeomorphicRegistration(DiffeomorphicRegistration):
                              static_grid2world, moving_grid2world, prealign)
         self._optimize()
         self._end_optimizer()
+        self.static_to_ref.forward = np.array(self.static_to_ref.forward)
+        self.static_to_ref.backward = np.array(self.static_to_ref.backward)
         return self.static_to_ref


### PR DESCRIPTION
Pickle fails when attempting to save memory views. Here we simply convert the `forward` and `backward` deformation fields to numpy arrays so we can now save the `DiffeomorphicMap` instance returned from `SymmetricDiffeomorphicRegistration` to disk with pickle.
