### PR TITLE
Return numpy arrays instead of memory views from cython functions

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -145,7 +145,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static, floating[:, :, :] moving,
                         Imean * sums[SI] + sums[CNT] * Imean * Imean)
                     factors[s, r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                         Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return factors
+    return np.array(factors)
 
 
 @cython.boundscheck(False)
@@ -200,7 +200,7 @@ def precompute_cc_factors_3d_test(floating[:, :, :] static,
                         Imean * sums[SI] + sums[CNT] * Imean * Imean)
                     factors[s, r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                         Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return factors
+    return np.array(factors)
 
 
 @cython.boundscheck(False)
@@ -272,7 +272,7 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
                     out[s, r, c, 0] -= temp * grad_static[s, r, c, 0]
                     out[s, r, c, 1] -= temp * grad_static[s, r, c, 1]
                     out[s, r, c, 2] -= temp * grad_static[s, r, c, 2]
-    return out, energy
+    return np.array(out), energy
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -346,7 +346,7 @@ def compute_cc_backward_step_3d(floating[:, :, :, :] grad_moving,
                     out[s, r, c, 0] -= temp * grad_moving[s, r, c, 0]
                     out[s, r, c, 1] -= temp * grad_moving[s, r, c, 1]
                     out[s, r, c, 2] -= temp * grad_moving[s, r, c, 2]
-    return out, energy
+    return np.array(out), energy
 
 
 @cython.boundscheck(False)
@@ -460,7 +460,7 @@ def precompute_cc_factors_2d(floating[:, :] static, floating[:, :] moving,
                     Imean * sums[SI] + sums[CNT] * Imean * Imean)
                 factors[r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                     Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return factors
+    return np.array(factors)
 
 
 @cython.boundscheck(False)
@@ -510,7 +510,7 @@ def precompute_cc_factors_2d_test(floating[:, :] static, floating[:, :] moving,
                     Imean * sums[SI] + sums[CNT] * Imean * Imean)
                 factors[r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                     Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return factors
+    return np.array(factors)
 
 
 @cython.boundscheck(False)
@@ -584,7 +584,7 @@ def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
                 temp = 2.0 * sfm / (sff * smm) * (Ji - sfm / sff * Ii)
                 out[r, c, 0] -= temp * grad_static[r, c, 0]
                 out[r, c, 1] -= temp * grad_static[r, c, 1]
-    return out, energy
+    return np.array(out), energy
 
 
 @cython.boundscheck(False)
@@ -652,4 +652,4 @@ def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
                 temp = 2.0 * sfm / (sff * smm) * (Ii - sfm / smm * Ji)
                 out[r, c, 0] -= temp * grad_moving[r, c, 0]
                 out[r, c, 1] -= temp * grad_moving[r, c, 1]
-    return out, energy
+    return np.array(out), energy

--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -145,7 +145,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static, floating[:, :, :] moving,
                         Imean * sums[SI] + sums[CNT] * Imean * Imean)
                     factors[s, r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                         Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return np.array(factors)
+    return np.asarray(factors)
 
 
 @cython.boundscheck(False)
@@ -200,7 +200,7 @@ def precompute_cc_factors_3d_test(floating[:, :, :] static,
                         Imean * sums[SI] + sums[CNT] * Imean * Imean)
                     factors[s, r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                         Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return np.array(factors)
+    return np.asarray(factors)
 
 
 @cython.boundscheck(False)
@@ -272,7 +272,7 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
                     out[s, r, c, 0] -= temp * grad_static[s, r, c, 0]
                     out[s, r, c, 1] -= temp * grad_static[s, r, c, 1]
                     out[s, r, c, 2] -= temp * grad_static[s, r, c, 2]
-    return np.array(out), energy
+    return np.asarray(out), energy
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -346,7 +346,7 @@ def compute_cc_backward_step_3d(floating[:, :, :, :] grad_moving,
                     out[s, r, c, 0] -= temp * grad_moving[s, r, c, 0]
                     out[s, r, c, 1] -= temp * grad_moving[s, r, c, 1]
                     out[s, r, c, 2] -= temp * grad_moving[s, r, c, 2]
-    return np.array(out), energy
+    return np.asarray(out), energy
 
 
 @cython.boundscheck(False)
@@ -460,7 +460,7 @@ def precompute_cc_factors_2d(floating[:, :] static, floating[:, :] moving,
                     Imean * sums[SI] + sums[CNT] * Imean * Imean)
                 factors[r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                     Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return np.array(factors)
+    return np.asarray(factors)
 
 
 @cython.boundscheck(False)
@@ -510,7 +510,7 @@ def precompute_cc_factors_2d_test(floating[:, :] static, floating[:, :] moving,
                     Imean * sums[SI] + sums[CNT] * Imean * Imean)
                 factors[r, c, 4] = (sums[SJ2] - Jmean * sums[SJ] -
                     Jmean * sums[SJ] + sums[CNT] * Jmean * Jmean)
-    return np.array(factors)
+    return np.asarray(factors)
 
 
 @cython.boundscheck(False)
@@ -584,7 +584,7 @@ def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
                 temp = 2.0 * sfm / (sff * smm) * (Ji - sfm / sff * Ii)
                 out[r, c, 0] -= temp * grad_static[r, c, 0]
                 out[r, c, 1] -= temp * grad_static[r, c, 1]
-    return np.array(out), energy
+    return np.asarray(out), energy
 
 
 @cython.boundscheck(False)
@@ -652,4 +652,4 @@ def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
                 temp = 2.0 * sfm / (sff * smm) * (Ii - sfm / smm * Ji)
                 out[r, c, 0] -= temp * grad_moving[r, c, 0]
                 out[r, c, 1] -= temp * grad_moving[r, c, 1]
-    return np.array(out), energy
+    return np.asarray(out), energy

--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -109,7 +109,7 @@ def quantize_positive_2d(floating[:, :] v, int num_levels):
                     out[i, j] = 0
                     hist[0] += 1
 
-    return out, levels, hist
+    return np.array(out), np.array(levels), np.array(hist)
 
 
 def quantize_positive_3d(floating[:, :, :] v, int num_levels):
@@ -209,7 +209,7 @@ def quantize_positive_3d(floating[:, :, :] v, int num_levels):
                     else:
                         out[k, i, j] = 0
                         hist[0] += 1
-    return out, levels, hist
+    return np.array(out), np.array(levels), np.array(hist)
 
 
 def compute_masked_class_stats_2d(int[:, :] mask, floating[:, :] v,
@@ -276,7 +276,7 @@ def compute_masked_class_stats_2d(int[:, :] mask, floating[:, :] v,
                 variances[i] /= counts[i]
             else:
                 variances[i] = INF64
-    return means, variances
+    return np.array(means), np.array(variances)
 
 
 def compute_masked_class_stats_3d(int[:, :, :] mask, floating[:, :, :] v,
@@ -345,7 +345,7 @@ def compute_masked_class_stats_3d(int[:, :, :] mask, floating[:, :, :] v,
                 variances[i] /= counts[i]
             else:
                 variances[i] = INF64
-    return means, variances
+    return np.array(means), np.array(variances)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -441,7 +441,7 @@ def compute_em_demons_step_2d(floating[:,:] delta_field,
                         prod = sigma_sq_x * delta
                         out[i, j, 0] = prod * gradient_moving[i, j, 0] / den
                         out[i, j, 1] = prod * gradient_moving[i, j, 1] / den
-    return out, energy
+    return np.array(out), energy
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -549,4 +549,4 @@ def compute_em_demons_step_3d(floating[:,:,:] delta_field,
                                 gradient_moving[k, i, j, 1] / den)
                             out[k, i, j, 2] = (sigma_sq_x * delta *
                                 gradient_moving[k, i, j, 2] / den)
-    return out, energy
+    return np.array(out), energy

--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -109,7 +109,7 @@ def quantize_positive_2d(floating[:, :] v, int num_levels):
                     out[i, j] = 0
                     hist[0] += 1
 
-    return np.array(out), np.array(levels), np.array(hist)
+    return np.asarray(out), np.array(levels), np.array(hist)
 
 
 def quantize_positive_3d(floating[:, :, :] v, int num_levels):
@@ -209,7 +209,7 @@ def quantize_positive_3d(floating[:, :, :] v, int num_levels):
                     else:
                         out[k, i, j] = 0
                         hist[0] += 1
-    return np.array(out), np.array(levels), np.array(hist)
+    return np.asarray(out), np.asarray(levels), np.asarray(hist)
 
 
 def compute_masked_class_stats_2d(int[:, :] mask, floating[:, :] v,
@@ -276,7 +276,7 @@ def compute_masked_class_stats_2d(int[:, :] mask, floating[:, :] v,
                 variances[i] /= counts[i]
             else:
                 variances[i] = INF64
-    return np.array(means), np.array(variances)
+    return np.asarray(means), np.asarray(variances)
 
 
 def compute_masked_class_stats_3d(int[:, :, :] mask, floating[:, :, :] v,
@@ -345,7 +345,7 @@ def compute_masked_class_stats_3d(int[:, :, :] mask, floating[:, :, :] v,
                 variances[i] /= counts[i]
             else:
                 variances[i] = INF64
-    return np.array(means), np.array(variances)
+    return np.asarray(means), np.asarray(variances)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -441,7 +441,7 @@ def compute_em_demons_step_2d(floating[:,:] delta_field,
                         prod = sigma_sq_x * delta
                         out[i, j, 0] = prod * gradient_moving[i, j, 0] / den
                         out[i, j, 1] = prod * gradient_moving[i, j, 1] / den
-    return np.array(out), energy
+    return np.asarray(out), energy
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -549,4 +549,4 @@ def compute_em_demons_step_3d(floating[:,:,:] delta_field,
                                 gradient_moving[k, i, j, 1] / den)
                             out[k, i, j, 2] = (sigma_sq_x * delta *
                                 gradient_moving[k, i, j, 2] / den)
-    return np.array(out), energy
+    return np.asarray(out), energy

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -502,7 +502,7 @@ def cubic_spline(double[:] x):
     with nogil:
         for i in range(n):
             sx[i] = _cubic_spline(x[i])
-    return sx
+    return np.array(sx)
 
 
 cdef inline double _cubic_spline(double x) nogil:
@@ -542,7 +542,7 @@ def cubic_spline_derivative(double[:] x):
     with nogil:
         for i in range(n):
             sx[i] = _cubic_spline_derivative(x[i])
-    return sx
+    return np.array(sx)
 
 
 cdef inline double _cubic_spline_derivative(double x) nogil:
@@ -1360,4 +1360,4 @@ def sample_domain_regular(int k, int[:] shape, double[:, :] grid2world,
                 samples[i, 0] = _apply_affine_3d_x0(s, r, c, 1, grid2world)
                 samples[i, 1] = _apply_affine_3d_x1(s, r, c, 1, grid2world)
                 samples[i, 2] = _apply_affine_3d_x2(s, r, c, 1, grid2world)
-    return samples
+    return np.array(samples)

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -502,7 +502,7 @@ def cubic_spline(double[:] x):
     with nogil:
         for i in range(n):
             sx[i] = _cubic_spline(x[i])
-    return np.array(sx)
+    return np.asarray(sx)
 
 
 cdef inline double _cubic_spline(double x) nogil:
@@ -542,7 +542,7 @@ def cubic_spline_derivative(double[:] x):
     with nogil:
         for i in range(n):
             sx[i] = _cubic_spline_derivative(x[i])
-    return np.array(sx)
+    return np.asarray(sx)
 
 
 cdef inline double _cubic_spline_derivative(double x) nogil:
@@ -1360,4 +1360,4 @@ def sample_domain_regular(int k, int[:] shape, double[:, :] grid2world,
                 samples[i, 0] = _apply_affine_3d_x0(s, r, c, 1, grid2world)
                 samples[i, 1] = _apply_affine_3d_x1(s, r, c, 1, grid2world)
                 samples[i, 2] = _apply_affine_3d_x2(s, r, c, 1, grid2world)
-    return np.array(samples)
+    return np.asarray(samples)

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -66,7 +66,7 @@ def solve_2d_symmetric_positive_definite(A, y, double det):
         <double*> cnp.PyArray_DATA(np.ascontiguousarray(y, float)),
         det,
         <double*> cnp.PyArray_DATA(out))
-    return out
+    return np.array(out)
 
 
 @cython.boundscheck(False)
@@ -154,7 +154,7 @@ def solve_3d_symmetric_positive_definite(g, y, double tau):
         <double*> cnp.PyArray_DATA(np.ascontiguousarray(y, float)),
         tau,
         <double*> cnp.PyArray_DATA(out))
-    return out, is_singular
+    return np.array(out), is_singular
 
 
 @cython.boundscheck(False)
@@ -640,7 +640,7 @@ def compute_residual_displacement_field_ssd_3d(
                         residual[s, r, c, 2] = (b[2] -
                                                 (gradient_field[s, r, c, 2] * dotP +
                                                  sigmasq * lambda_param * y[2]))
-    return residual
+    return np.array(residual)
 
 
 @cython.boundscheck(False)
@@ -742,7 +742,7 @@ cpdef compute_residual_displacement_field_ssd_2d(
                     residual[r, c, 1] = (b[1] -
                                          (gradient_field[r, c, 1] * dotP +
                                           sigmasq * lambda_param * y[1]))
-    return residual
+    return np.array(residual)
 
 
 @cython.boundscheck(False)
@@ -816,7 +816,7 @@ def compute_ssd_demons_step_2d(floating[:,:] delta_field,
                     out[i, j, 0] = delta * gradient_moving[i, j, 0] / den
                     out[i, j, 1] = delta * gradient_moving[i, j, 1] / den
 
-    return out, energy
+    return np.array(out), energy
 
 
 @cython.boundscheck(False)
@@ -898,4 +898,4 @@ def compute_ssd_demons_step_3d(floating[:,:,:] delta_field,
                                            gradient_moving[k, i, j, 1] / den)
                         out[k, i, j, 2] = (delta *
                                            gradient_moving[k, i, j, 2] / den)
-    return out, energy
+    return np.array(out), energy

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -66,7 +66,7 @@ def solve_2d_symmetric_positive_definite(A, y, double det):
         <double*> cnp.PyArray_DATA(np.ascontiguousarray(y, float)),
         det,
         <double*> cnp.PyArray_DATA(out))
-    return np.array(out)
+    return np.asarray(out)
 
 
 @cython.boundscheck(False)
@@ -154,7 +154,7 @@ def solve_3d_symmetric_positive_definite(g, y, double tau):
         <double*> cnp.PyArray_DATA(np.ascontiguousarray(y, float)),
         tau,
         <double*> cnp.PyArray_DATA(out))
-    return np.array(out), is_singular
+    return np.asarray(out), is_singular
 
 
 @cython.boundscheck(False)
@@ -640,7 +640,7 @@ def compute_residual_displacement_field_ssd_3d(
                         residual[s, r, c, 2] = (b[2] -
                                                 (gradient_field[s, r, c, 2] * dotP +
                                                  sigmasq * lambda_param * y[2]))
-    return np.array(residual)
+    return np.asarray(residual)
 
 
 @cython.boundscheck(False)
@@ -742,7 +742,7 @@ cpdef compute_residual_displacement_field_ssd_2d(
                     residual[r, c, 1] = (b[1] -
                                          (gradient_field[r, c, 1] * dotP +
                                           sigmasq * lambda_param * y[1]))
-    return np.array(residual)
+    return np.asarray(residual)
 
 
 @cython.boundscheck(False)
@@ -816,7 +816,7 @@ def compute_ssd_demons_step_2d(floating[:,:] delta_field,
                     out[i, j, 0] = delta * gradient_moving[i, j, 0] / den
                     out[i, j, 1] = delta * gradient_moving[i, j, 1] / den
 
-    return np.array(out), energy
+    return np.asarray(out), energy
 
 
 @cython.boundscheck(False)
@@ -898,4 +898,4 @@ def compute_ssd_demons_step_3d(floating[:,:,:] delta_field,
                                            gradient_moving[k, i, j, 1] / den)
                         out[k, i, j, 2] = (delta *
                                            gradient_moving[k, i, j, 2] / den)
-    return np.array(out), energy
+    return np.asarray(out), energy

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -72,7 +72,7 @@ cdef class Transform:
             raise ValueError("Invalid point dimension: %d"%(m,))
         J = np.zeros((self.dim, n))
         ret = self._jacobian(theta, x, J)
-        return J
+        return np.array(J)
 
     def get_identity_parameters(self):
         r""" Parameter values corresponding to the identity transform
@@ -86,7 +86,7 @@ cdef class Transform:
             raise ValueError("Invalid transform.")
         theta = np.zeros(self.number_of_parameters)
         self._get_identity_parameters(theta)
-        return theta
+        return np.array(theta)
 
     def param_to_matrix(self, double[:] theta):
         r""" Matrix representation of this transform with the given parameters
@@ -106,7 +106,7 @@ cdef class Transform:
             raise ValueError("Invalid number of parameters: %d"%(n,))
         T = np.eye(self.dim + 1)
         self._param_to_matrix(theta, T)
-        return T
+        return np.array(T)
 
     def get_number_of_parameters(self):
         return self.number_of_parameters

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -72,7 +72,7 @@ cdef class Transform:
             raise ValueError("Invalid point dimension: %d"%(m,))
         J = np.zeros((self.dim, n))
         ret = self._jacobian(theta, x, J)
-        return np.array(J)
+        return np.asarray(J)
 
     def get_identity_parameters(self):
         r""" Parameter values corresponding to the identity transform
@@ -86,7 +86,7 @@ cdef class Transform:
             raise ValueError("Invalid transform.")
         theta = np.zeros(self.number_of_parameters)
         self._get_identity_parameters(theta)
-        return np.array(theta)
+        return np.asarray(theta)
 
     def param_to_matrix(self, double[:] theta):
         r""" Matrix representation of this transform with the given parameters
@@ -106,7 +106,7 @@ cdef class Transform:
             raise ValueError("Invalid number of parameters: %d"%(n,))
         T = np.eye(self.dim + 1)
         self._param_to_matrix(theta, T)
-        return np.array(T)
+        return np.asarray(T)
 
     def get_number_of_parameters(self):
         return self.number_of_parameters

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -56,7 +56,7 @@ def interpolate_vector_2d(floating[:, :, :] field, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_vector_2d[floating](field,
                 locations[i, 0], locations[i, 1], out[i])
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 cdef inline int _interpolate_vector_2d(floating[:, :, :] field, double dii,
@@ -166,7 +166,7 @@ def interpolate_scalar_2d(floating[:, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_2d[floating](image,
                 locations[i, 0], locations[i, 1], &out[i])
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 cdef inline int _interpolate_scalar_2d(floating[:, :] image, double dii,
@@ -270,7 +270,7 @@ def interpolate_scalar_nn_2d(number[:, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_nn_2d[number](image,
                 locations[i, 0], locations[i, 1], &out[i])
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 cdef inline int _interpolate_scalar_nn_2d(number[:, :] image, double dii,
@@ -363,7 +363,7 @@ def interpolate_scalar_nn_3d(number[:, :, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_nn_3d[number](image,
                 locations[i, 0], locations[i, 1], locations[i, 2], &out[i])
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 cdef inline int _interpolate_scalar_nn_3d(number[:, :, :] volume, double dkk,
@@ -465,7 +465,7 @@ def interpolate_scalar_3d(floating[:, :, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_3d[floating](image,
                 locations[i, 0], locations[i, 1], locations[i, 2], &out[i])
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 cdef inline int _interpolate_scalar_3d(floating[:, :, :] volume,
@@ -598,7 +598,7 @@ def interpolate_vector_3d(floating[:, :, :, :] field, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_vector_3d[floating](field,
                 locations[i, 0], locations[i, 1], locations[i, 2], out[i])
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 cdef inline int _interpolate_vector_3d(floating[:, :, :, :] field, double dkk,
@@ -909,7 +909,7 @@ def compose_vector_fields_2d(floating[:, :, :] d1, floating[:, :, :] d2,
 
     _compose_vector_fields_2d[floating](d1, d2, premult_index, premult_disp,
                                         time_scaling, comp, stats)
-    return comp, stats
+    return np.array(comp), np.array(stats)
 
 
 cdef void _compose_vector_fields_3d(floating[:, :, :, :] d1,
@@ -1121,7 +1121,7 @@ def compose_vector_fields_3d(floating[:, :, :, :] d1, floating[:, :, :, :] d2,
 
     _compose_vector_fields_3d[floating](d1, d2, premult_index, premult_disp,
                                         time_scaling, comp, stats)
-    return comp, stats
+    return np.array(comp), np.array(stats)
 
 
 def invert_vector_field_fixed_point_2d(floating[:, :, :] d,
@@ -1225,7 +1225,7 @@ def invert_vector_field_fixed_point_2d(floating[:, :, :] d,
             iter_count += 1
         stats[0] = substats[1]
         stats[1] = iter_count
-    return p
+    return np.array(p)
 
 
 def invert_vector_field_fixed_point_3d(floating[:, :, :, :] d,
@@ -1339,7 +1339,7 @@ def invert_vector_field_fixed_point_3d(floating[:, :, :, :] d,
             iter_count += 1
         stats[0] = error
         stats[1] = iter_count
-    return p
+    return np.array(p)
 
 
 def simplify_warp_function_2d(floating[:, :, :] d,
@@ -1455,7 +1455,7 @@ def simplify_warp_function_2d(floating[:, :, :] d,
                 else:
                     out[i, j, 0] = di
                     out[i, j, 1] = dj
-    return out
+    return np.array(out)
 
 
 def simplify_warp_function_3d(floating[:, :, :, :] d,
@@ -1553,7 +1553,7 @@ def simplify_warp_function_3d(floating[:, :, :, :] d,
                             k, i, j, 1, affine_idx_in)
                         dj = _apply_affine_3d_x2(
                             k, i, j, 1, affine_idx_in)
-                        inside = _interpolate_vector_3d[floating](d, dk, di, 
+                        inside = _interpolate_vector_3d[floating](d, dk, di,
                                                                   dj, tmp)
                         dkk = tmp[0]
                         dii = tmp[1]
@@ -1582,7 +1582,7 @@ def simplify_warp_function_3d(floating[:, :, :, :] d,
                         out[k, i, j, 0] = dk
                         out[k, i, j, 1] = di
                         out[k, i, j, 2] = dj
-    return out
+    return np.array(out)
 
 
 def reorient_vector_field_2d(floating[:, :, :] d,
@@ -1709,7 +1709,7 @@ def downsample_scalar_field_3d(floating[:, :, :] field):
                 for j in range(nnc):
                     if cnt[k, i, j] > 0:
                         down[k, i, j] /= cnt[k, i, j]
-    return down
+    return np.array(down)
 
 
 def downsample_displacement_field_3d(floating[:, :, :, :] field):
@@ -1761,7 +1761,7 @@ def downsample_displacement_field_3d(floating[:, :, :, :] field):
                         down[k, i, j, 0] /= cnt[k, i, j]
                         down[k, i, j, 1] /= cnt[k, i, j]
                         down[k, i, j, 2] /= cnt[k, i, j]
-    return down
+    return np.array(down)
 
 
 def downsample_scalar_field_2d(floating[:, :] field):
@@ -1802,7 +1802,7 @@ def downsample_scalar_field_2d(floating[:, :] field):
             for j in range(nnc):
                 if cnt[i, j] > 0:
                     down[i, j] /= cnt[i, j]
-    return down
+    return np.array(down)
 
 
 def downsample_displacement_field_2d(floating[:, :, :] field):
@@ -1845,7 +1845,7 @@ def downsample_displacement_field_2d(floating[:, :, :] field):
                 if cnt[i, j] > 0:
                     down[i, j, 0] /= cnt[i, j]
                     down[i, j, 1] /= cnt[i, j]
-    return down
+    return np.array(down)
 
 
 def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
@@ -1976,7 +1976,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
                                                               dii, djj,
                                                               &warped[k,i,j])
-    return warped
+    return np.array(warped)
 
 
 def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
@@ -2042,7 +2042,7 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
                         djj = j
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
                         dii, djj, &out[k,i,j])
-    return out
+    return np.array(out)
 
 
 def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
@@ -2172,7 +2172,7 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
 
                     inside = _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
                                                        &warped[k,i,j])
-    return warped
+    return np.array(warped)
 
 
 def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
@@ -2237,7 +2237,7 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
                         djj = j
                     _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
                                                       &out[k,i,j])
-    return out
+    return np.array(out)
 
 
 def warp_2d(floating[:, :] image, floating[:, :, :] d1,
@@ -2351,7 +2351,7 @@ def warp_2d(floating[:, :] image, floating[:, :, :] d1,
                 # Interpolate the input image at the resulting location
                 _interpolate_scalar_2d[floating](image, dii, djj,
                                                  &warped[i, j])
-    return warped
+    return np.array(warped)
 
 
 def transform_2d_affine(floating[:, :] image, int[:] ref_shape,
@@ -2411,7 +2411,7 @@ def transform_2d_affine(floating[:, :] image, int[:] ref_shape,
                     djj = j
                 _interpolate_scalar_2d[floating](image, dii, djj,
                                                  &out[i, j])
-    return out
+    return np.array(out)
 
 
 def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
@@ -2525,7 +2525,7 @@ def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
                 # Interpolate the input image at the resulting location
                 _interpolate_scalar_nn_2d[number](image, dii, djj,
                                                   &warped[i, j])
-    return warped
+    return np.array(warped)
 
 
 def transform_2d_affine_nn(number[:, :] image, int[:] ref_shape,
@@ -2585,7 +2585,7 @@ def transform_2d_affine_nn(number[:, :] image, int[:] ref_shape,
                     djj = j
                 _interpolate_scalar_nn_2d[number](image, dii, djj,
                                                   &out[i, j])
-    return out
+    return np.array(out)
 
 
 def resample_displacement_field_3d(floating[:, :, :, :] field,
@@ -2630,7 +2630,7 @@ def resample_displacement_field_3d(floating[:, :, :, :] field,
                 djj = <double> j * factors[2]
                 _interpolate_vector_3d[floating](field, dkk, dii, djj,
                                                  expanded[k, i, j])
-    return expanded
+    return np.array(expanded)
 
 
 def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
@@ -2671,7 +2671,7 @@ def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
             djj = j*factors[1]
             inside = _interpolate_vector_2d[floating](field, dii, djj,
                                                       expanded[i, j])
-    return expanded
+    return np.array(expanded)
 
 
 def create_random_displacement_2d(int[:] from_shape,
@@ -2753,7 +2753,7 @@ def create_random_displacement_2d(int[:] from_shape,
             output[i, j, 0] = dii - di
             output[i, j, 1] = djj - dj
 
-    return output, int_field
+    return np.array(output), np.array(int_field)
 
 
 def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2world,
@@ -2840,7 +2840,7 @@ def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2worl
                 output[k, i, j, 1] = dii - di
                 output[k, i, j, 2] = djj - dj
 
-    return output, int_field
+    return np.array(output), np.array(int_field)
 
 
 def create_harmonic_fields_2d(cnp.npy_intp nrows, cnp.npy_intp ncols,
@@ -2890,7 +2890,7 @@ def create_harmonic_fields_2d(cnp.npy_intp nrows, cnp.npy_intp ncols,
             inv[i, j, 0] = b * np.cos(m * theta) * ii
             inv[i, j, 1] = b * np.cos(m * theta) * jj
 
-    return d, inv
+    return np.array(d), np.array(inv)
 
 
 def create_harmonic_fields_3d(int nslices, cnp.npy_intp nrows,
@@ -2949,7 +2949,7 @@ def create_harmonic_fields_3d(int nslices, cnp.npy_intp nrows,
                 inv[k, i, j, 1] = b * np.cos(m * theta) * ii
                 inv[k, i, j, 2] = b * np.cos(m * theta) * jj
 
-    return d, inv
+    return np.array(d), np.array(inv)
 
 
 def create_circle(cnp.npy_intp nrows, cnp.npy_intp ncols, cnp.npy_intp radius):
@@ -2986,7 +2986,7 @@ def create_circle(cnp.npy_intp nrows, cnp.npy_intp ncols, cnp.npy_intp radius):
                 c[i, j] = 1
             else:
                 c[i, j] = 0
-    return c
+    return np.array(c)
 
 
 def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
@@ -3030,7 +3030,7 @@ def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
                     s[k, i, j] = 1
                 else:
                     s[k, i, j] = 0
-    return s
+    return np.array(s)
 
 
 def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
@@ -3370,7 +3370,7 @@ def _sparse_gradient_2d(floating[:, :] img, double[:, :] img_world2grid,
                 dx[p] = sample_points[i, p]
 
 
-def gradient(img, img_world2grid, img_spacing, out_shape, 
+def gradient(img, img_world2grid, img_spacing, out_shape,
              out_grid2world):
     r""" Gradient of an image in physical space
 
@@ -3414,7 +3414,7 @@ def gradient(img, img_world2grid, img_spacing, out_shape,
     jd_grad(img, img_world2grid.astype(np.float64),
             img_spacing.astype(np.float64),
             out_grid2world.astype(np.float64), out, inside)
-    return out, inside
+    return np.array(out), np.array(inside)
 
 
 def sparse_gradient(img, img_world2grid, img_spacing, sample_points):
@@ -3455,4 +3455,4 @@ def sparse_gradient(img, img_world2grid, img_spacing, sample_points):
         jd_grad = _sparse_gradient_3d
     jd_grad(img, img_world2grid.astype(np.float64),
             img_spacing.astype(np.float64), sample_points, out, inside)
-    return out, inside
+    return np.array(out), np.array(inside)

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -56,7 +56,7 @@ def interpolate_vector_2d(floating[:, :, :] field, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_vector_2d[floating](field,
                 locations[i, 0], locations[i, 1], out[i])
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 cdef inline int _interpolate_vector_2d(floating[:, :, :] field, double dii,
@@ -166,7 +166,7 @@ def interpolate_scalar_2d(floating[:, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_2d[floating](image,
                 locations[i, 0], locations[i, 1], &out[i])
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 cdef inline int _interpolate_scalar_2d(floating[:, :] image, double dii,
@@ -270,7 +270,7 @@ def interpolate_scalar_nn_2d(number[:, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_nn_2d[number](image,
                 locations[i, 0], locations[i, 1], &out[i])
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 cdef inline int _interpolate_scalar_nn_2d(number[:, :] image, double dii,
@@ -363,7 +363,7 @@ def interpolate_scalar_nn_3d(number[:, :, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_nn_3d[number](image,
                 locations[i, 0], locations[i, 1], locations[i, 2], &out[i])
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 cdef inline int _interpolate_scalar_nn_3d(number[:, :, :] volume, double dkk,
@@ -465,7 +465,7 @@ def interpolate_scalar_3d(floating[:, :, :] image, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_scalar_3d[floating](image,
                 locations[i, 0], locations[i, 1], locations[i, 2], &out[i])
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 cdef inline int _interpolate_scalar_3d(floating[:, :, :] volume,
@@ -598,7 +598,7 @@ def interpolate_vector_3d(floating[:, :, :, :] field, double[:, :] locations):
         for i in range(n):
             inside[i] = _interpolate_vector_3d[floating](field,
                 locations[i, 0], locations[i, 1], locations[i, 2], out[i])
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 cdef inline int _interpolate_vector_3d(floating[:, :, :, :] field, double dkk,
@@ -909,7 +909,7 @@ def compose_vector_fields_2d(floating[:, :, :] d1, floating[:, :, :] d2,
 
     _compose_vector_fields_2d[floating](d1, d2, premult_index, premult_disp,
                                         time_scaling, comp, stats)
-    return np.array(comp), np.array(stats)
+    return np.asarray(comp), np.asarray(stats)
 
 
 cdef void _compose_vector_fields_3d(floating[:, :, :, :] d1,
@@ -1121,7 +1121,7 @@ def compose_vector_fields_3d(floating[:, :, :, :] d1, floating[:, :, :, :] d2,
 
     _compose_vector_fields_3d[floating](d1, d2, premult_index, premult_disp,
                                         time_scaling, comp, stats)
-    return np.array(comp), np.array(stats)
+    return np.asarray(comp), np.asarray(stats)
 
 
 def invert_vector_field_fixed_point_2d(floating[:, :, :] d,
@@ -1225,7 +1225,7 @@ def invert_vector_field_fixed_point_2d(floating[:, :, :] d,
             iter_count += 1
         stats[0] = substats[1]
         stats[1] = iter_count
-    return np.array(p)
+    return np.asarray(p)
 
 
 def invert_vector_field_fixed_point_3d(floating[:, :, :, :] d,
@@ -1339,7 +1339,7 @@ def invert_vector_field_fixed_point_3d(floating[:, :, :, :] d,
             iter_count += 1
         stats[0] = error
         stats[1] = iter_count
-    return np.array(p)
+    return np.asarray(p)
 
 
 def simplify_warp_function_2d(floating[:, :, :] d,
@@ -1455,7 +1455,7 @@ def simplify_warp_function_2d(floating[:, :, :] d,
                 else:
                     out[i, j, 0] = di
                     out[i, j, 1] = dj
-    return np.array(out)
+    return np.asarray(out)
 
 
 def simplify_warp_function_3d(floating[:, :, :, :] d,
@@ -1582,7 +1582,7 @@ def simplify_warp_function_3d(floating[:, :, :, :] d,
                         out[k, i, j, 0] = dk
                         out[k, i, j, 1] = di
                         out[k, i, j, 2] = dj
-    return np.array(out)
+    return np.asarray(out)
 
 
 def reorient_vector_field_2d(floating[:, :, :] d,
@@ -1709,7 +1709,7 @@ def downsample_scalar_field_3d(floating[:, :, :] field):
                 for j in range(nnc):
                     if cnt[k, i, j] > 0:
                         down[k, i, j] /= cnt[k, i, j]
-    return np.array(down)
+    return np.asarray(down)
 
 
 def downsample_displacement_field_3d(floating[:, :, :, :] field):
@@ -1761,7 +1761,7 @@ def downsample_displacement_field_3d(floating[:, :, :, :] field):
                         down[k, i, j, 0] /= cnt[k, i, j]
                         down[k, i, j, 1] /= cnt[k, i, j]
                         down[k, i, j, 2] /= cnt[k, i, j]
-    return np.array(down)
+    return np.asarray(down)
 
 
 def downsample_scalar_field_2d(floating[:, :] field):
@@ -1802,7 +1802,7 @@ def downsample_scalar_field_2d(floating[:, :] field):
             for j in range(nnc):
                 if cnt[i, j] > 0:
                     down[i, j] /= cnt[i, j]
-    return np.array(down)
+    return np.asarray(down)
 
 
 def downsample_displacement_field_2d(floating[:, :, :] field):
@@ -1845,7 +1845,7 @@ def downsample_displacement_field_2d(floating[:, :, :] field):
                 if cnt[i, j] > 0:
                     down[i, j, 0] /= cnt[i, j]
                     down[i, j, 1] /= cnt[i, j]
-    return np.array(down)
+    return np.asarray(down)
 
 
 def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
@@ -1976,7 +1976,7 @@ def warp_3d(floating[:, :, :] volume, floating[:, :, :, :] d1,
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
                                                               dii, djj,
                                                               &warped[k,i,j])
-    return np.array(warped)
+    return np.asarray(warped)
 
 
 def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
@@ -2042,7 +2042,7 @@ def transform_3d_affine(floating[:, :, :] volume, int[:] ref_shape,
                         djj = j
                     inside = _interpolate_scalar_3d[floating](volume, dkk,
                         dii, djj, &out[k,i,j])
-    return np.array(out)
+    return np.asarray(out)
 
 
 def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
@@ -2172,7 +2172,7 @@ def warp_3d_nn(number[:, :, :] volume, floating[:, :, :, :] d1,
 
                     inside = _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
                                                        &warped[k,i,j])
-    return np.array(warped)
+    return np.asarray(warped)
 
 
 def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
@@ -2237,7 +2237,7 @@ def transform_3d_affine_nn(number[:, :, :] volume, int[:] ref_shape,
                         djj = j
                     _interpolate_scalar_nn_3d[number](volume, dkk, dii, djj,
                                                       &out[k,i,j])
-    return np.array(out)
+    return np.asarray(out)
 
 
 def warp_2d(floating[:, :] image, floating[:, :, :] d1,
@@ -2351,7 +2351,7 @@ def warp_2d(floating[:, :] image, floating[:, :, :] d1,
                 # Interpolate the input image at the resulting location
                 _interpolate_scalar_2d[floating](image, dii, djj,
                                                  &warped[i, j])
-    return np.array(warped)
+    return np.asarray(warped)
 
 
 def transform_2d_affine(floating[:, :] image, int[:] ref_shape,
@@ -2411,7 +2411,7 @@ def transform_2d_affine(floating[:, :] image, int[:] ref_shape,
                     djj = j
                 _interpolate_scalar_2d[floating](image, dii, djj,
                                                  &out[i, j])
-    return np.array(out)
+    return np.asarray(out)
 
 
 def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
@@ -2525,7 +2525,7 @@ def warp_2d_nn(number[:, :] image, floating[:, :, :] d1,
                 # Interpolate the input image at the resulting location
                 _interpolate_scalar_nn_2d[number](image, dii, djj,
                                                   &warped[i, j])
-    return np.array(warped)
+    return np.asarray(warped)
 
 
 def transform_2d_affine_nn(number[:, :] image, int[:] ref_shape,
@@ -2585,7 +2585,7 @@ def transform_2d_affine_nn(number[:, :] image, int[:] ref_shape,
                     djj = j
                 _interpolate_scalar_nn_2d[number](image, dii, djj,
                                                   &out[i, j])
-    return np.array(out)
+    return np.asarray(out)
 
 
 def resample_displacement_field_3d(floating[:, :, :, :] field,
@@ -2630,7 +2630,7 @@ def resample_displacement_field_3d(floating[:, :, :, :] field,
                 djj = <double> j * factors[2]
                 _interpolate_vector_3d[floating](field, dkk, dii, djj,
                                                  expanded[k, i, j])
-    return np.array(expanded)
+    return np.asarray(expanded)
 
 
 def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
@@ -2671,7 +2671,7 @@ def resample_displacement_field_2d(floating[:, :, :] field, double[:] factors,
             djj = j*factors[1]
             inside = _interpolate_vector_2d[floating](field, dii, djj,
                                                       expanded[i, j])
-    return np.array(expanded)
+    return np.asarray(expanded)
 
 
 def create_random_displacement_2d(int[:] from_shape,
@@ -2753,7 +2753,7 @@ def create_random_displacement_2d(int[:] from_shape,
             output[i, j, 0] = dii - di
             output[i, j, 1] = djj - dj
 
-    return np.array(output), np.array(int_field)
+    return np.asarray(output), np.asarray(int_field)
 
 
 def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2world,
@@ -2840,7 +2840,7 @@ def create_random_displacement_3d(int[:] from_shape, double[:, :] from_grid2worl
                 output[k, i, j, 1] = dii - di
                 output[k, i, j, 2] = djj - dj
 
-    return np.array(output), np.array(int_field)
+    return np.asarray(output), np.asarray(int_field)
 
 
 def create_harmonic_fields_2d(cnp.npy_intp nrows, cnp.npy_intp ncols,
@@ -2890,7 +2890,7 @@ def create_harmonic_fields_2d(cnp.npy_intp nrows, cnp.npy_intp ncols,
             inv[i, j, 0] = b * np.cos(m * theta) * ii
             inv[i, j, 1] = b * np.cos(m * theta) * jj
 
-    return np.array(d), np.array(inv)
+    return np.asarray(d), np.asarray(inv)
 
 
 def create_harmonic_fields_3d(int nslices, cnp.npy_intp nrows,
@@ -2949,7 +2949,7 @@ def create_harmonic_fields_3d(int nslices, cnp.npy_intp nrows,
                 inv[k, i, j, 1] = b * np.cos(m * theta) * ii
                 inv[k, i, j, 2] = b * np.cos(m * theta) * jj
 
-    return np.array(d), np.array(inv)
+    return np.asarray(d), np.asarray(inv)
 
 
 def create_circle(cnp.npy_intp nrows, cnp.npy_intp ncols, cnp.npy_intp radius):
@@ -2986,7 +2986,7 @@ def create_circle(cnp.npy_intp nrows, cnp.npy_intp ncols, cnp.npy_intp radius):
                 c[i, j] = 1
             else:
                 c[i, j] = 0
-    return np.array(c)
+    return np.asarray(c)
 
 
 def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
@@ -3030,7 +3030,7 @@ def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
                     s[k, i, j] = 1
                 else:
                     s[k, i, j] = 0
-    return np.array(s)
+    return np.asarray(s)
 
 
 def _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
@@ -3414,7 +3414,7 @@ def gradient(img, img_world2grid, img_spacing, out_shape,
     jd_grad(img, img_world2grid.astype(np.float64),
             img_spacing.astype(np.float64),
             out_grid2world.astype(np.float64), out, inside)
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)
 
 
 def sparse_gradient(img, img_world2grid, img_spacing, sample_points):
@@ -3455,4 +3455,4 @@ def sparse_gradient(img, img_world2grid, img_spacing, sample_points):
         jd_grad = _sparse_gradient_3d
     jd_grad(img, img_world2grid.astype(np.float64),
             img_spacing.astype(np.float64), sample_points, out, inside)
-    return np.array(out), np.array(inside)
+    return np.asarray(out), np.asarray(inside)


### PR DESCRIPTION
Workaround to prevent this kind of memory leaks:
https://github.com/omarocegueda/cython_leak_repro/blob/master/memory_leak.ipynb
which occur when using memory views allocated and returned from cython functions