### PR TITLE
MRG: refactor and test setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __config__.py
 .DS_Store
 .coverage
 .buildbot.patch
+.eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ pyx-stamps
 __config__.py
 .DS_Store
 .coverage
+.buildbot.patch

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     global:
         - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt"
         - VENV_ARGS="--python=python"
+        - INSTALL_TYPE="setup"
 python:
     - 2.6
     - 3.2
@@ -49,6 +50,16 @@ matrix:
         - LIBGL_ALWAYS_INDIRECT=y
         - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
         - TEST_WITH_XVFB=true
+    - python: 2.7
+      env:
+        - INSTALL_TYPE=sdist
+    - python: 2.7
+      env:
+        - INSTALL_TYPE=wheel
+    - python: 2.7
+      env:
+        - INSTALL_TYPE=requirements
+        - DEPENDS=
 before_install:
     - source tools/travis_tools.sh
     - virtualenv $VENV_ARGS venv
@@ -69,7 +80,21 @@ before_install:
           retry pip install xvfbwrapper;
       fi
 install:
-    - python setup.py install
+    - |
+      if [ "$INSTALL_TYPE" == "setup" ]; then
+          python setup.py install
+      elif [ "$INSTALL_TYPE" == "sdist" ]; then
+        python setup_egg.py egg_info  # check egg_info while we're here
+        python setup_egg.py sdist
+        wheelhouse_pip_install dist/*.tar.gz
+      elif [ "$INSTALL_TYPE" == "wheel" ]; then
+        pip install wheel
+        python setup_egg.py bdist_wheel
+        wheelhouse_pip_install dist/*.whl
+      elif [ "$INSTALL_TYPE" == "requirements" ]; then
+        wheelhouse_pip_install -r requirements.txt
+        python setup.py install
+      fi
 # command to run tests, e.g. python setup.py test
 script:
     # Change into an innocuous directory and find tests from installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
     - python: 2.7
       env:
         - COVERAGE=1
+        # Check these values against requirements.txt and dipy/info.py
         - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==1.2.0"
     - python: 2.7
       env:

--- a/cythexts.py
+++ b/cythexts.py
@@ -94,6 +94,8 @@ def cyproc_exts(exts, cython_min_version,
         Can be ``build_ext`` input (if we have good c files) or cython
         ``build_ext`` if we have a good cython, or a class raising an informative
         error on ``run()``
+    need_cython : bool
+        True if we need Cython to build extensions, False otherwise.
     """
     if stamped_pyx_ok(exts, hash_stamps_fname):
         # Replace pyx with c files, use standard builder
@@ -106,7 +108,7 @@ def cyproc_exts(exts, cython_min_version,
                 else:
                     sources.append(source)
             mod.sources = sources
-        return build_ext
+        return build_ext, False
     # We need cython
     try:
         from Cython.Compiler.Version import version as cyversion
@@ -114,14 +116,14 @@ def cyproc_exts(exts, cython_min_version,
         return derror_maker(build_ext,
                             'Need cython>={0} to build extensions '
                             'but cannot import "Cython"'.format(
-                            cython_min_version))
+                            cython_min_version)), True
     if LooseVersion(cyversion) >= cython_min_version:
         from Cython.Distutils import build_ext as extbuilder
-        return extbuilder
+        return extbuilder, True
     return derror_maker(build_ext,
                         'Need cython>={0} to build extensions'
                         'but found cython version {1}'.format(
-                        cython_min_version, cyversion))
+                        cython_min_version, cyversion)), True
 
 
 def build_stamp(pyxes, include_dirs=()):

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -78,7 +78,8 @@ under the GPL license.
 """
 
 # versions for dependencies
-NUMPY_MIN_VERSION='1.6'
+# Check these versions against .travis.yml and requirements.txt
+NUMPY_MIN_VERSION='1.7.1'
 SCIPY_MIN_VERSION='0.9'
 CYTHON_MIN_VERSION='0.18'
 NIBABEL_MIN_VERSION='1.2.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy>=1.6
+# Check against .travis.yml file and dipy/info.py
+numpy>=1.7.1
 scipy>=0.9
 cython>=0.18
 nibabel>=1.2

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,12 @@ import numpy as np
 import os
 import sys
 from copy import deepcopy
-from os.path import join as pjoin, dirname
+from os.path import join as pjoin, dirname, exists
 from glob import glob
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
-if os.path.exists('MANIFEST'): os.remove('MANIFEST')
-
-
-# Get version and release info, which is all stored in dipy/info.py
-ver_file = os.path.join('dipy', 'info.py')
-# Use exec for compabibility with Python 3
-exec(open(ver_file).read())
+if exists('MANIFEST'): os.remove('MANIFEST')
 
 # force_setuptools can be set from the setup_egg.py script
 if not 'force_setuptools' in globals():
@@ -31,50 +25,49 @@ if not 'force_setuptools' in globals():
 if force_setuptools:
     import setuptools
 
-# We may just have imported setuptools, or we may have been exec'd from a
-# setuptools environment like pip
-if 'setuptools' in sys.modules:
-    # Try to preempt setuptools monkeypatching of Extension handling when Pyrex
-    # is missing.  Otherwise the monkeypatched Extension will change .pyx
-    # filenames to .c filenames, and we probably don't have the .c files.
-    sys.path.insert(0, pjoin(dirname(__file__), 'fake_pyrex'))
-    # Set setuptools extra arguments
-    nibabel_spec = 'nibabel>=' + NIBABEL_MIN_VERSION
-    extra_setuptools_args = dict(
-        tests_require=['nose'],
-        test_suite='nose.collector',
-        zip_safe=False,
-        extras_require = dict(
-            doc=['Sphinx>=1.0'],
-            test=['nose>=0.10.1']),
-        install_requires = [nibabel_spec])
-    # I removed numpy and scipy from install requires because easy_install seems
-    # to want to fetch these if they are already installed, meaning of course
-    # that there's a long fragile and unnecessary compile before the install
-    # finishes.
-    # We need setuptools install command because we're going to override it
-    # further down.  Using distutils install command causes some confusion, due
-    # to the Pyrex / setuptools hack above (force_setuptools)
-    from setuptools.command import install
-    # If running setuptools and nibabel is not installed, we have to force
-    # setuptools to install nibabel locally for the script to continue.  This
-    # hack is from
-    # http://stackoverflow.com/questions/12060925/best-way-to-share-code-across-several-setup-py-scripts
-    # with thanks
-    from setuptools.dist import Distribution
-    Distribution(dict(setup_requires=nibabel_spec))
-else:
-    extra_setuptools_args = {}
-    from distutils.command import install
-
 # Import distutils _after_ potential setuptools import above, and after removing
 # MANIFEST
 from distutils.core import setup
 from distutils.extension import Extension
 from distutils.command import build_py, build_ext
 
+import cythexts
 from cythexts import cyproc_exts, get_pyx_sdist, derror_maker
-from setup_helpers import install_scripts_bat, add_flag_checking
+from setup_helpers import (install_scripts_bat, add_flag_checking,
+                           get_pkg_version, version_error_msg, read_vars_from)
+
+# Get version and release info, which is all stored in dipy/info.py
+info = read_vars_from(pjoin('dipy', 'info.py'))
+
+# We may just have imported setuptools, or we may have been exec'd from a
+# setuptools environment like pip
+using_setuptools = 'setuptools' in sys.modules
+extra_setuptools_args = {}
+if using_setuptools:
+    # Try to preempt setuptools monkeypatching of Extension handling when Pyrex
+    # is missing.  Otherwise the monkeypatched Extension will change .pyx
+    # filenames to .c filenames, and we probably don't have the .c files.
+    sys.path.insert(0, pjoin(dirname(__file__), 'fake_pyrex'))
+    # Set setuptools extra arguments
+    extra_setuptools_args = dict(
+        tests_require=['nose'],
+        test_suite='nose.collector',
+        zip_safe=False,
+        extras_require = dict(
+            doc=['Sphinx>=1.0'],
+            test=['nose>=0.10.1']))
+    # I removed numpy and scipy from install requires because easy_install seems
+    # to want to fetch these if they are already installed, meaning of course
+    # that there's a long fragile and unnecessary compile before the install
+    # finishes.
+    # If running setuptools and nibabel is not installed, we have to force
+    # setuptools to install nibabel locally for the script to continue.  This
+    # hack is from
+    # http://stackoverflow.com/questions/12060925/best-way-to-share-code-across-several-setup-py-scripts
+    # with thanks
+    from setuptools.dist import Distribution
+    nibabel_spec = 'nibabel>=' + info.NIBABEL_MIN_VERSION
+    Distribution(dict(setup_requires=nibabel_spec))
 
 # Define extensions
 EXTS = []
@@ -121,20 +114,21 @@ for modulename, other_sources, language in (
 # We need to set up tripwires to raise errors when actually doing things, like
 # building, rather than unconditionally in the setup.py import or exec
 # We may make tripwire versions of build_ext, build_py, install
+need_cython = True
 try:
-    from nisext.sexts import package_check, get_comrec_build
+    from nisext.sexts import get_comrec_build
 except ImportError: # No nibabel
     msg = ('Need nisext package from nibabel installation'
            ' - please install nibabel first')
     pybuilder = derror_maker(build_py.build_py, msg)
     extbuilder = derror_maker(build_ext.build_ext, msg)
-    def package_check(*args, **kwargs):
-        raise RuntimeError(msg + " or try 'python setup_egg.py install'")
 else: # We have nibabel
     pybuilder = get_comrec_build('dipy')
     # Cython is a dependency for building extensions, iff we don't have stamped
     # up pyx and c files.
-    build_ext = cyproc_exts(EXTS, CYTHON_MIN_VERSION, 'pyx-stamps')
+    build_ext = cyproc_exts(EXTS, info.CYTHON_MIN_VERSION, 'pyx-stamps')
+    # build_ext is default when we don't need cython
+    need_cython = not build_ext is cythexts.build_ext
     # Add openmp flags if they work
     simple_test_c = """int main(int argc, char** argv) { return(0); }"""
     omp_test_c = """#include <omp.h>
@@ -144,39 +138,53 @@ else: # We have nibabel
             [['-msse2', '-mfpmath=sse'], [], simple_test_c, 'USING_GCC_SSE2'],
             [['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP']], 'dipy')
 
-# Installer that checks for install-time dependencies
-class installer(install.install):
-    def run(self):
-        package_check('numpy', NUMPY_MIN_VERSION)
-        package_check('scipy', SCIPY_MIN_VERSION)
-        package_check('nibabel', NIBABEL_MIN_VERSION)
-        install.install.run(self)
+# Hard and soft dependency checking
+# pkg_import_name, version_str, setuptools_field, heavy_yes_no
+cython_dep = ((('Cython', info.CYTHON_MIN_VERSION, 'setup_requires', False),)
+              if need_cython else ())
+DEPS = (
+    (('numpy', info.NUMPY_MIN_VERSION, 'setup_requires', True),) +
+    cython_dep +
+    (('scipy', info.SCIPY_MIN_VERSION, 'install_requires', True),
+     ('nibabel', info.NIBABEL_MIN_VERSION, 'install_requires', False)))
+
+for name, min_ver, req_type, heavy in DEPS:
+    found_ver = get_pkg_version(name)
+    ver_err_msg = version_error_msg(name, found_ver, min_ver)
+    if not using_setuptools:
+        if ver_err_msg != None:
+            raise RuntimeError(ver_err_msg)
+    else:  # Using setuptools
+        # Add packages to given section of setup/install_requires
+        if ver_err_msg != None or not heavy:
+            new_req = '{0}>={1}'.format(name, min_ver)
+            old_reqs = extra_setuptools_args.get(req_type, [])
+            extra_setuptools_args[req_type] = old_reqs + [new_req]
 
 
 cmdclass = dict(
     build_py=pybuilder,
     build_ext=extbuilder,
-    install=installer,
     install_scripts=install_scripts_bat,
     sdist=get_pyx_sdist(include_dirs=['src']))
 
 
 def main(**extra_args):
-    setup(name=NAME,
-          maintainer=MAINTAINER,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          long_description=LONG_DESCRIPTION,
-          url=URL,
-          download_url=DOWNLOAD_URL,
-          license=LICENSE,
-          classifiers=CLASSIFIERS,
-          author=AUTHOR,
-          author_email=AUTHOR_EMAIL,
-          platforms=PLATFORMS,
-          version=VERSION,
-          requires=REQUIRES,
-          provides=PROVIDES,
+    setup(name=info.NAME,
+          maintainer=info.MAINTAINER,
+          maintainer_email=info.MAINTAINER_EMAIL,
+          description=info.DESCRIPTION,
+          long_description=info.LONG_DESCRIPTION,
+          url=info.URL,
+          download_url=info.DOWNLOAD_URL,
+          license=info.LICENSE,
+          classifiers=info.CLASSIFIERS,
+          author=info.AUTHOR,
+          author_email=info.AUTHOR_EMAIL,
+          platforms=info.PLATFORMS,
+          version=info.VERSION,
+          requires=info.REQUIRES,
+          provides=info.PROVIDES,
           packages     = ['dipy',
                           'dipy.tests',
                           'dipy.align',

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ if force_setuptools:
 # MANIFEST
 from distutils.core import setup
 from distutils.extension import Extension
-from distutils.command import build_py, build_ext
+from distutils.command.build_py import build_py as du_build_py
+from distutils.command.build_ext import build_ext as du_build_ext
 
-import cythexts
 from cythexts import cyproc_exts, get_pyx_sdist, derror_maker
 from setup_helpers import (install_scripts_bat, add_flag_checking,
                            get_pkg_version, version_error_msg, read_vars_from)
@@ -120,15 +120,15 @@ try:
 except ImportError: # No nibabel
     msg = ('Need nisext package from nibabel installation'
            ' - please install nibabel first')
-    pybuilder = derror_maker(build_py.build_py, msg)
-    extbuilder = derror_maker(build_ext.build_ext, msg)
+    pybuilder = derror_maker(du_build_py, msg)
+    extbuilder = derror_maker(du_build_ext, msg)
 else: # We have nibabel
     pybuilder = get_comrec_build('dipy')
     # Cython is a dependency for building extensions, iff we don't have stamped
     # up pyx and c files.
     build_ext = cyproc_exts(EXTS, info.CYTHON_MIN_VERSION, 'pyx-stamps')
     # build_ext is default when we don't need cython
-    need_cython = not build_ext is cythexts.build_ext
+    need_cython = build_ext is not du_build_ext
     # Add openmp flags if they work
     simple_test_c = """int main(int argc, char** argv) { return(0); }"""
     omp_test_c = """#include <omp.h>

--- a/setup.py
+++ b/setup.py
@@ -126,9 +126,9 @@ else: # We have nibabel
     pybuilder = get_comrec_build('dipy')
     # Cython is a dependency for building extensions, iff we don't have stamped
     # up pyx and c files.
-    build_ext = cyproc_exts(EXTS, info.CYTHON_MIN_VERSION, 'pyx-stamps')
-    # build_ext is default when we don't need cython
-    need_cython = build_ext is not du_build_ext
+    build_ext, need_cython = cyproc_exts(EXTS,
+                                         info.CYTHON_MIN_VERSION,
+                                         'pyx-stamps')
     # Add openmp flags if they work
     simple_test_c = """int main(int argc, char** argv) { return(0); }"""
     omp_test_c = """#include <omp.h>

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -2,6 +2,7 @@
 
 '''
 import os
+import sys
 from os.path import join as pjoin, split as psplit, splitext, dirname, exists
 import tempfile
 import shutil
@@ -226,6 +227,75 @@ def version_error_msg(pkg_name, found_ver, min_ver):
         return None
     return 'We need {0} version {1}, but found version {2}'.format(
         pkg_name, found_ver, min_ver)
+
+
+class SetupDependency(object):
+    """ SetupDependency class
+
+    Parameters
+    ----------
+    import_name : str
+        Name with which required package should be ``import``ed.
+    min_ver : str
+        Distutils version string giving minimum version for package.
+    req_type : {'install_requires', 'setup_requires'}, optional
+        Setuptools dependency type.
+    heavy : {False, True}, optional
+        If True, and package is already installed (importable), then do not add
+        to the setuptools dependency lists.  This prevents setuptools
+        reinstalling big packages when the package was installed without using
+        setuptools, or this is an upgrade, and we want to avoid the pip default
+        behavior of upgrading all dependencies.
+    install_name : str, optional
+        Name identifying package to install from pypi etc, if different from
+        `import_name`.
+    """
+
+    def __init__(self, import_name,
+                 min_ver,
+                 req_type='install_requires',
+                 heavy=False,
+                 install_name=None):
+        self.import_name = import_name
+        self.min_ver = min_ver
+        self.req_type = req_type
+        self.heavy = heavy
+        self.install_name = (import_name if install_name is None
+                             else install_name)
+
+    def check_fill(self, setuptools_kwargs):
+        """ Process this dependency, maybe filling `setuptools_kwargs`
+
+        Run checks on this dependency.  If not using setuptools, then raise
+        error for unmet dependencies.  If using setuptools, add missing or
+        not-heavy dependencies to `setuptools_kwargs`.
+
+        A heavy dependency is one that is inconvenient to install
+        automatically, such as numpy or (particularly) scipy, matplotlib.
+
+        Parameters
+        ----------
+        setuptools_kwargs : dict
+            Dictionary of setuptools keyword arguments that may be modified
+            in-place while checking dependencies.
+        """
+        found_ver = get_pkg_version(self.import_name)
+        ver_err_msg = version_error_msg(self.import_name,
+                                        found_ver,
+                                        self.min_ver)
+        if not 'setuptools' in sys.modules:
+            # Not using setuptools; raise error for any unmet dependencies
+            if ver_err_msg is not None:
+                raise RuntimeError(ver_err_msg)
+            return
+        # Using setuptools; add packages to given section of
+        # setup/install_requires, unless it's a heavy dependency for which we
+        # already have an acceptable importable version.
+        if self.heavy and ver_err_msg:
+            return
+        new_req = '{0}>={1}'.format(self.import_name, self.min_ver)
+        old_reqs = setuptools_kwargs.get(self.req_type, [])
+        setuptools_kwargs[self.req_type] = old_reqs + [new_req]
 
 
 class Bunch(object):


### PR DESCRIPTION
Refactor setup.py to work better with pip.  Allow setuptools / pip installs
into systems that don't have Cython (Cython gets installed automatically).

Update requirements in requirements.txt file and info.py.

Check installation via sdist and wheels.