### PR TITLE
BF: fix shebang lines for scripts

### DIFF
--- a/bin/dipy_fit_tensor
+++ b/bin/dipy_fit_tensor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 from __future__ import division, print_function, absolute_import
 
 import os

--- a/bin/dipy_peak_extraction
+++ b/bin/dipy_peak_extraction
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!python
 
 import nibabel as nib
 import numpy as np

--- a/bin/dipy_quickbundles
+++ b/bin/dipy_quickbundles
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!python
 from dipy.fixes import argparse as arg
 import os
 import warnings 

--- a/bin/dipy_sh_estimate
+++ b/bin/dipy_sh_estimate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!python
 
 import nibabel as nib
 import numpy as np

--- a/bin/dipy_tracking_gui
+++ b/bin/dipy_tracking_gui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 import sys
 import pickle
 from dipy.tracking.gui_tools import gui_track


### PR DESCRIPTION
Scripts should have shebang line "#!python" for correct installation
from e.g. pip.