### PR TITLE
RF: A couple more places where numpy 1.10 compatibility prohibits...

### DIFF
--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -1736,11 +1736,11 @@ def local_skeleton_clustering_3pts(tracks, d_thr=10):
         if m_k<d_thr:
             if flip[i_k]==1:
                 ts[0]=track[-1];ts[1]=track[1];ts[-1]=track[0]
-                C[i_k]['hidden']+=ts
+                C[i_k]['hidden'] = C[i_k]['hidden'] + ts
             else:
                 #print(track.shape)
                 #print(track.dtype)
-                C[i_k]['hidden']+=track
+                C[i_k]['hidden'] = C[i_k]['hidden'] + track
             C[i_k]['N'] = C[i_k]['N'] + 1
             C[i_k]['indices'].append(it)
         else:


### PR DESCRIPTION
inplace assignments. 

Continues #777, to fix http://nipy.bic.berkeley.edu/builders/dipy-bdist-mpkg-3.3/builds/250/steps/shell_10/logs/stdio