### PR TITLE
Fix anisotropic voxel size use by setting vox_size in vtkImageReslice of slicer actor

### DIFF
--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -66,8 +66,10 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     >>> data2.shape
     (77, 77, 40)
     """
-    R = np.array(new_zooms) / np.array(zooms)
-    new_shape = np.array(zooms)/np.array(new_zooms) * np.array(data.shape[:3])
+    new_zooms = np.array(new_zooms, dtype='f8')
+    zooms = np.array(zooms, dtype='f8')
+    R = new_zooms / zooms
+    new_shape = zooms / new_zooms * np.array(data.shape[:3])
     new_shape = tuple(np.round(new_shape).astype('i8'))
     kwargs = {'matrix': R, 'output_shape': new_shape, 'order': order,
               'mode': mode, 'cval': cval}

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -47,8 +47,8 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
         latter may have problems with images with anisotropic voxel size.
     interpolation : string
         If 'linear' (default) then linear interpolation is used on the final
-        texture texture mapping. If 'nearest' then nearest neighbor
-        interpolation is used on the final texture mapping.
+        texture mapping. If 'nearest' then nearest neighbor interpolation is
+        used on the final texture mapping.
 
     Returns
     -------

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -195,6 +195,9 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
     else:
         image_actor.SetInterpolate(True)
 
+    if major_version >= 6:
+        image_actor.GetMapper().BorderOn()
+
     return image_actor
 
 

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -21,8 +21,7 @@ if have_vtk:
 
 
 def slicer(data, affine=None, value_range=None, opacity=1.,
-           lookup_colormap=None, force_voxel_size=True,
-           interpolation='linear'):
+           lookup_colormap=None, interpolation='linear'):
     """ Cuts 3D scalar or rgb volumes into 2D images
 
     Parameters
@@ -40,11 +39,6 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
         Opacity of 0 means completely transparent and 1 completely visible.
     lookup_colormap : vtkLookupTable
         If None (default) then a grayscale map is created.
-    force_voxel_size : bool
-        If True (default) then initial voxel sizes of the image will be
-        recovered from the affine and used to show the slices correctly. If
-        False then the output spacing will be considered as (1., 1., 1.). The
-        latter may have problems with images with anisotropic voxel size.
     interpolation : string
         If 'linear' (default) then linear interpolation is used on the final
         texture mapping. If 'nearest' then nearest neighbor interpolation is
@@ -128,10 +122,10 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
 
     # Adding this will allow to support anisotropic voxels
     # and also gives the opportunity to slice per voxel coordinates
-    if force_voxel_size:
-        RZS = affine[:3, :3]
-        zooms = np.sqrt(np.sum(RZS * RZS, axis=0))
-        image_resliced.SetOutputSpacing(*zooms)
+
+    RZS = affine[:3, :3]
+    zooms = np.sqrt(np.sum(RZS * RZS, axis=0))
+    image_resliced.SetOutputSpacing(*zooms)
 
     image_resliced.SetInterpolationModeToLinear()
     image_resliced.Update()

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -111,8 +111,7 @@ def test_slicer():
 
     data = (255 * np.random.rand(50, 50, 50))
     affine = np.diag([1, 3, 2, 1])
-    slicer = actor.slicer(data, affine,
-                          force_voxel_size=True, interpolation='nearest')
+    slicer = actor.slicer(data, affine, interpolation='nearest')
     slicer.display(None, None, 25)
 
     renderer.add(slicer)
@@ -128,8 +127,8 @@ def test_slicer():
 
     data = (255 * np.random.rand(50, 50, 50))
     affine = np.diag([1, 3, 2, 1])
-    slicer = actor.slicer(data, affine,
-                          force_voxel_size=False, interpolation='linear')
+
+    slicer = actor.slicer(data, affine, interpolation='linear')
     slicer.display(None, None, 25)
 
     renderer.add(slicer)
