### PR TITLE
Fixes issue #813 by not checking data type explicitly.

### DIFF
--- a/dipy/segment/cythonutils.pxd
+++ b/dipy/segment/cythonutils.pxd
@@ -30,7 +30,7 @@ cdef struct Shape:
 cdef Shape shape_from_memview(Data data) nogil
 
 
-cdef Shape tuple2shape(dims)
+cdef Shape tuple2shape(dims) except *
 
 
 cdef shape2tuple(Shape shape)

--- a/dipy/segment/cythonutils.pyx
+++ b/dipy/segment/cythonutils.pyx
@@ -30,7 +30,7 @@ cdef Shape shape_from_memview(Data data) nogil:
     return shape
 
 
-cdef Shape tuple2shape(dims):
+cdef Shape tuple2shape(dims) except *:
     """ Converts a Python's tuple into a `Shape` Cython's struct.
 
     Parameters

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -41,7 +41,7 @@ cdef class Feature(object):
         """ Cython version of `Feature.infer_shape`. """
         with gil:
             shape = self.infer_shape(np.asarray(datum))
-            if type(shape) is int:
+            if np.asarray(shape).ndim == 0:
                 return tuple2shape((1, shape))
             elif len(shape) == 1:
                 return tuple2shape((1,) + shape)

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -286,7 +286,7 @@ def test_using_python_feature_with_cython_metric():
 
     class ArcLengthFeature(dipymetric.Feature):
         def infer_shape(self, streamline):
-            return long(1)
+            return np.int64(1)
 
         def extract(self, streamline):
             return np.sum(np.sqrt(np.sum((streamline[1:] - streamline[:-1]) ** 2)))

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 import dipy.segment.metric as dipymetric
 from dipy.segment.featurespeed import extract
@@ -286,7 +287,10 @@ def test_using_python_feature_with_cython_metric():
 
     class ArcLengthFeature(dipymetric.Feature):
         def infer_shape(self, streamline):
-            return np.int64(1)
+            if sys.version_info > (3,):
+                return 1
+
+            return long(1)
 
         def extract(self, streamline):
             return np.sum(np.sqrt(np.sum((streamline[1:] - streamline[:-1]) ** 2)))

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -285,10 +285,13 @@ def test_using_python_feature_with_cython_metric():
     d2 = metric.dist(features1, features2)
     assert_equal(d1, d2)
 
+    # Python 2.7 on Windows 64 bits uses long type instead of int for
+    # constants integer. We make sure the code is robust to such behaviour
+    # by explicitly testing it.
     class ArcLengthFeature(dipymetric.Feature):
         def infer_shape(self, streamline):
             if sys.version_info > (3,):
-                return 1
+                return 1  # In Python 3, constant integer are of type long.
 
             return long(1)
 

--- a/dipy/segment/tests/test_feature.py
+++ b/dipy/segment/tests/test_feature.py
@@ -284,6 +284,23 @@ def test_using_python_feature_with_cython_metric():
     d2 = metric.dist(features1, features2)
     assert_equal(d1, d2)
 
+    class ArcLengthFeature(dipymetric.Feature):
+        def infer_shape(self, streamline):
+            return long(1)
+
+        def extract(self, streamline):
+            return np.sum(np.sqrt(np.sum((streamline[1:] - streamline[:-1]) ** 2)))
+
+    # Test using Python Feature with Cython Metric
+    feature = ArcLengthFeature()
+    metric = dipymetric.EuclideanMetric(feature)
+    d1 = dipymetric.dist(metric, s1, s2)
+
+    features1 = metric.feature.extract(s1)
+    features2 = metric.feature.extract(s2)
+    d2 = metric.dist(features1, features2)
+    assert_equal(d1, d2)
+
 
 if __name__ == '__main__':
     run_module_suite()


### PR DESCRIPTION
According to issue #813, on Windows 64bit machines, integer constants are of type `long` instead of `int`. I added a unit test that explicitly test using a `long` as the type of the value returned by `feature.infer_shape`.

This PR also fixes another issue that came up in `metric.dist` while creating the new unit test.