### PR TITLE
MRG: pull in discarded changes from maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
     - 3.2
     - 3.3
     - 3.4
+    - 3.5
 matrix:
   include:
     - python: 2.7
@@ -53,6 +54,8 @@ before_install:
     - virtualenv $VENV_ARGS venv
     - source venv/bin/activate
     - python --version # just to check
+    # Needed for Python 3.5 wheel fetching
+    - pip install -U pip
     - retry pip install nose;
     - wheelhouse_pip_install $DEPENDS;
     - if [ "${COVERAGE}" == "1" ]; then

--- a/dipy/utils/tests/test_tripwire.py
+++ b/dipy/utils/tests/test_tripwire.py
@@ -1,0 +1,29 @@
+""" Testing tripwire module.
+"""
+
+from ..tripwire import TripWire, is_tripwire, TripWireError
+
+from nose import SkipTest
+from nose.tools import (assert_true, assert_false, assert_raises,
+                        assert_equal, assert_not_equal)
+
+
+def test_is_tripwire():
+    assert_false(is_tripwire(object()))
+    assert_true(is_tripwire(TripWire('some message')))
+
+
+def test_tripwire():
+    # Test tripwire object
+    silly_module_name = TripWire('We do not have silly_module_name')
+    assert_raises(TripWireError,
+                  getattr,
+                  silly_module_name,
+                  'do_silly_thing')
+    # Check AttributeError can be checked too
+    try:
+        silly_module_name.__wrapped__
+    except TripWireError as err:
+        assert_true(isinstance(err, AttributeError))
+    else:
+        raise RuntimeError("No error raised, but expected")

--- a/dipy/utils/tripwire.py
+++ b/dipy/utils/tripwire.py
@@ -1,7 +1,7 @@
 """ Class to raise error for missing modules or other misfortunes
 """
 
-class TripWireError(Exception):
+class TripWireError(AttributeError):
     """ Exception if trying to use TripWire object """
 
 

--- a/tools/travis_tools.sh
+++ b/tools/travis_tools.sh
@@ -1,5 +1,6 @@
 # Tools for working with travis-ci
-export WHEELHOUSE="http://travis-wheels.scikit-image.org/"
+export WHEELHOST="travis-wheels.scikit-image.org"
+export WHEELHOUSE="http://${WHEELHOST}/"
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804
@@ -21,5 +22,5 @@ retry () {
 
 wheelhouse_pip_install() {
     # Install pip requirements via travis wheelhouse
-    retry pip install --timeout=60 --no-index --find-links $WHEELHOUSE $@
+    retry pip install --timeout=60 --no-index --trusted-host $WHEELHOST --find-links $WHEELHOUSE $@
 }


### PR DESCRIPTION
I was puzzled to see that current master doesn't have the `Tripwire` fixes
Ariel did on the maintenance branch.

After a bit of debugging, I think what happened is you (Ariel) did a ``git
merge -s ours`` on the maintenance branch, at merge commit 6d31467 .  This has
the effect of marking that part of the maintenance history as known, but
throwing away the changes from the maintenance branch.  It's the right thing to
do if you are making changes you *don't* want in mainline, but the wrong thing
to do if you do want the changes.

I don't know how to undo that in a nice way, so I just cherry-picked back the
relevant commits.