@@ -139,7 +138,7 @@ def test_slicer():
     arr = window.snapshot(renderer, offscreen=False)
     report = window.analyze_snapshot(arr, find_objects=True)
     npt.assert_equal(report.objects, 1)
-    npt.assert_equal(slicer.shape, (50, 148, 99))
+    npt.assert_equal(data.shape, slicer.shape)
 
 
 @xvfb_it

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -107,6 +107,40 @@ def test_slicer():
     report = window.analyze_snapshot(arr, find_objects=True)
     npt.assert_equal(report.objects, 1)
 
+    renderer.clear()
+
+    data = (255 * np.random.rand(50, 50, 50))
+    affine = np.diag([1, 3, 2, 1])
+    slicer = actor.slicer(data, affine,
+                          force_voxel_size=True, interpolation=False)
+    slicer.display(None, None, 25)
+
+    renderer.add(slicer)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    arr = window.snapshot(renderer, offscreen=False)
+    report = window.analyze_snapshot(arr, find_objects=True)
+    npt.assert_equal(report.objects, 1)
+    npt.assert_equal(data.shape, slicer.shape)
+
+    renderer.clear()
+
+    data = (255 * np.random.rand(50, 50, 50))
+    affine = np.diag([1, 3, 2, 1])
+    slicer = actor.slicer(data, affine,
+                          force_voxel_size=False, interpolation=True)
+    slicer.display(None, None, 25)
+
+    renderer.add(slicer)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    arr = window.snapshot(renderer, offscreen=False)
+    report = window.analyze_snapshot(arr, find_objects=True)
+    npt.assert_equal(report.objects, 1)
+    npt.assert_equal(slicer.shape, (50, 148, 99))
+
 
 @xvfb_it
 @npt.dec.skipif(not run_test)

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -128,17 +128,24 @@ def test_slicer():
     data = (255 * np.random.rand(50, 50, 50))
     affine = np.diag([1, 3, 2, 1])
 
-    slicer = actor.slicer(data, affine, interpolation='linear')
+    from dipy.align.reslice import reslice
+
+    data2, affine2 = reslice(data, affine, zooms=(1, 3, 2),
+                             new_zooms=(1, 1, 1))
+
+    slicer = actor.slicer(data2, affine2, interpolation='linear')
     slicer.display(None, None, 25)
 
     renderer.add(slicer)
     renderer.reset_camera()
     renderer.reset_clipping_range()
 
+    # window.show(renderer, reset_camera=False)
     arr = window.snapshot(renderer, offscreen=False)
     report = window.analyze_snapshot(arr, find_objects=True)
     npt.assert_equal(report.objects, 1)
-    npt.assert_equal(data.shape, slicer.shape)
+    npt.assert_array_equal([1, 3, 2] * np.array(data.shape),
+                           np.array(slicer.shape))
 
 
 @xvfb_it

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -112,7 +112,7 @@ def test_slicer():
     data = (255 * np.random.rand(50, 50, 50))
     affine = np.diag([1, 3, 2, 1])
     slicer = actor.slicer(data, affine,
-                          force_voxel_size=True, interpolation=False)
+                          force_voxel_size=True, interpolation='nearest')
     slicer.display(None, None, 25)
 
     renderer.add(slicer)
@@ -129,7 +129,7 @@ def test_slicer():
     data = (255 * np.random.rand(50, 50, 50))
     affine = np.diag([1, 3, 2, 1])
     slicer = actor.slicer(data, affine,
-                          force_voxel_size=False, interpolation=True)
+                          force_voxel_size=False, interpolation='linear')
     slicer.display(None, None, 25)
 
     renderer.add(slicer)


### PR DESCRIPTION
If the voxel size was not isotropic the slicer was not showing properly the image in world space. Now this is fixed. The previous version had the potential advantage of allowing to slice in 1mm voxel size rather than in voxel coordinates. This is still available by unsetting the flag voxel size and it should work nicely with isotropic voxel sizes but the results will not be nice with anisotropic voxel sizes therefore it is set to false by default.