### PR TITLE
BF: revert accidentally committed COMMIT_INFO.txt

### DIFF
--- a/dipy/COMMIT_INFO.txt
+++ b/dipy/COMMIT_INFO.txt
@@ -1,3 +1,6 @@
+# This is an ini file that may contain information about the code state
 [commit hash]
-archive_subst_hash = $Format:%h$
-install_hash = 439dcc7
+# The line below may contain a valid hash if it has been substituted during 'git archive'
+archive_subst_hash=$Format:%h$
+# This line may be modified by the install process
+install_hash=


### PR DESCRIPTION
COMMIT_INFO.txt should be a template for the install, but the written
out instance of the template got committed back in commit c3a8f3f.