### PR TITLE
trilinear_interpolate4d only works on float64

### DIFF
--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -33,7 +33,7 @@ class SimplePmfGen(PmfGen):
 class SHCoeffPmfGen(PmfGen):
 
     def __init__(self, shcoeff, sphere, basis_type):
-        self.shcoeff = shcoeff#.astype(np.float32)
+        self.shcoeff = shcoeff.astype(np.float64)
         self.sphere = sphere
         sh_order = order_from_ncoef(shcoeff.shape[-1])
         try:

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -33,7 +33,7 @@ class SimplePmfGen(PmfGen):
 class SHCoeffPmfGen(PmfGen):
 
     def __init__(self, shcoeff, sphere, basis_type):
-        self.shcoeff = shcoeff.astype(np.float32)
+        self.shcoeff = shcoeff#.astype(np.float32)
         self.sphere = sphere
         sh_order = order_from_ncoef(shcoeff.shape[-1])
         try:

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -33,7 +33,7 @@ class SimplePmfGen(PmfGen):
 class SHCoeffPmfGen(PmfGen):
 
     def __init__(self, shcoeff, sphere, basis_type):
-        self.shcoeff = shcoeff
+        self.shcoeff = shcoeff.astype(np.float32)
         self.sphere = sphere
         sh_order = order_from_ncoef(shcoeff.shape[-1])
         try:

--- a/dipy/direction/tests/test_prob_direction_getter.py
+++ b/dipy/direction/tests/test_prob_direction_getter.py
@@ -5,6 +5,7 @@ from dipy.core.sphere import unit_octahedron
 from dipy.reconst.shm import SphHarmFit, SphHarmModel
 from dipy.direction import ProbabilisticDirectionGetter
 
+
 def test_ProbabilisticDirectionGetter():
     # Test the constructors and errors of the ProbabilisticDirectionGetter
 
@@ -20,43 +21,47 @@ def test_ProbabilisticDirectionGetter():
     data = np.zeros((3, 3, 3, 7))
     fit = model.fit(data)
 
-    # Sample point and direction
-    point = np.zeros(3)
-    dir = unit_octahedron.vertices[0].copy()
+    # Test if the tracking works on different dtype of the same data.
+    for dtype in [np.float32, np.float64]:
 
-    # make a dg from a fit
-    dg = ProbabilisticDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
-                                                   unit_octahedron)
-    state = dg.get_direction(point, dir)
-    npt.assert_equal(state, 1)
+        fit = fit.astype(dtype)
 
-    # Make a dg from a pmf
-    N = unit_octahedron.theta.shape[0]
-    pmf = np.zeros((3, 3, 3, N))
-    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, unit_octahedron)
-    state = dg.get_direction(point, dir)
-    npt.assert_equal(state, 1)
+        # Sample point and direction
+        point = np.zeros(3)
+        dir = unit_octahedron.vertices[0].copy()
 
-    # pmf shape must match sphere
-    bad_pmf = pmf[..., 1:]
-    npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_pmf,
-                      bad_pmf, 90, unit_octahedron)
+        # make a dg from a fit
+        dg = ProbabilisticDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
+                                                       unit_octahedron)
+        state = dg.get_direction(point, dir)
+        npt.assert_equal(state, 1)
 
-    # pmf must have 4 dimensions
-    bad_pmf = pmf[0, ...]
-    npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_pmf,
-                      bad_pmf, 90, unit_octahedron)
-    # pmf cannot have negative values
-    pmf[0, 0, 0, 0] = -1
-    npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_pmf, pmf,
-                      90, unit_octahedron)
+        # Make a dg from a pmf
+        N = unit_octahedron.theta.shape[0]
+        pmf = np.zeros((3, 3, 3, N))
+        dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, unit_octahedron)
+        state = dg.get_direction(point, dir)
+        npt.assert_equal(state, 1)
 
-    # Check basis_type keyword
-    dg = ProbabilisticDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
-                                                   unit_octahedron,
-                                                   basis_type="mrtrix")
+        # pmf shape must match sphere
+        bad_pmf = pmf[..., 1:]
+        npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_pmf,
+                          bad_pmf, 90, unit_octahedron)
 
-    npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_shcoeff,
-                      fit.shm_coeff, 90, unit_octahedron,
-                      basis_type="not a basis")
+        # pmf must have 4 dimensions
+        bad_pmf = pmf[0, ...]
+        npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_pmf,
+                          bad_pmf, 90, unit_octahedron)
+        # pmf cannot have negative values
+        pmf[0, 0, 0, 0] = -1
+        npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_pmf, pmf,
+                          90, unit_octahedron)
 
+        # Check basis_type keyword
+        dg = ProbabilisticDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
+                                                       unit_octahedron,
+                                                       basis_type="mrtrix")
+
+        npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_shcoeff,
+                          fit.shm_coeff, 90, unit_octahedron,
+                          basis_type="not a basis")


### PR DESCRIPTION
So now it force the shm coefficient to float64. Could also patch the cython file to accept more datatype, thought maybe float32 is not precise enough, who knows.
