### PR TITLE
TST: Make skipping with TEST_WITH_XVFB=skip more explicit.

### DIFF
--- a/dipy/testing/decorators.py
+++ b/dipy/testing/decorators.py
@@ -61,10 +61,6 @@ def xvfb_it(my_test):
     fname = my_test.__name__
 
     def test_with_xvfb():
-        if use_xvfb == 'skip':
-            def skipper_func():
-                pass
-            return skipper_func
         if use_xvfb:
             from xvfbwrapper import Xvfb
             display = Xvfb(width=1920, height=1080)

--- a/dipy/viz/tests/test_fvtk.py
+++ b/dipy/viz/tests/test_fvtk.py
@@ -1,5 +1,5 @@
-""" Testing visualization with fvtk
-"""
+"""Testing visualization with fvtk."""
+import os
 import numpy as np
 
 from dipy.viz import fvtk
@@ -8,10 +8,15 @@ from dipy import data
 import numpy.testing as npt
 from dipy.testing.decorators import xvfb_it
 
+use_xvfb = os.environ.get('TEST_WITH_XVFB', False)
+if use_xvfb == 'skip':
+    skip_it = True
+else:
+    skip_it = False
 
+
+@npt.dec.skipif(not fvtk.have_vtk or not fvtk.have_vtk_colors or skip_it)
 @xvfb_it
-@npt.dec.skipif(not fvtk.have_vtk)
-@npt.dec.skipif(not fvtk.have_vtk_colors)
 def test_fvtk_functions():
     # This tests will fail if any of the given actors changed inputs or do
     # not exist
@@ -64,9 +69,8 @@ def test_fvtk_functions():
     fvtk.add(r, p2)
 
 
+@npt.dec.skipif(not fvtk.have_vtk or not fvtk.have_vtk_colors or skip_it)
 @xvfb_it
-@npt.dec.skipif(not fvtk.have_vtk)
-@npt.dec.skipif(not fvtk.have_vtk_colors)
 def test_fvtk_ellipsoid():
 
     evals = np.array([1.4, .35, .35]) * 10 ** (-3)

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -9,10 +9,19 @@ from dipy.tracking.streamline import center_streamlines, transform_streamlines
 from dipy.align.tests.test_streamlinear import fornix_streamlines
 from dipy.testing.decorators import xvfb_it
 
-run_test = actor.have_vtk and actor.have_vtk_colors and window.have_imread
+use_xvfb = os.environ.get('TEST_WITH_XVFB', False)
+if use_xvfb == 'skip':
+    skip_it = True
+else:
+    skip_it = False
+
+run_test = (actor.have_vtk and
+            actor.have_vtk_colors and
+            window.have_imread and
+            not skip_it)
 
 if actor.have_vtk:
-    if actor.major_version == 5 and os.environ.get('TEST_WITH_XVFB', False):
+    if actor.major_version == 5 and use_xvfb:
         skip_slicer = True
     else:
         skip_slicer = False
@@ -148,8 +157,8 @@ def test_slicer():
                            np.array(slicer.shape))
 
 
-@xvfb_it
 @npt.dec.skipif(not run_test)
+@xvfb_it
 def test_streamtube_and_line_actors():
     renderer = window.renderer()
 


### PR DESCRIPTION
This seems (just) a bit more civilized than my previous kludge. 