### PR TITLE
RF: Convert nan values in bvectors to 0's

### DIFF
--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -134,11 +134,11 @@ def gradient_table_from_bvals_bvecs(bvals, bvecs, b0_threshold=0, atol=1e-2,
                          "respectively, where N is the number of diffusion "
                          "gradients")
 
+    bvecs[np.isnan(bvecs)] = 0
     bvecs_close_to_1 = abs(vector_norm(bvecs) - 1) <= atol
     if bvecs.shape[1] != 3 or not np.all(bvecs_close_to_1[dwi_mask]):
         raise ValueError("bvecs should be (N, 3), a set of N unit vectors")
 
-    bvecs = np.where(bvecs_close_to_1[:, None], bvecs, 0)
     bvals = bvals * bvecs_close_to_1
     gradients = bvals[:, None] * bvecs
 

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -243,7 +243,7 @@ def gradient_table(bvals, bvecs=None, big_delta=None, small_delta=None,
                              " array containing both bvals and bvecs")
     else:
         bvecs = np.asarray(bvecs)
-        if (bvecs.shape[1] > bvecs.shape[0]) and bvecs.shape[0] > 1:
+        if (bvecs.shape[1] > bvecs.shape[0])  and bvecs.shape[0] > 1:
             bvecs = bvecs.T
     return gradient_table_from_bvals_bvecs(bvals, bvecs, big_delta=big_delta,
                                            small_delta=small_delta,

--- a/dipy/core/gradients.py
+++ b/dipy/core/gradients.py
@@ -134,11 +134,12 @@ def gradient_table_from_bvals_bvecs(bvals, bvecs, b0_threshold=0, atol=1e-2,
                          "respectively, where N is the number of diffusion "
                          "gradients")
 
-    bvecs[np.isnan(bvecs)] = 0
+    bvecs = np.where(np.isnan(bvecs), 0, bvecs)
     bvecs_close_to_1 = abs(vector_norm(bvecs) - 1) <= atol
     if bvecs.shape[1] != 3 or not np.all(bvecs_close_to_1[dwi_mask]):
         raise ValueError("bvecs should be (N, 3), a set of N unit vectors")
 
+    bvecs = np.where(bvecs_close_to_1[:, None], bvecs, 0)
     bvals = bvals * bvecs_close_to_1
     gradients = bvals[:, None] * bvecs
 

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -1,5 +1,6 @@
-from nose.tools import assert_true, assert_raises
+import warnings
 
+from nose.tools import assert_true, assert_raises
 import numpy as np
 import numpy.testing as npt
 
@@ -247,6 +248,13 @@ def test_reorient_bvecs():
     # Verify that giving the wrong number of affines raises an error:
     full_affines.append(np.zeros((4, 4)))
     assert_raises(ValueError, reorient_bvecs, gt_rot, full_affines)
+
+
+def test_nan_bvecs():
+    fdata, fbvals, fbvecs = get_data()
+    with warnings.catch_warnings(True) as w:
+        gtab = gradient_table(fbvals, fbvecs)
+        npt.assert_(len(w) == 0)
 
 
 if __name__ == "__main__":

--- a/dipy/core/tests/test_gradients.py
+++ b/dipy/core/tests/test_gradients.py
@@ -251,8 +251,15 @@ def test_reorient_bvecs():
 
 
 def test_nan_bvecs():
+    """
+    Test that the presence of nan's in b-vectors doesn't raise warnings.
+
+    In previous versions, the presence of NaN in b-vectors was taken to
+    indicate a 0 b-value, but also raised a warning when testing for the length
+    of these vectors. This checks that it doesn't happen.
+    """
     fdata, fbvals, fbvecs = get_data()
-    with warnings.catch_warnings(True) as w:
+    with warnings.catch_warnings(record=True) as w:
         gtab = gradient_table(fbvals, fbvecs)
         npt.assert_(len(w) == 0)
 


### PR DESCRIPTION
This get's rid of warnings of the following type that currently show up
in our tests:

    ./Users/arokem/source/dipy/dipy/core/gradients.py:132: RuntimeWarning: invalid value encountered in less_equal
  bvecs_close_to_1 = abs(vector_norm(bvecs) - 1) <= atol