### PR TITLE
NF: Free water tensor model

### DIFF
--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -252,8 +252,8 @@ class FreeWaterTensorFit(TensorFit):
         return predict.reshape(shape + (gtab.bvals.shape[0], ))
 
 
-def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
-              piterations=3, S0=None):
+def _wls_iter(design_matrix, sig, min_diffusivity, Diso=3e-3, piterations=3,
+              S0=None):
     """ Helper function used by wls_fit_tensor - Applies WLS fit of the
     water free elimination model to single voxel signals.
 
@@ -439,7 +439,7 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
         S0 = np.zeros(len(data_flat))
         S0_p = np.zeros(len(data_flat_p))
         for vox in range(len(data_flat_p)):
-            fw_params_p[vox], S0_p[vox] = _wls_iter(design_matrix, inv_design,
+            fw_params_p[vox], S0_p[vox] = _wls_iter(design_matrix,
                                                     data_flat_p[vox],
                                                     min_diffusivity,
                                                     Diso=Diso,
@@ -448,7 +448,7 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
         S0 = S0.ravel()
         S0_p = S0[~cond]
         for vox in range(len(data_flat_p)):
-            fw_params_p[vox], S0_p[vox] = _wls_iter(design_matrix, inv_design,
+            fw_params_p[vox], S0_p[vox] = _wls_iter(design_matrix,
                                                     data_flat_p[vox],
                                                     min_diffusivity,
                                                     Diso=Diso,

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -366,7 +366,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
     inv_WT_S2_W = np.linalg.pinv(np.dot(WTS2, W))
     WT_S2_LS = np.dot(WTS2, log_s)
     params = np.dot(inv_WT_S2_W, WT_S2_LS)
-    
+
     # General free-water signal contribution
     fwsig = np.exp(np.dot(design_matrix, 
                           np.array([Diso, 0, Diso, 0, 0, Diso, 0])))

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -371,9 +371,9 @@ def wls_fit_tensor(gtab, data, Diso=3e-3, mask=None, min_signal=None,
     if min_signal is None:
         data = data.ravel()
         if np.all(data == 0):
-            return 1.0e-6
+            min_signal = 1.0e-6
         else:
-            return data[data > 0].min()
+            min_signal = data[data > 0].min()
 
     # Prepare S0
     S0 = np.mean(data[:, :, :, gtab.b0s_mask], axis=-1)
@@ -710,9 +710,9 @@ def nls_fit_tensor(gtab, data, Diso=3e-3, min_signal=None, weighting=None,
     if min_signal is None:
         data = data.ravel()
         if np.all(data == 0):
-            return 1.0e-6
+            min_signal = 1.0e-6
         else:
-            return data[data > 0].min()
+            min_signal = data[data > 0].min()
 
     # Prepare S0
     S0 = np.mean(data[:, :, :, gtab.b0s_mask], axis=-1)

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -21,9 +21,8 @@ from dipy.core.ndindex import ndindex
 
 
 def fwdti_prediction(params, gtab, Diso=3.0e-3):
-    """
-    Predict a signal given the parameters of the free water diffusion tensor
-    model.
+    """ Signal prediction given the free water DTI model parameters.
+
     Parameters
     ----------
     params : ndarray
@@ -35,8 +34,9 @@ def fwdti_prediction(params, gtab, Diso=3.0e-3):
         The gradient table for this prediction
     Diso : float, optional
         Value of the free water isotropic diffusion. Default is set to 3e-3
-        $mm^{2}.s^{-1}$. Please ajust this value if you are assuming different
+        $mm^{2}.s^{-1}$. Please adjust this value if you are assuming different
         units of diffusion.
+
     Notes
     -----
     The predicted signal is given by:
@@ -47,6 +47,7 @@ def fwdti_prediction(params, gtab, Diso=3.0e-3):
     quadratic form of the tensor determined by the input parameters, $f$ is the
     free water diffusion compartment, $D_{iso}$ is the free water diffusivity
     which is equal to $3 * 10^{-3} mm^{2}s^{-1} [1]_.
+
     References
     ----------
     .. [1] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
@@ -87,10 +88,10 @@ def fwdti_prediction(params, gtab, Diso=3.0e-3):
 
 
 class FreeWaterTensorModel(ReconstModel):
-    """ Class for the Free Water Elimitation Diffusion Tensor Model
-    """
+    """ Class for the Free Water Elimitation Diffusion Tensor Model """
     def __init__(self, gtab, fit_method="NLS", *args, **kwargs):
         """ Free Water Diffusion Tensor Model [1]_.
+
         Parameters
         ----------
         gtab : GradientTable class instance
@@ -108,6 +109,7 @@ class FreeWaterTensorModel(ReconstModel):
         min_signal : float
             The minimum signal value. Needs to be a strictly positive
             number. Default: minimal signal in the data provided to `fit`.
+
         References
         ----------
         .. [1] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
@@ -137,6 +139,7 @@ class FreeWaterTensorModel(ReconstModel):
 
     def fit(self, data, mask=None):
         """ Fit method of the free water elimination DTI model class
+
         Parameters
         ----------
         data : array
@@ -174,8 +177,9 @@ class FreeWaterTensorModel(ReconstModel):
         return FreeWaterTensorFit(self, fwdti_params)
 
     def predict(self, fwdti_params):
-        """
-        Predict a signal for this TensorModel class instance given parameters.
+        """ Predict a signal for this TensorModel class instance given
+        parameters.
+
         Parameters
         ----------
         fwdti_params : ndarray
@@ -196,6 +200,7 @@ class FreeWaterTensorFit(TensorFit):
         """ Initialize a FreeWaterTensorFit class instance.
         Since the free water tensor model is an extension of DTI, class
         instance is defined as subclass of the TensorFit from dti.py
+
         Parameters
         ----------
         model : FreeWaterTensorModel Class instance
@@ -213,21 +218,18 @@ class FreeWaterTensorFit(TensorFit):
 
     @property
     def f(self):
-        """
-        Returns the free water diffusion volume fraction f
-        """
+        """ Returns the free water diffusion volume fraction f """
         return self.model_params[..., 12]
         
     @property
     def S0(self):
-        """
-        Returns the non-diffusion weighted signal estimate
-        """
+        """ Returns the non-diffusion weighted signal estimate """
         return self.model_params[..., 13]
 
     def predict(self, gtab):
         r""" Given a free water tensor model fit, predict the signal on the
         vertices of a gradient table
+
         Parameters
         ----------
         fwdti_params : ndarray (x, y, z, 14) or (n, 14)
@@ -240,14 +242,6 @@ class FreeWaterTensorFit(TensorFit):
                 4) The estimate of the non diffusion-weighted signal S0
         gtab : a GradientTable class instance
             The gradient table for this prediction
-        S0 : float or ndarray (optional)
-            The non diffusion-weighted signal in every voxel, or across all
-            voxels. Default: 1
-        Notes
-        -----
-        The predicted signal is given by:
-        .. math::
-            edit
         """
         return fwdti_prediction(self.model_params, gtab)
 
@@ -256,6 +250,7 @@ def wls_fit_tensor(design_matrix, data, Diso=3e-3, piterations=3,
                    riterations=2):
     r""" Computes weighted least squares (WLS) fit to calculate self-diffusion
     tensor using a linear regression model [1]_.
+
     Parameters
     ----------
     design_matrix : array (g, 7)
@@ -275,6 +270,7 @@ def wls_fit_tensor(design_matrix, data, Diso=3e-3, piterations=3,
         Number of iteration repetitions with adapted S0. To insure that S0 is
         taken as a model free parameter Each precision iteration is repeated
         riterations times with adapted S0.
+
     Returns
     -------
     All parameters estimated from the free water tensor model.
@@ -284,6 +280,7 @@ def wls_fit_tensor(design_matrix, data, Diso=3e-3, piterations=3,
            first, second and third coordinates of the eigenvector
         3) The volume fraction of the free water compartment
         4) The estimate of the non diffusion-weighted signal S0
+
     References
     ----------
     .. [1] Chung, SW., Lu, Y., Henry, R.G., 2006. Comparison of bootstrap
@@ -318,6 +315,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
               piterations=3, riterations=2):
     """ Helper function used by wls_fit_tensor - Applies WLS fit of the
     water free elimination model to single voxel signals.
+
     Parameters
     ----------
     design_matrix : array (g, 7)
@@ -343,6 +341,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
         Number of iteration repetitions with adapted S0. To insure that S0 is
         taken as a model free parameter Each precision iteration is repeated
         riterations times with adapted S0.
+
     Returns
     -------
     All parameters estimated from the free water tensor model.
@@ -409,6 +408,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
             # Select params for lower F2
             Mind = np.argmin(F2)
             params = all_new_params[:, Mind]
+
         # Updated f
         f = fs[Mind]
         # refining precision
@@ -563,15 +563,7 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
         f = params[12]
         s0 = params[13]
         start_params = np.concatenate((dt, [-np.log(s0), f]), axis=0)
-        # Do the optimization in this voxel:
-        # if jac:
-            #this_tensor, status = opt.leastsq(_nlls_err_func, start_params,
-            #                                  args=(design_matrix,
-            #                                        flat_data[vox],
-            #                                        weighting,
-            #                                        sigma),
-            #                                  Dfun=_nlls_jacobian_func)
-        #else:
+
         this_tensor, status = opt.leastsq(_nlls_err_func, start_params[:8],
                                           args=(design_matrix,
                                                 flat_data[vox],

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -21,7 +21,7 @@ from dipy.core.ndindex import ndindex
 
 
 def fwdti_prediction(params, gtab, S0=1, Diso=3.0e-3):
-    """ Signal prediction given the free water DTI model parameters.
+    r""" Signal prediction given the free water DTI model parameters.
 
     Parameters
     ----------
@@ -63,12 +63,12 @@ def fwdti_prediction(params, gtab, S0=1, Diso=3.0e-3):
     qform = vec_val_vect(evecs, evals)
     lower_dt = lower_triangular(qform, S0)
     lower_diso = lower_dt.copy()
-    lower_diso[..., 0] =  lower_diso[..., 2] = lower_diso[..., 5] = Diso
-    lower_diso[..., 1] =  lower_diso[..., 3] = lower_diso[..., 4] = 0
+    lower_diso[..., 0] = lower_diso[..., 2] = lower_diso[..., 5] = Diso
+    lower_diso[..., 1] = lower_diso[..., 3] = lower_diso[..., 4] = 0
     D = design_matrix(gtab)
 
     pred_sig = np.zeros(f.shape + (gtab.bvals.shape[0],))
-    mask = _positive_evals(evals[..., 0], evals[..., 1], evals[..., 2])    
+    mask = _positive_evals(evals[..., 0], evals[..., 1], evals[..., 2])
     index = ndindex(f.shape)
     for v in index:
         if mask[v]:
@@ -140,7 +140,7 @@ class FreeWaterTensorModel(ReconstModel):
             should be analyzed that has the shape data.shape[:-1]
         """
         if mask is None:
-            # Flatten it to 2D either way:
+            # Flatten mask to 2D:
             data_in_mask = np.reshape(data, (-1, data.shape[-1]))
         else:
             # Check for valid shape of the mask
@@ -153,7 +153,7 @@ class FreeWaterTensorModel(ReconstModel):
         bmag = int(np.log10(self.gtab.bvals.max()))
         b = self.gtab.bvals.copy() / (10 ** (bmag-1))  # normalize b units
         b = b.round()
-        uniqueb = np.unique(b) 
+        uniqueb = np.unique(b)
         if len(uniqueb) < 3:
             mes = "fwdti fit requires data for at least 2 non zero b-values"
             raise ValueError(mes)
@@ -176,7 +176,7 @@ class FreeWaterTensorModel(ReconstModel):
             fwdti_params = np.zeros(data.shape[:-1] + (13,))
             fwdti_params[mask, :] = params_in_mask
             S0 = np.zeros(data.shape[:-1])
-            S0[mask] = S0_im 
+            S0[mask] = S0_im
 
         return FreeWaterTensorFit(self, fwdti_params, S0)
 
@@ -235,7 +235,7 @@ class FreeWaterTensorFit(TensorFit):
         ----------
         gtab : a GradientTable class instance
             The gradient table for this prediction
-        
+
         S0 : float array
            The mean non-diffusion weighted signal in each voxel. Default: 1 in
            all voxels.
@@ -254,7 +254,7 @@ class FreeWaterTensorFit(TensorFit):
         predict = np.empty((size, gtab.bvals.shape[0]))
         for i in range(0, size, step):
             predict[i:i+step] = fwdti_prediction(params[i:i+step], gtab, S0=S0)
-        return predict.reshape(shape + (gtab.bvals.shape[0], ))
+        return predict.reshape(shape + (gtab.bvals.shape[0],))
 
 
 def _wls_iter(design_matrix, sig, min_diffusivity, min_signal, Diso=3e-3,
@@ -338,7 +338,7 @@ def _wls_iter(design_matrix, sig, min_diffusivity, min_signal, Diso=3e-3,
             # component is larger than the total fiber. This cases are present
             # for inapropriate large volume fractions (given the current S0
             # value estimated). To overcome this issue negative SA are replaced
-            # by data's min positive signal. 
+            # by data's min positive signal.
             SA[SA <= 0] = min_signal
             y = np.log(SA / (1-FS))
             all_new_params = np.dot(invWTS2W_WTS2, y)
@@ -414,7 +414,7 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
         diffusion value, the diffusion signal is assumed to be only free water
         diffusion (i.e. volume fraction will be set to 1 and tissue's diffusion
         parameters are set to zero). Default md_reg is 2.7e-3 $mm^{2}.s^{-1}$
-        (corresponding to 90% of the free water diffusion value).        
+        (corresponding to 90% of the free water diffusion value).
 
     Returns
     -------
@@ -480,17 +480,18 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
     params_out[cond, 12] = 1  # Only free water
     params_out = params_out.reshape((data.shape[:-1]) + (13,))
     S0out[~cond] = S0cond
-    S0out[cond] = np.mean(data_flat[cond, :] / 
+    S0out[cond] = np.mean(data_flat[cond, :] /
                           np.exp(np.dot(design_matrix[..., :6],
-                                        np.array([Diso, 0, Diso, 0, 0, Diso]))),
+                                        np.array([Diso, 0, Diso,
+                                                  0, 0, Diso]))),
                           -1)  # Only free water
     S0out = S0out.reshape(data.shape[:-1])
     return params_out, S0out
 
 
 def _nls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
-                   weighting=None, sigma=None, cholesky=False,
-                   f_transform=False):
+                  weighting=None, sigma=None, cholesky=False,
+                  f_transform=False):
     """ Error function for the non-linear least-squares fit of the tensor water
     elimination model.
 
@@ -582,8 +583,8 @@ def _nls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
 
 
 def _nls_jacobian_func(tensor_elements, design_matrix, data, Diso=3e-3,
-                        weighting=None, sigma=None, cholesky=False,
-                        f_transform=False):
+                       weighting=None, sigma=None, cholesky=False,
+                       f_transform=False):
     """The Jacobian is the first derivative of the least squares error
     function.
 
@@ -627,8 +628,8 @@ def _nls_jacobian_func(tensor_elements, design_matrix, data, Diso=3e-3,
 
 
 def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
-                    weighting=None, sigma=None, cholesky=False,
-                    f_transform=True, jac=False, mdreg=2.7e-3):
+                   weighting=None, sigma=None, cholesky=False,
+                   f_transform=True, jac=False, mdreg=2.7e-3):
     """
     Fit the water elimination tensor model using the non-linear least-squares.
 
@@ -723,7 +724,8 @@ def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
     # If is still None is parameters initial guess was given but not S0
     if np.any(S0) is None:
         evals = dtiparams[..., :3]
-        evecs = np.reshape(dtiparams[..., 3:12], (data_flat.shape[0],) + (3, 3))
+        evecs = np.reshape(dtiparams[..., 3:12],
+                           (data_flat.shape[0],) + (3, 3))
         dti_low_tri = lower_triangular(vec_val_vect(evecs, evals))
         S0out = np.mean(data_flat /
                         np.exp(np.dot(dti_low_tri, design_matrix[..., :6].T)),
@@ -779,7 +781,6 @@ def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
                                                     cholesky,
                                                     f_transform))
 
-
         # Invert the cholesky decomposition if this was requested
         if cholesky:
             this_tensor[:6] = cholesky_to_lower_triangular(this_tensor[:6])
@@ -800,7 +801,7 @@ def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
     params_out = np.reshape(params_out, (data.shape[:-1]) + (13,))
     S0out[~cond] = S0_cond
     S0out[cond] = \
-        np.mean(data_flat[cond, :] / \
+        np.mean(data_flat[cond, :] /
                 np.exp(np.dot(design_matrix[..., :6],
                               np.array([Diso, 0, Diso, 0, 0, Diso]))),
                 -1)  # Only free water
@@ -809,7 +810,7 @@ def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
 
 
 def lower_triangular_to_cholesky(tensor_elements):
-    """ Perfoms Cholesky decompostion of the diffusion tensor
+    """ Perfoms Cholesky decomposition of the diffusion tensor
 
     Parameters
     ----------

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -508,7 +508,6 @@ def _nls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
         ft = arcsin(2*f - 1) + pi/2
     design_matrix : array
         The design matrix
-
     data : array
         The voxel signal in all gradient directions
     Diso : float, optional
@@ -518,7 +517,6 @@ def _nls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
     weighting : str (optional).
          Whether to use the Geman McClure weighting criterion (see [1]_
          for details)
-
     sigma : float or float array (optional)
         If 'sigma' weighting is used, we will weight the error function
         according to the background noise estimated either in aggregate over
@@ -530,7 +528,6 @@ def _nls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
         If true, the diffusion tensor elements were decomposed using cholesky
         decomposition. See fwdti.nls_fit_tensor
         Default: False
-
     f_transform : bool, optional
         If true, the water volume fraction was converted to
         ft = arcsin(2*f - 1) + pi/2, insuring f estimates between 0 and 1.
@@ -657,7 +654,6 @@ def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
         Value of the free water isotropic diffusion. Default is set to 3e-3
         $mm^{2}.s^{-1}$. Please ajust this value if you are assuming different
         units of diffusion.
-
     weighting: str, optional
         the weighting scheme to use in considering the
         squared-error. Default behavior is to use uniform weighting. Other
@@ -671,7 +667,6 @@ def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
         If true it uses cholesky decomposition to insure that diffusion tensor
         is positive define.
         Default: False
-
     f_transform : bool, optional
         If true, the water volume fractions is converted during the convergence
         procedure to ft = arcsin(2*f - 1) + pi/2, insuring f estimates between

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -369,7 +369,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
     
     # General free-water signal contribution
     fwsig = np.exp(np.dot(design_matrix, 
-                          np.array([Diso, 0, Diso, 0, 0, Diso, -np.log(1.)])))
+                          np.array([Diso, 0, Diso, 0, 0, Diso, 0])))
 
     df = 1  # initialize precision
     flow = 0  # lower f evaluated

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -262,8 +262,6 @@ def _wls_iter(design_matrix, sig, min_diffusivity, Diso=3e-3, piterations=3,
     design_matrix : array (g, 7)
         Design matrix holding the covariants used to solve for the regression
         coefficients.
-    inv_design : array (g, 7)
-        Inverse of the design matrix.
     sig : array (g, )
         Diffusion-weighted signal for a single voxel data.
     min_diffusivity : float
@@ -425,7 +423,6 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
 
     # inverting design matrix and defining minimun diffusion aloud
     min_diffusivity = tol / -design_matrix.min()
-    inv_design = np.linalg.pinv(design_matrix)
 
     # Computing WLS DTI solution for MD regularization
     dti_params = dti_wls_fit(design_matrix, data_flat)

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -302,7 +302,7 @@ def wls_iter(design_matrix, sig, S0, min_signal=1.0e-6, Diso=3e-3,
     return fw_params
 
 
-def wls_fit_tensor(gtab, data, Diso=3e-3, mask=None, min_signal=None,
+def wls_fit_tensor(gtab, data, Diso=3e-3, mask=None, min_signal=1.0e-6,
                    piterations=3, mdreg=2.7e-3):
     r""" Computes weighted least squares (WLS) fit to calculate self-diffusion
     tensor using a linear regression model [1]_.
@@ -327,7 +327,7 @@ def wls_fit_tensor(gtab, data, Diso=3e-3, mask=None, min_signal=None,
         Default: False
     min_signal : float
         The minimum signal value. Needs to be a strictly positive
-        number. Default: minimal signal in the data provided to `fit`.
+        number. Default: 1.0e-6.
     piterations : inter, optional
         Number of iterations used to refine the precision of f. Default is set
         to 3 corresponding to a precision of 0.01.
@@ -364,16 +364,8 @@ def wls_fit_tensor(gtab, data, Diso=3e-3, mask=None, min_signal=None,
         mask = np.ones(data.shape[:-1], dtype=bool)
     else:
         if mask.shape != data.shape[:-1]:
-                raise ValueError("Mask is not the same shape as data.")
+            raise ValueError("Mask is not the same shape as data.")
         mask = np.array(mask, dtype=bool, copy=False)
-
-    # Prepare min_signal
-    if min_signal is None:
-        data = data.ravel()
-        if np.all(data == 0):
-            min_signal = 1.0e-6
-        else:
-            min_signal = data[data > 0].min()
 
     # Prepare S0
     S0 = np.mean(data[:, :, :, gtab.b0s_mask], axis=-1)
@@ -632,7 +624,7 @@ def nls_iter(design_matrix, sig, S0, min_signal=1.0e-6, Diso=3e-3,
     return params
 
 
-def nls_fit_tensor(gtab, data, Diso=3e-3, min_signal=None, weighting=None,
+def nls_fit_tensor(gtab, data, Diso=3e-3, min_signal=1.0e-6, weighting=None,
                    sigma=None, cholesky=False, f_transform=True, jac=False,
                    mdreg=2.7e-3, mask=None):
     """
@@ -658,7 +650,7 @@ def nls_fit_tensor(gtab, data, Diso=3e-3, min_signal=None, weighting=None,
         Default: False
     min_signal : float
         The minimum signal value. Needs to be a strictly positive
-        number. Default: minimal signal in the data provided to `fit`.
+        number. Default: 1.0e-6.
     f_transform : bool, optional
         If true, the water volume fractions is converted during the convergence
         procedure to ft = arcsin(2*f - 1) + pi/2, insuring f estimates between
@@ -703,16 +695,8 @@ def nls_fit_tensor(gtab, data, Diso=3e-3, min_signal=None, weighting=None,
         mask = np.ones(data.shape[:-1], dtype=bool)
     else:
         if mask.shape != data.shape[:-1]:
-                raise ValueError("Mask is not the same shape as data.")
+            raise ValueError("Mask is not the same shape as data.")
         mask = np.array(mask, dtype=bool, copy=False)
-
-    # Prepare min_signal
-    if min_signal is None:
-        data = data.ravel()
-        if np.all(data == 0):
-            min_signal = 1.0e-6
-        else:
-            min_signal = data[data > 0].min()
 
     # Prepare S0
     S0 = np.mean(data[:, :, :, gtab.b0s_mask], axis=-1)

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -217,6 +217,13 @@ class FreeWaterTensorFit(TensorFit):
         Returns the free water diffusion volume fraction f
         """
         return self.model_params[..., 12]
+        
+    @property
+    def S0(self):
+        """
+        Returns the non-diffusion weighted signal estimate
+        """
+        return self.model_params[..., 13]
 
     def predict(self, gtab):
         r""" Given a free water tensor model fit, predict the signal on the

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -581,7 +581,7 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
             fw_params[vox, 12] = this_tensor[7]
             fw_params[vox, 13] = np.exp(-this_tensor[6])
         # If leastsq failed to converge and produced nans, we'll resort to the
-        # OLS solution in this voxel:
+        # WLS solution in this voxel:
         except np.linalg.LinAlgError:
             evals, evecs = decompose_tensor(
                               from_lower_triangular(start_params[:6]))

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -594,6 +594,69 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
     return fw_params
 
 
+def lower_triangular_to_cholesky(tensor_elements):
+    """ Perfoms Cholesky decompostion of the diffusion tensor 
+    
+    Parameters
+    ----------
+    tensor_elements : array (6,)
+        Array containing the six elements of diffusion tensor's lower
+        triangular.
+
+    Returns
+    -------
+    cholesky_elements : array (6,)
+        Array containing the six Cholesky's decomposition elements
+        (R0, R1, R2, R3, R4, R5) [1]_.
+
+    References
+    ----------
+    .. [1] Koay, C.G., Carew, J.D., Alexander, A.L., Basser, P.J.,
+           Meyerand, M.E., 2006. Investigation of anomalous estimates of
+           tensor-derived quantities in diffusion tensor imaging. Magnetic
+           Resonance in Medicine, 55(4), 930-936. doi:10.1002/mrm.20832
+    """
+    R0 = np.sqrt(tensor_elements[0])
+    R3 = tensor_elements[1] / R0
+    R1 = np.sqrt(tensor_elements[2] - R3**2)
+    R5 = tensor_elements[3] / R0
+    R4 = (tensor_elements[4] - R3*R5) / R1
+    R2 = np.sqrt(tensor_elements[5] - R4**2 - R5**2)
+
+    return np.array([R0, R1, R2, R3, R4, R5])
+
+
+def cholesky_to_lower_triangular(R):
+    """ Convert Cholesky decompostion elements to the diffusion tensor elements
+    
+    Parameters
+    ----------
+    R : array (6,)
+        Array containing the six Cholesky's decomposition elements
+        (R0, R1, R2, R3, R4, R5) [1]_.    
+
+    Returns
+    -------
+    tensor_elements : array (6,)
+        Array containing the six elements of diffusion tensor's lower
+        triangular.
+
+    References
+    ----------
+    .. [1] Koay, C.G., Carew, J.D., Alexander, A.L., Basser, P.J.,
+           Meyerand, M.E., 2006. Investigation of anomalous estimates of
+           tensor-derived quantities in diffusion tensor imaging. Magnetic
+           Resonance in Medicine, 55(4), 930-936. doi:10.1002/mrm.20832
+    """
+    Dxx = R[0]**2
+    Dxy = R[0]*R[3]
+    Dyy = R[1]**2 + R[3]**2
+    Dxz = R[0]*R[5]
+    Dyz = R[1]*R[4] + R[3]*R[5]
+    Dzz = R[2]**2 + R[4]**2 + R[5]**2
+    return np.array([Dxx, Dxy, Dyy, Dxz, Dyz, Dzz])
+
+
 common_fit_methods = {'WLLS': wls_fit_tensor,
                       'WLS': wls_fit_tensor,
                       'NLLS': nlls_fit_tensor,

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -627,7 +627,7 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
         0 and 1.
         Default: True
     jac : bool
-        Use the Jacobian? Default: True
+        Use the Jacobian? Default: False
 
     Returns
     -------
@@ -643,11 +643,6 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
     else:
         fw_params = fw_params.reshape((-1, fw_params.shape[-1]))
 
-    # if bounds==None:
-    """
-    bounds = ([0., -Diso, 0., -Diso, -Diso, 0., -10., 0],
-              [Diso, Diso, Diso, Diso, Diso, Diso, 10., 1])
-    """
     for vox in range(flat_data.shape[0]):
         if np.all(flat_data[vox] == 0):
             raise ValueError("The data in this voxel contains only zeros")
@@ -672,26 +667,6 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
 
         # Use the Levenberg-Marquardt algorithm wrapped in opt.leastsq
         start_params = np.concatenate((dt, [-np.log(s0), f]), axis=0)
-        """
-        lb = np.array(bounds[0])
-        ub = np.array(bounds[1])
-        start_params[start_params<lb] = lb[start_params<lb]
-        start_params[start_params>ub] = ub[start_params>ub]       
-        if jac:
-            out = opt.least_squares(_nlls_err_func, start_params[:8],
-                                    args=(design_matrix, flat_data[vox],
-                                          Diso, weighting, sigma, cholesky,
-                                          f_transform),
-                                    jac=_nlls_jacobian_func,
-                                    bounds=bounds)
-        else:
-            out = opt.least_squares(_nlls_err_func, start_params[:8],
-                                    args=(design_matrix, flat_data[vox],
-                                          Diso, weighting, sigma, cholesky,
-                                          f_transform),
-                                    bounds=bounds)
-        this_tensor = out.x
-        """
         if jac:
             this_tensor, status = opt.leastsq(_nlls_err_func, start_params[:8],
                                               args=(design_matrix,

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -88,10 +88,12 @@ class FreeWaterTensorModel(ReconstModel):
         gtab : GradientTable class instance
         fit_method : str or callable
             str can be one of the following:
+
             'WLS' for weighted linear least square fit according to [1]_
-                fwdti.wls_fit_tensor
+                :func:`fwdti.wls_fit_tensor`
             'NLS' for non-linear least square fit according to [1]_
-                fwdti.wls_fit_tensor
+                :func:`fwdti.nls_fit_tensor`
+
             callable has to have the signature:
               fit_method(design_matrix, data, *args, **kwargs)
         args, kwargs : arguments and key-word arguments passed to the
@@ -140,7 +142,7 @@ class FreeWaterTensorModel(ReconstModel):
             should be analyzed that has the shape data.shape[:-1]
         """
         if mask is None:
-            # Flatten mask to 2D:
+            # Flatten data to 2D:
             data_in_mask = np.reshape(data, (-1, data.shape[-1]))
         else:
             # Check for valid shape of the mask

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -88,7 +88,7 @@ def fwdti_prediction(params, gtab, Diso=3.0e-3):
 
 
 class FreeWaterTensorModel(ReconstModel):
-    """ Class for the Free Water Elimitation Diffusion Tensor Model """
+    """ Class for the Free Water Elimination Diffusion Tensor Model """
     def __init__(self, gtab, fit_method="NLS", *args, **kwargs):
         """ Free Water Diffusion Tensor Model [1]_.
 
@@ -409,7 +409,7 @@ def wls_fit_tensor(design_matrix, data, Diso=3e-3, piterations=3, S0=None):
     """
     tol = 1e-6
 
-    # preparing data and initializing parametres
+    # preparing data and initializing parameters
     data = np.asarray(data)
     data_flat = data.reshape((-1, data.shape[-1]))
     fw_params = np.empty((len(data_flat), 14))
@@ -418,7 +418,7 @@ def wls_fit_tensor(design_matrix, data, Diso=3e-3, piterations=3, S0=None):
     min_diffusivity = tol / -design_matrix.min()
     inv_design = np.linalg.pinv(design_matrix)
 
-    # lopping WLS solution on all data voxels
+    # looping WLS solution on all data voxels
     if S0 is None:
         for vox in range(len(data_flat)):
             fw_params[vox] = _wls_iter(design_matrix, inv_design,

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -427,8 +427,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
 
 def _nlls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
                    weighting=None, sigma=None):
-    """
-    Error function for the non-linear least-squares fit of the tensor water
+    """ Error function for the non-linear least-squares fit of the tensor water
     elimination model.
 
     Parameters
@@ -550,6 +549,8 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
     if fw_params==None:
         fw_params = wls_fit_tensor(design_matrix, flat_data,  Diso=Diso)
 
+    fw_params = fw_params.reshape((-1, fw_params.shape[-1]))
+    
     for vox in range(flat_data.shape[0]):
         if np.all(flat_data[vox] == 0):
             raise ValueError("The data in this voxel contains only zeros")

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -21,10 +21,10 @@ from dipy.core.sphere import Sphere
 from .vec_val_sum import vec_val_vect
 from dipy.core.ndindex import ndindex
 
-from dipy.utils.arrfuncs import pinv
-
-def fwdti_prediction(params, gtab, Diso=3.0e-3):
-    """ Signal prediction given the free water DTI model parameters.
+def fwdti_prediction(params, gtab, S0, Diso=3.0e-3):
+    """
+    Predict a signal given the parameters of the free water diffusion tensor
+    model.
 
     Parameters
     ----------
@@ -64,7 +64,7 @@ def fwdti_prediction(params, gtab, Diso=3.0e-3):
            doi: 10.1016/j.neuroimage.2014.09.053
     """
     evals = params[..., :3]
-    evecs = params[..., 3:-2].reshape(params.shape[:-1] + (3, 3))
+    evecs = params[..., 3:-1].reshape(params.shape[:-1] + (3, 3))
     f = params[..., -1]
     qform = vec_val_vect(evecs, evals)
     sphere = Sphere(xyz=gtab.bvecs[~gtab.b0s_mask])

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -241,22 +241,8 @@ class FreeWaterTensorFit(TensorFit):
         S0 : float array
            The mean non-diffusion weighted signal in each voxel. Default: 1 in
            all voxels.
-
-        step : int, optional
-            Number of voxels to be processed simultaneously
         """
-        shape = self.model_params.shape[:-1]
-        size = np.prod(shape)
-        if step is None:
-            step = self.model.kwargs.get('step', size)
-        if step >= size:
-            return fwdti_prediction(self.model_params, gtab, S0=S0)
-        params = np.reshape(self.model_params,
-                            (-1, self.model_params.shape[-1]))
-        predict = np.empty((size, gtab.bvals.shape[0]))
-        for i in range(0, size, step):
-            predict[i:i+step] = fwdti_prediction(params[i:i+step], gtab, S0=S0)
-        return predict.reshape(shape + (gtab.bvals.shape[0],))
+        return fwdti_prediction(self.model_params, gtab, S0=S0)
 
 
 def _wls_iter(design_matrix, sig, min_diffusivity, min_signal, Diso=3e-3,

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -321,7 +321,7 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
     ----------
     design_matrix : array (g, 7)
         Design matrix holding the covariants used to solve for the regression
-        coefficients
+        coefficients.
     inv_design : array (g, 7)
         Inverse of the design matrix.
     sig : array (g, )

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -256,7 +256,7 @@ def wls_iter(design_matrix, sig, S0, min_signal=1.0e-6, Diso=3e-3,
     invWTS2W_WTS2 = np.dot(inv_WT_S2_W, WTS2)
     params = np.dot(invWTS2W_WTS2, log_s)
 
-    md = mean_diffusivity(params[..., :3])
+    md = (params[0] + params[2] + params[5]) / 3
     # Process voxel if it has significant signal from tissue
     if md < mdreg and np.mean(sig) > min_signal:
         # General free-water signal contribution

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -588,10 +588,10 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
     flat_data = data.reshape((-1, data.shape[-1]))
 
     # Use the WLS method parameters as the starting point if fw_params is None:
-    if fw_params is None:
+    if np.any(fw_params) is None:
         fw_params = wls_fit_tensor(design_matrix, flat_data,  Diso=Diso)
-
-    fw_params = fw_params.reshape((-1, fw_params.shape[-1]))
+    else:
+        fw_params = fw_params.reshape((-1, fw_params.shape[-1]))
 
     # if bounds==None:
     #     bounds = ([0., -Diso, 0., -Diso, -Diso, 0., -10., 0.],

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -12,12 +12,10 @@ from .base import ReconstModel
 
 from dipy.reconst.dti import (TensorFit, design_matrix, _min_positive_signal,
                               decompose_tensor, from_lower_triangular,
-                              lower_triangular, apparent_diffusion_coef,
-                              mean_diffusivity)
+                              lower_triangular, mean_diffusivity)
 from dipy.reconst.dti import wls_fit_tensor as dti_wls_fit
 from dipy.reconst.dki import _positive_evals
 
-from dipy.core.sphere import Sphere
 from .vec_val_sum import vec_val_vect
 from dipy.core.ndindex import ndindex
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -24,7 +24,7 @@ def fwdti_prediction(params, gtab, S0=1, Diso=3.0e-3):
 
     Parameters
     ----------
-    params : ndarray
+    params : (..., 13) ndarray
         Model parameters. The last dimension should have the 12 tensor
         parameters (3 eigenvalues, followed by the 3 corresponding
         eigenvectors) and the volume fraction of the free water compartment.
@@ -37,6 +37,11 @@ def fwdti_prediction(params, gtab, S0=1, Diso=3.0e-3):
         Value of the free water isotropic diffusion. Default is set to 3e-3
         $mm^{2}.s^{-1}$. Please adjust this value if you are assuming different
         units of diffusion.
+
+    Returns
+    --------
+    S : (..., N) ndarray
+        Simulated signal based on the free water DTI model
 
     Notes
     -----
@@ -154,13 +159,18 @@ class FreeWaterTensorModel(ReconstModel):
 
         Parameters
         ----------
-        fwdti_params : ndarray
+        fwdti_params : (..., 13) ndarray
             The last dimension should have 13 parameters: the 12 tensor
             parameters (3 eigenvalues, followed by the 3 corresponding
             eigenvectors) and the free water volume fraction.
         S0 : float or ndarray
             The non diffusion-weighted signal in every voxel, or across all
             voxels. Default: 1
+
+        Returns
+        --------
+        S : (..., N) ndarray
+            Simulated signal based on the free water DTI model
         """
         return fwdti_prediction(fwdti_params, self.gtab, S0=S0)
 
@@ -203,6 +213,11 @@ class FreeWaterTensorFit(TensorFit):
         S0 : float array
            The mean non-diffusion weighted signal in each voxel. Default: 1 in
            all voxels.
+
+        Returns
+        --------
+        S : (..., N) ndarray
+            Simulated signal based on the free water DTI model
         """
         return fwdti_prediction(self.model_params, gtab, S0=S0)
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -488,7 +488,7 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
     return fw_params, S0f
 
 
-def _nlls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
+def _nls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
                    weighting=None, sigma=None, cholesky=False,
                    f_transform=False):
     """ Error function for the non-linear least-squares fit of the tensor water
@@ -525,13 +525,13 @@ def _nlls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
         weighting.
     cholesky : bool, optional
         If true, the diffusion tensor elements were decomposed using cholesky
-        decomposition. See fwdti.nlls_fit_tensor
+        decomposition. See fwdti.nls_fit_tensor
         Default: False
 
     f_transform : bool, optional
         If true, the water volume fraction was converted to
         ft = arcsin(2*f - 1) + pi/2, insuring f estimates between 0 and 1.
-        See fwdti.nlls_fit_tensor
+        See fwdti.nls_fit_tensor
         Default: True
     """
     tensor = np.copy(tensor_elements)
@@ -581,7 +581,7 @@ def _nlls_err_func(tensor_elements, design_matrix, data, Diso=3e-3,
         return np.sqrt(w * se)
 
 
-def _nlls_jacobian_func(tensor_elements, design_matrix, data, Diso=3e-3,
+def _nls_jacobian_func(tensor_elements, design_matrix, data, Diso=3e-3,
                         weighting=None, sigma=None, cholesky=False,
                         f_transform=False):
     """The Jacobian is the first derivative of the least squares error
@@ -603,7 +603,7 @@ def _nlls_jacobian_func(tensor_elements, design_matrix, data, Diso=3e-3,
     f_transform : bool, optional
         If true, the water volume fraction was converted to
         ft = arcsin(2*f - 1) + pi/2, insuring f estimates between 0 and 1.
-        See fwdti.nlls_fit_tensor
+        See fwdti.nls_fit_tensor
         Default: True
     """
     tensor = np.copy(tensor_elements)
@@ -626,7 +626,7 @@ def _nlls_jacobian_func(tensor_elements, design_matrix, data, Diso=3e-3,
     return np.concatenate((T - S, df[:, None]), axis=1)
 
 
-def nlls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
+def nls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
                     weighting=None, sigma=None, cholesky=False,
                     f_transform=True, jac=False, mdreg=2.7e-3):
     """
@@ -757,7 +757,7 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
         # Use the Levenberg-Marquardt algorithm wrapped in opt.leastsq
         start_params = np.concatenate((dt, [-np.log(s0), f]), axis=0)
         if jac:
-            this_tensor, status = opt.leastsq(_nlls_err_func, start_params[:8],
+            this_tensor, status = opt.leastsq(_nls_err_func, start_params[:8],
                                               args=(design_matrix,
                                                     flat_data[vox],
                                                     Diso,
@@ -765,9 +765,9 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
                                                     sigma,
                                                     cholesky,
                                                     f_transform),
-                                              Dfun=_nlls_jacobian_func)
+                                              Dfun=_nls_jacobian_func)
         else:
-            this_tensor, status = opt.leastsq(_nlls_err_func, start_params[:8],
+            this_tensor, status = opt.leastsq(_nls_err_func, start_params[:8],
                                               args=(design_matrix,
                                                     flat_data[vox],
                                                     Diso,
@@ -869,6 +869,6 @@ def cholesky_to_lower_triangular(R):
 
 common_fit_methods = {'WLLS': wls_fit_tensor,
                       'WLS': wls_fit_tensor,
-                      'NLLS': nlls_fit_tensor,
-                      'NLS': nlls_fit_tensor,
+                      'NLLS': nls_fit_tensor,
+                      'NLS': nls_fit_tensor,
                       }

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -149,6 +149,15 @@ class FreeWaterTensorModel(ReconstModel):
             mask = np.array(mask, dtype=bool, copy=False)
             data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
+        # Check if at least three b-values are given
+        bmag = int(np.log10(self.gtab.bvals.max()))
+        b = self.gtab.bvals.copy() / (10 ** (bmag-1))  # normalize b units
+        b = b.round()
+        uniqueb = np.unique(b) 
+        if len(uniqueb) < 3:
+            mes = "fwdti fit requires data for at least 2 non zero b-values"
+            raise ValueError(mes)
+
         if self.min_signal is None:
             min_signal = _min_positive_signal(data)
         else:

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -89,7 +89,7 @@ def fwdti_prediction(params, gtab, Diso=3.0e-3):
 class FreeWaterTensorModel(ReconstModel):
     """ Class for the Free Water Elimitation Diffusion Tensor Model
     """
-    def __init__(self, gtab, fit_method="WLS", *args, **kwargs):
+    def __init__(self, gtab, fit_method="NLS", *args, **kwargs):
         """ Free Water Diffusion Tensor Model [1]_.
         Parameters
         ----------
@@ -168,7 +168,7 @@ class FreeWaterTensorModel(ReconstModel):
             out_shape = data.shape[:-1] + (-1, )
             fwdti_params = params_in_mask.reshape(out_shape)
         else:
-            fwdti_params = np.zeros(data.shape[:-1] + (13,))
+            fwdti_params = np.zeros(data.shape[:-1] + (14,))
             fwdti_params[mask, :] = params_in_mask
 
         return FreeWaterTensorFit(self, fwdti_params)
@@ -179,9 +179,10 @@ class FreeWaterTensorModel(ReconstModel):
         Parameters
         ----------
         fwdti_params : ndarray
-            The last dimension should have 13 parameters: the 12 tensor
+            The last dimension should have 14 parameters: the 12 tensor
             parameters (3 eigenvalues, followed by the 3 corresponding
-            eigenvectors) and the volume fraction of the free water compartment
+            eigenvectors), the volume fraction of the free water compartment
+            and the estimate of the non diffusion-weighted signal S0.
         S0 : float or ndarray
             The non diffusion-weighted signal in every voxel, or across all
             voxels. Default: 1
@@ -199,13 +200,14 @@ class FreeWaterTensorFit(TensorFit):
         ----------
         model : FreeWaterTensorModel Class instance
             Class instance containing the free water tensor model for the fit
-        model_params : ndarray (x, y, z, 13) or (n, 13)
+        model_params : ndarray (x, y, z, 14) or (n, 14)
             All parameters estimated from the free water tensor model.
             Parameters are ordered as follows:
                 1) Three diffusion tensor's eigenvalues
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector
                 3) The volume fraction of the free water compartment
+                4) The estimate of the non diffusion-weighted signal S0
         """
         TensorFit.__init__(self, model, model_params)
 
@@ -221,13 +223,14 @@ class FreeWaterTensorFit(TensorFit):
         vertices of a gradient table
         Parameters
         ----------
-        fwdti_params : ndarray (x, y, z, 13) or (n, 13)
+        fwdti_params : ndarray (x, y, z, 14) or (n, 14)
             All parameters estimated from the free water tensor model.
             Parameters are ordered as follows:
                 1) Three diffusion tensor's eigenvalues
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector
                 3) The volume fraction of the free water compartment
+                4) The estimate of the non diffusion-weighted signal S0
         gtab : a GradientTable class instance
             The gradient table for this prediction
         S0 : float or ndarray (optional)
@@ -500,12 +503,13 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, Diso=3e-3,
         Data or response variables holding the data. Note that the last
         dimension should contain the data. It makes no copies of data.
 
-    fw_params: ([X, Y, Z, ...], 13), optional
-           A first model parameters guess (3 eigenvalues follow the coordinates
-           of 3 eigenvalues and the volume fraction of the free water
-           compartment). If the initial fw_paramters are not given, function
-           will use the WLS free water elimination algorithm to estimate the
-           parameters first guess.
+    fw_params: ([X, Y, Z, ...], 14), optional
+           A first model parameters guess (3 eigenvalues, 3 coordinates
+           of 3 eigenvalues, the volume fraction of the free water
+           compartment, and the estimate of the non diffusion-weighted signal
+           S0). If the initial fw_paramters are not given, function will use
+           the WLS free water elimination algorithm to estimate the parameters
+           first guess.
            Default: None
 
     Diso : float, optional

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -16,7 +16,7 @@ from dipy.reconst.dti import (TensorFit, design_matrix, _min_positive_signal,
 from dipy.reconst.dti import wls_fit_tensor as dti_wls_fit
 from dipy.reconst.dki import _positive_evals
 
-from .vec_val_sum import vec_val_vect
+from dipy.reconst.vec_val_sum import vec_val_vect
 from dipy.core.ndindex import ndindex
 
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -436,7 +436,7 @@ def wls_fit_tensor(design_matrix, data, S0=None, Diso=3e-3, piterations=3,
 
     # looping WLS solution on all data voxels
     if S0 is None:
-        S0 = np.zeros(data_flat.shape[-1])
+        S0 = np.zeros(len(data_flat))
         S0_p = np.zeros(len(data_flat_p))
         for vox in range(len(data_flat_p)):
             fw_params_p[vox], S0_p[vox] = _wls_iter(design_matrix, inv_design,
@@ -687,9 +687,11 @@ def nlls_fit_tensor(design_matrix, data, fw_params=None, S0=None, Diso=3e-3,
 
     # Initializing fw_params according to selected initial guess
     if np.any(fw_params) is None:
-        fw_params = np.zeros((len(flat_data), 14))
-        fw_params[~cond, :12] = dti_params[~cond, :]
-        fw_params[~cond, 12] = 0.2
+        if np.any(S0) is None:
+            fw_params, S0 = wls_fit_tensor(design_matrix, flat_data, Diso=Diso)
+        else:
+            fw_params, S0 = wls_fit_tensor(design_matrix, flat_data, S0=S0,
+                                           Diso=Diso)
     else:
         fw_params = fw_params.reshape((-1, fw_params.shape[-1]))
 

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -385,7 +385,13 @@ def _wls_iter(design_matrix, inv_design, sig, min_diffusivity, Diso=3e-3,
         for r in range(riterations):
             # Free-water adjusted signal
             S0 = np.exp(-params[6])
-            y = np.log((SI - FS*S0*SFW.T) / (1 - FS))
+            SA = SI - FS*S0*SFW.T
+            # SA < 0 means that the signal components from the free water
+            # component is larger than the total fiber. This cases are present
+            # for inapropriate large volume fractions (given the current S0
+            # value estimated). To avoid the log of negative values:
+            SA[SA <= 0] = 0.0001  # same min signal assumed in dti.py
+            y = np.log(SA / (1-FS))
 
             # Estimate tissue's tensor from inv(A.T*S2*A)*A.T*S2*y
             S2 = np.diag(np.square(np.dot(W, params)))

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -150,3 +150,25 @@ def test_fwdti_predictions():
     assert_array_almost_equal(S_pred1, DWI)
     S_pred2 = fwdm.predict(model_params_mv)
     assert_array_almost_equal(S_pred2, DWI)
+
+
+def test_fwdti_errors():
+    # 1st error - if a unknown fit method is given to the FWTM
+    assert_raises(ValueError, fwdti.FreeWaterTensorModel, gtab_2s,
+                  fit_method="pKT")
+    # 2nd error - if min_signal is negative
+    assert_raises(ValueError, fwdti.FreeWaterTensorModel, gtab_2s,
+                  min_signal=-1)
+    # 3rd error - if incorrect mask is given
+    fwdtiM = fwdti.FreeWaterTensorModel(gtab_2s)
+    incorrect_mask = np.array([[True, True, False], [True, False, False]])
+    assert_raises(ValueError, fwdtiM.fit, DWI, mask=incorrect_mask)
+
+    # Testing the correct usage
+    fwdtiM = fwdti.FreeWaterTensorModel(gtab_2s, min_signal=1)
+    correct_mask = np.zeros((2, 2, 2))
+    correct_mask[0, :, :] = 1;
+    correct_mask = correct_mask > 0
+    fwdtiF = fwdtiM.fit(DWI, mask=correct_mask)
+    assert_array_almost_equal(fwdtiF.fa, FAref)
+    assert_array_almost_equal(fwdtiF.f, GTF)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -11,8 +11,10 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_almost_equal)
 from nose.tools import assert_raises
 from dipy.reconst.dti import (from_lower_triangular, decompose_tensor)
+from dipy.reconst.fwdti import (lower_triangular_to_cholesky,
+                                cholesky_to_lower_triangular)
 from dipy.sims.voxel import (multi_tensor, single_tensor, _check_directions,
-                             all_tensor_evecs)
+                             all_tensor_evecs, multi_tensor_dki)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
 from dipy.data import get_data
@@ -214,3 +216,13 @@ def test_fwdti_restore():
     fwdtiF2 = fwdm2.fit(S_conta)
     assert_array_almost_equal(fwdtiF2.fa, FAdti)
     assert_array_almost_equal(fwdtiF2.f, gtf)
+
+
+def test_cholesky():
+    S, dt, kt = multi_tensor_dki(gtab, mevals, S0=100,
+                                 angles=[(45., 45.), (45., 45.)],
+                                 fractions=[80, 20])
+    R = lower_triangular_to_cholesky(dt)
+    tensor = cholesky_to_lower_triangular(R)
+    assert_array_almost_equal(dt, tensor)
+

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -143,7 +143,6 @@ def test_fwdti_multi_voxel():
 
 def test_fwdti_predictions():
     # single voxel case
-    # test funtion
     gtf = 0.50  # ground truth volume fraction
     angles = [(90, 0), (90, 0)]
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
@@ -158,30 +157,25 @@ def test_fwdti_predictions():
     assert_array_almost_equal(S_pred1, S_conta)
 
     # Testing in model class
-    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS', S0=S0)
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s)
     S_pred2 = fwdm.predict(model_params)
     assert_array_almost_equal(S_pred2, S_conta)
 
     # Testing in fit class
     fwefit = fwdm.fit(S_conta)
-    # Adjust simulations according to model parameters (note here testing the
-    # robustness of fit is not the objective)
-    mevals_ad = np.array([fwefit.model_params[0:3], [0.003, 0.003, 0.003]])
-    angles_ad = fwefit.model_params[3:-2].reshape(3, 3)
-    gtf_ad = fwefit.model_params[-2]
-    S0ad = fwefit.model_params[-1]
-    S_conta_ad, peaks = multi_tensor(gtab_2s, mevals_ad, S0=S0ad,
-                                     angles=angles_ad,
-                                     fractions=[(1-gtf_ad) * 100, gtf_ad*100],
-                                     snr=None)
     S_pred3 = fwefit.predict(gtab_2s)
-    assert_array_almost_equal(S_pred3, S_conta_ad, decimal=5)
+    assert_array_almost_equal(S_pred3, S_conta, decimal=5)
 
     # Multi voxel simulation
-    S_pred1 = fwdti_prediction(model_params_mv, gtab_2s)
+    S_pred1 = fwdti_prediction(model_params_mv, gtab_2s)  # function
     assert_array_almost_equal(S_pred1, DWI)
-    S_pred2 = fwdm.predict(model_params_mv)
+    S_pred2 = fwdm.predict(model_params_mv)  # Model class
     assert_array_almost_equal(S_pred2, DWI)
+    fwefit = fwdm.fit(DWI)  # Fit class
+    S_pred3 = fwefit.predict(gtab_2s)
+    assert_array_almost_equal(S_pred3, DWI)
+    S_pred4 = fwefit.predict(gtab_2s, step=2)  # Assign smaller step
+    assert_array_almost_equal(S_pred4, DWI)
 
 
 def test_fwdti_errors():

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -10,7 +10,8 @@ from numpy.testing import (assert_array_almost_equal, assert_almost_equal)
 from nose.tools import assert_raises
 from dipy.reconst.dti import (from_lower_triangular, decompose_tensor)
 from dipy.reconst.fwdti import (lower_triangular_to_cholesky,
-                                cholesky_to_lower_triangular)
+                                cholesky_to_lower_triangular,
+                                nls_fit_tensor, wls_fit_tensor)
 from dipy.sims.voxel import (multi_tensor, single_tensor,
                              all_tensor_evecs, multi_tensor_dki)
 from dipy.io.gradients import read_bvals_bvecs
@@ -233,3 +234,6 @@ def test_fwdti_jac_multi_voxel():
     fwefit = fwdm.fit(DWI[0, :, :])
     Ffwe = fwefit.f
     assert_array_almost_equal(Ffwe, GTF[0, :])
+
+
+def test_standalone_functions():

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -69,38 +69,31 @@ def test_fwdti_singlevoxel():
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
                                   angles=[(90, 0), (90, 0)],
                                   fractions=[(1-gtf) * 100, gtf*100], snr=None)
-    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS', S0=S0)
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
     fwefit = fwdm.fit(S_conta)
     FAfwe = fwefit.fa
     Ffwe = fwefit.f
-    S0fwe = fwefit.S0
 
     assert_almost_equal(FAdti, FAfwe, decimal=3)
     assert_almost_equal(Ffwe, gtf, decimal=3)
-    assert_almost_equal(S0fwe, S0, decimal=3)
 
     # Test non-linear fit
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', cholesky=False)
     fwefit = fwdm.fit(S_conta)
     FAfwe = fwefit.fa
     Ffwe = fwefit.f
-    S0fwe = fwefit.S0
 
     assert_almost_equal(FAdti, FAfwe)
     assert_almost_equal(Ffwe, gtf)
-    assert_almost_equal(S0fwe, S0, decimal=3)
 
-    # Test non-linear fit, when no first guess is given
-    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', fw_params=None,
-                                      cholesky=False)
+    # Test cholesky
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', cholesky=True)
     fwefit = fwdm.fit(S_conta)
     FAfwe = fwefit.fa
     Ffwe = fwefit.f
-    S0fwe = fwefit.S0
 
     assert_almost_equal(FAdti, FAfwe)
     assert_almost_equal(Ffwe, gtf)
-    assert_almost_equal(S0fwe, 100)
 
 
 def test_fwdti_precision():
@@ -128,16 +121,6 @@ def test_fwdti_multi_voxel():
 
     # Test cholesky
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', cholesky=True)
-    fwefit = fwdm.fit(DWI)
-    Ffwe = fwefit.f
-
-    assert_array_almost_equal(Ffwe, GTF)
-
-    # Test multi voxels with initial guess
-    fwdm_wlls = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
-    fwefit_wlls = fwdm_wlls.fit(DWI)
-    fwe_initial = fwefit_wlls.model_params
-    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, fw_params=fwe_initial)
     fwefit = fwdm.fit(DWI)
     Ffwe = fwefit.f
 
@@ -177,8 +160,6 @@ def test_fwdti_predictions():
     fwefit = fwdm.fit(DWI)  # Fit class
     S_pred3 = fwefit.predict(gtab_2s, S0=100)
     assert_array_almost_equal(S_pred3, DWI)
-    S_pred4 = fwefit.predict(gtab_2s, S0=100, step=2)  # Assign smaller step
-    assert_array_almost_equal(S_pred4, DWI)
 
 
 def test_fwdti_errors():

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -77,28 +77,28 @@ def test_fwdti_precision():
 def test_fwdti_multi_voxel():
     # 8 voxels tested
     DWI = np.zeros((2, 2, 2, len(gtab_2s.bvals)))
-    Fref = np.zeros((2, 2, 2))
     FAref = np.zeros((2, 2, 2))
     # Diffusion of tissue and water compartments are constant for all voxel
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
 
-    # volume fractions are random
+    # volume fractions
+    GTF = np.array([[[0.06, 0.71], [0.33, 0.89]],
+                    [[0., 0,], [0., 0.]]])
     for i in range(2):
         for j in range(2):
-            gtf = random.uniform(0, 1)
+            gtf = GTF[0, i, j]
             S, p = multi_tensor(gtab_2s, mevals, S0=100,
                                 angles=[(0, 0), (0, 0)],
                                 fractions=[(1-gtf) * 100, gtf*100], snr=None)
-            DWI[i, j, 0] = S
-            Fref[i, j, 0] = gtf
-            FAref[i, j, 0] = FAdti
+            DWI[0, i, j] = S
+            FAref[0, i, j] = FAdti
 
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
     fwefit = fwdm.fit(DWI)
     FAfwe = fwefit.fa
     Ffwe = fwefit.f
 
-    assert_array_almost_equal(Ffwe, Fref, decimal=1)
+    assert_array_almost_equal(Ffwe, GTF, decimal=2)
     
 
 def test_fwdti_predictions():

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -93,5 +93,5 @@ def test_fwdti_multi_voxel():
     FAfwe = fwefit.fa
     Ffwe = fwefit.f
 
-    assert_array_almost_equal(Ffwe, Fref, decimal=2)
+    assert_array_almost_equal(Ffwe, Fref, decimal=1)
     

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -41,7 +41,7 @@ def test_fwdti_singlevoxel():
     gtf = 0.50  #ground truth volume fraction
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
-                                  angles=[(0, 0), (0, 0)],
+                                  angles=[(90, 0), (90, 0)],
                                   fractions=[(1-gtf) * 100, gtf*100], snr=None)
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
     fwefit = fwdm.fit(S_conta)
@@ -57,7 +57,7 @@ def test_fwdti_precision():
     gtf = 0.63416  #ground truth volume fraction
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
-                                  angles=[(0, 0), (0, 0)],
+                                  angles=[(90, 0), (90, 0)],
                                   fractions=[(1-gtf) * 100, gtf*100], snr=None)
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS', piterations=5)
     fwefit = fwdm.fit(S_conta)
@@ -82,7 +82,7 @@ def test_fwdti_multi_voxel():
         for j in range(2):
             gtf = GTF[0, i, j]
             S, p = multi_tensor(gtab_2s, mevals, S0=100,
-                                angles=[(0, 0), (0, 0)],
+                                angles=[(90, 0), (90, 0)],
                                 fractions=[(1-gtf) * 100, gtf*100], snr=None)
             DWI[0, i, j] = S
             FAref[0, i, j] = FAdti
@@ -100,7 +100,7 @@ def test_fwdti_predictions():
     # test funtion
     gtf = 0.50  #ground truth volume fraction
     S0=100
-    angles = [(0, 0), (0, 0)]
+    angles = [(90, 0), (90, 0)]
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=S0,
                                   angles=angles,
@@ -128,8 +128,5 @@ def test_fwdti_predictions():
                                      fractions=[(1-gtf_ad) * 100, gtf_ad*100],
                                      snr=None)
     S_pred3 = fwefit.predict(gtab_2s, S0=S0)
-    assert_array_almost_equal(S_pred3, S_conta_ad)
-    
+    assert_array_almost_equal(S_pred3, S_conta_ad, decimal=5)
 
-    S_pred1 = fwdti_prediction(fwefit.model_params, gtab_2s, S0)
-    assert_array_almost_equal(S_pred1, S_conta, decimal=1)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -230,7 +230,7 @@ def test_fwdti_restore():
     assert_array_almost_equal(fwdtiF.fa, FAdti)
     assert_array_almost_equal(fwdtiF.f, gtf)
     # Weighting seem to need a better initial guess
-    fwdm2 = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', weighting='gmm', 
+    fwdm2 = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', weighting='gmm',
                                        fw_params=fwdfit_ini.model_params)
     fwdtiF2 = fwdm2.fit(S_conta)
     assert_array_almost_equal(fwdtiF2.fa, FAdti)
@@ -259,7 +259,7 @@ def test_fwdti_jac_multi_voxel():
     fwefit = fwdm.fit(DWI[0, :, :])
     Ffwe = fwefit.f
     assert_array_almost_equal(Ffwe, GTF[0, :])
-    
+
     # with f transform
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS',
                                       fw_params=fw_params_initial,
@@ -268,4 +268,3 @@ def test_fwdti_jac_multi_voxel():
     fwefit = fwdm.fit(DWI[0, :, :])
     Ffwe = fwefit.f
     assert_array_almost_equal(Ffwe, GTF[0, :])
-

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -44,11 +44,11 @@ FAref = np.zeros((2, 2, 2))
 mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
 # volume fractions
 GTF = np.array([[[0.06, 0.71], [0.33, 0.91]],
-                [[0., 0,], [0., 0.]]])
+                [[0., 0.], [0., 0.]]])
 # S0 multivoxel
 S0m = 100 * np.ones((2, 2, 2))
 # model_params ground truth (to be fill)
-model_params_mv = np.zeros((2, 2, 2, 14))         
+model_params_mv = np.zeros((2, 2, 2, 14))
 for i in range(2):
     for j in range(2):
         gtf = GTF[0, i, j]
@@ -65,7 +65,7 @@ for i in range(2):
 
 def test_fwdti_singlevoxel():
     # Simulation when water contamination is added
-    gtf = 0.50  #ground truth volume fraction
+    gtf = 0.50  # ground truth volume fraction
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
                                   angles=[(90, 0), (90, 0)],
@@ -86,7 +86,7 @@ def test_fwdti_singlevoxel():
 
     assert_almost_equal(FAdti, FAfwe)
     assert_almost_equal(Ffwe, gtf)
-    
+
     # Test non-linear fit, when no first guess is given
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', fw_params=None,
                                       cholesky=False)
@@ -122,14 +122,14 @@ def test_fwdti_multi_voxel():
     Ffwe = fwefit.f
 
     assert_array_almost_equal(Ffwe, GTF)
-    
+
     # Test cholesky
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', cholesky=True)
     fwefit = fwdm.fit(DWI)
     Ffwe = fwefit.f
 
     assert_array_almost_equal(Ffwe, GTF)
-    
+
     # Test multi voxels with initial guess
     fwdm_wlls = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS', S0=S0m)
     fwefit_wlls = fwdm_wlls.fit(DWI)
@@ -139,7 +139,7 @@ def test_fwdti_multi_voxel():
     Ffwe = fwefit.f
 
     assert_array_almost_equal(Ffwe, GTF)
-    
+
 
 def test_fwdti_predictions():
     # single voxel case
@@ -193,7 +193,7 @@ def test_fwdti_errors():
     # Testing the correct usage
     fwdtiM = fwdti.FreeWaterTensorModel(gtab_2s, min_signal=1)
     correct_mask = np.zeros((2, 2, 2))
-    correct_mask[0, :, :] = 1;
+    correct_mask[0, :, :] = 1
     correct_mask = correct_mask > 0
     fwdtiF = fwdtiM.fit(DWI, mask=correct_mask)
     assert_array_almost_equal(fwdtiF.fa, FAref)
@@ -207,13 +207,13 @@ def test_fwdti_errors():
 def test_fwdti_restore():
     # Restore has to work well even in nonproblematic cases
     # Simulate a signal corrupted by free water diffusion contamination
-    gtf = 0.50  #ground truth volume fraction
+    gtf = 0.50  # ground truth volume fraction
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
                                   angles=[(90, 0), (90, 0)],
                                   fractions=[(1-gtf) * 100, gtf*100], snr=None)
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', weighting='sigma',
-                                      sigma = 4)
+                                      sigma=4)
     fwdtiF = fwdm.fit(S_conta)
     assert_array_almost_equal(fwdtiF.fa, FAdti)
     assert_array_almost_equal(fwdtiF.f, gtf)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -231,3 +231,25 @@ def test_cholesky_functions():
     tensor = cholesky_to_lower_triangular(R)
     assert_array_almost_equal(dt, tensor)
 
+
+def test_fwdti_jac_multi_voxel():
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS', S0=S0m[0, :])
+    fwefit = fwdm.fit(DWI[0, :, :])
+    fw_params_initial = fwefit.model_params
+
+    # no f transform
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS',
+                                      fw_params=fw_params_initial,
+                                      f_transform=False, jac=True)
+    fwefit = fwdm.fit(DWI[0, :, :])
+    Ffwe = fwefit.f
+    assert_array_almost_equal(Ffwe, GTF[0, :])
+    
+    # with f transform
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS',
+                                      fw_params=fw_params_initial,
+                                      f_transform=True, jac=True)
+    fwefit = fwdm.fit(DWI[0, :, :])
+    Ffwe = fwefit.f
+    assert_array_almost_equal(Ffwe, GTF[0, :])
+

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -195,9 +195,7 @@ def test_fwdti_errors():
     assert_raises(ValueError, fwdtiM.fit, DWI, mask=incorrect_mask)
 
     # 4rd error - if data with only one non zero b-value is given
-    fwdtiM = fwdti.FreeWaterTensorModel(gtab)
-    S_tissue = single_tensor(gtab, S0=100, evals=evals, evecs=evecs, snr=None)
-    assert_raises(ValueError, fwdtiM.fit, S_tissue)
+    assert_raises(ValueError, fwdti.FreeWaterTensorModel, gtab)
 
     # Testing the correct usage
     fwdtiM = fwdti.FreeWaterTensorModel(gtab_2s, min_signal=1)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -83,7 +83,7 @@ def test_fwdti_singlevoxel():
     assert_almost_equal(FAdti, FAfwe)
     assert_almost_equal(Ffwe, gtf)
     
-    # Test non-linear fit, when no first quess is given
+    # Test non-linear fit, when no first guess is given
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', fw_params=None)
     fwefit = fwdm.fit(S_conta)
     FAfwe = fwefit.fa
@@ -97,7 +97,7 @@ def test_fwdti_singlevoxel():
 
 def test_fwdti_precision():
     # Simulation when water contamination is added
-    gtf = 0.63416  #ground truth volume fraction
+    gtf = 0.63416  # ground truth volume fraction
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
                                   angles=[(90, 0), (90, 0)],
@@ -122,7 +122,7 @@ def test_fwdti_multi_voxel():
 def test_fwdti_predictions():
     # single voxel case
     # test funtion
-    gtf = 0.50  #ground truth volume fraction
+    gtf = 0.50  # ground truth volume fraction
     S0=100
     angles = [(90, 0), (90, 0)]
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
@@ -184,14 +184,13 @@ def test_fwdti_errors():
     assert_array_almost_equal(fwdtiF.fa, FAref)
     assert_array_almost_equal(fwdtiF.f, GTF)
 
-    # 4th error - if a sigma is selected by no value of sigma is given for
-    # in the non-linear approach to performe restore
+    # 4th error - if a sigma is selected by no value of sigma is given
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS', weighting='sigma')
     assert_raises(ValueError, fwdm.fit, DWI)
 
 
 def test_fwdti_restore():
-    # Restore have to work well even in nonproblematic cases
+    # Restore has to work well even in nonproblematic cases
     # Simulate a signal corrupted by free water diffusion contamination
     gtf = 0.50  #ground truth volume fraction
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -7,7 +7,12 @@ import random
 import dipy.reconst.dti as dti
 import dipy.reconst.fwdti as fwdti
 from dipy.reconst.fwdti import fwdti_prediction
+<<<<<<< HEAD
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal)
+=======
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_almost_equal)
+>>>>>>> TEST, BF: First version of the fwdti_prediction test (still single voxel and with low precision). Bug in function fwdti_prediction found and fix
 from nose.tools import assert_raises
 from dipy.reconst.dti import (from_lower_triangular, decompose_tensor)
 from dipy.reconst.fwdti import (lower_triangular_to_cholesky,
@@ -95,3 +100,17 @@ def test_fwdti_multi_voxel():
 
     assert_array_almost_equal(Ffwe, Fref, decimal=1)
     
+
+def test_fwdti_predictions():
+    # single voxel case
+    gtf = 0.50  #ground truth volume fraction
+    S0=100
+    mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
+    S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=S0,
+                                  angles=[(0, 0), (0, 0)],
+                                  fractions=[(1-gtf) * 100, gtf*100], snr=None)
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
+    fwefit = fwdm.fit(S_conta)
+
+    S_pred1 = fwdti_prediction(fwefit.model_params, gtab_2s, S0)
+    assert_array_almost_equal(S_pred1, S_conta, decimal=1)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -257,6 +257,21 @@ def test_fwdti_jac_multi_voxel():
     assert_array_almost_equal(Ffwe, GTF[0, :])
 
 
+def test_md_regularization():
+    # single voxel
+    gtf = 0.97  # for this ground truth value, md is larger than 2.7e-3
+    mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
+    S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
+                                  angles=[(90, 0), (90, 0)],
+                                  fractions=[(1-gtf) * 100, gtf*100], snr=None)
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS')
+    fwefit = fwdm.fit(S_conta)
+
+    assert_array_almost_equal(fwefit.fa, 0.0)
+    assert_array_almost_equal(fwefit.md, 0.0)
+    assert_array_almost_equal(fwefit.f, 1.0)
+
+
 def test_standalone_functions():
     # WLS procedure
     params = wls_fit_tensor(gtab_2s, DWI)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -88,9 +88,11 @@ def test_fwdti_singlevoxel():
     fwefit = fwdm.fit(S_conta)
     FAfwe = fwefit.fa
     Ffwe = fwefit.f
+    S0fwe = fwefit.S0
 
     assert_almost_equal(FAdti, FAfwe)
     assert_almost_equal(Ffwe, gtf)
+    assert_almost_equal(S0fwe, 100)
 
 
 def test_fwdti_precision():

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -41,7 +41,7 @@ FAref = np.zeros((2, 2, 2))
 # Diffusion of tissue and water compartments are constant for all voxel
 mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
 # volume fractions
-GTF = np.array([[[0.06, 0.71], [0.33, 0.89]],
+GTF = np.array([[[0.06, 0.71], [0.33, 0.93]],
                 [[0., 0,], [0., 0.]]])
 # model_params ground truth (to be fill)
 model_params_mv = np.zeros((2, 2, 2, 14))         
@@ -74,6 +74,15 @@ def test_fwdti_singlevoxel():
     assert_almost_equal(FAdti, FAfwe, decimal=3)
     assert_almost_equal(Ffwe, gtf, decimal=3)
 
+    # Test non-linear fit
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS')
+    fwefit = fwdm.fit(S_conta)
+    FAfwe = fwefit.fa
+    Ffwe = fwefit.f
+
+    assert_almost_equal(FAdti, FAfwe)
+    assert_almost_equal(Ffwe, gtf)
+
 
 def test_fwdti_precision():
     # Simulation when water contamination is added
@@ -92,7 +101,7 @@ def test_fwdti_precision():
 
 
 def test_fwdti_multi_voxel():
-    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS')
     fwefit = fwdm.fit(DWI)
     Ffwe = fwefit.f
 

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -194,6 +194,11 @@ def test_fwdti_errors():
     incorrect_mask = np.array([[True, True, False], [True, False, False]])
     assert_raises(ValueError, fwdtiM.fit, DWI, mask=incorrect_mask)
 
+    # 4rd error - if data with only one non zero b-value is given
+    fwdtiM = fwdti.FreeWaterTensorModel(gtab)
+    S_tissue = single_tensor(gtab, S0=100, evals=evals, evecs=evecs, snr=None)
+    assert_raises(ValueError, fwdtiM.fit, S_tissue)
+
     # Testing the correct usage
     fwdtiM = fwdti.FreeWaterTensorModel(gtab_2s, min_signal=1)
     correct_mask = np.zeros((2, 2, 2))

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -7,18 +7,12 @@ import random
 import dipy.reconst.dti as dti
 import dipy.reconst.fwdti as fwdti
 from dipy.reconst.fwdti import fwdti_prediction
-<<<<<<< HEAD
-from numpy.testing import (assert_array_almost_equal, assert_almost_equal)
-=======
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_almost_equal)
->>>>>>> TEST, BF: First version of the fwdti_prediction test (still single voxel and with low precision). Bug in function fwdti_prediction found and fix
 from nose.tools import assert_raises
 from dipy.reconst.dti import (from_lower_triangular, decompose_tensor)
-from dipy.reconst.fwdti import (lower_triangular_to_cholesky,
-                                cholesky_to_lower_triangular)
-from dipy.sims.voxel import (multi_tensor, single_tensor,
-                             all_tensor_evecs, multi_tensor_dki)
+from dipy.sims.voxel import (multi_tensor, single_tensor, _check_directions,
+                             all_tensor_evecs)
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import gradient_table
 from dipy.data import get_data
@@ -103,14 +97,39 @@ def test_fwdti_multi_voxel():
 
 def test_fwdti_predictions():
     # single voxel case
+    # test funtion
     gtf = 0.50  #ground truth volume fraction
     S0=100
+    angles = [(0, 0), (0, 0)]
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
     S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=S0,
-                                  angles=[(0, 0), (0, 0)],
+                                  angles=angles,
                                   fractions=[(1-gtf) * 100, gtf*100], snr=None)
+    R = all_tensor_evecs(peaks[0])
+    R = R.reshape((9))
+    model_params = np.concatenate(([0.0017, 0.0003, 0.0003], R, [gtf]), axis=0)
+    S_pred1 = fwdti_prediction(model_params, gtab_2s, S0)
+    assert_array_almost_equal(S_pred1, S_conta)
+
+    # Testing in model class
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
+    S_pred2 = fwdm.predict(model_params, S0=S0)
+    assert_array_almost_equal(S_pred2, S_conta)
+
+    # Testing in fit class
     fwefit = fwdm.fit(S_conta)
+    # Adjust simulations according to model parameters (note here testing the
+    # robustness of fit is not the objective)
+    mevals_ad = np.array([fwefit.model_params[0:3], [0.003, 0.003, 0.003]])
+    angles_ad = fwefit.model_params[3:-1].reshape(3, 3)
+    gtf_ad = fwefit.model_params[-1]
+    S_conta_ad, peaks = multi_tensor(gtab_2s, mevals_ad, S0=S0,
+                                     angles=angles_ad,
+                                     fractions=[(1-gtf_ad) * 100, gtf_ad*100],
+                                     snr=None)
+    S_pred3 = fwefit.predict(gtab_2s, S0=S0)
+    assert_array_almost_equal(S_pred3, S_conta_ad)
+    
 
     S_pred1 = fwdti_prediction(fwefit.model_params, gtab_2s, S0)
     assert_array_almost_equal(S_pred1, S_conta, decimal=1)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -118,6 +118,14 @@ def test_fwdti_multi_voxel():
 
     assert_array_almost_equal(Ffwe, GTF, decimal=2)
     
+    # Test multi voxels with initial guess
+    fwdm_wlls = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
+    fwefit_wlls = fwdm_wlls.fit(DWI)
+    fwe_initial = fwefit_wlls.model_params
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, fw_params=fwe_initial)
+
+    assert_array_almost_equal(Ffwe, GTF, decimal=2)
+    
 
 def test_fwdti_predictions():
     # single voxel case

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -48,7 +48,7 @@ GTF = np.array([[[0.06, 0.71], [0.33, 0.91]],
 # S0 multivoxel
 S0m = 100 * np.ones((2, 2, 2))
 # model_params ground truth (to be fill)
-model_params_mv = np.zeros((2, 2, 2, 14))
+model_params_mv = np.zeros((2, 2, 2, 13))
 for i in range(2):
     for j in range(2):
         gtf = GTF[0, i, j]
@@ -60,7 +60,7 @@ for i in range(2):
         R = all_tensor_evecs(p[0])
         R = R.reshape((9))
         model_params_mv[0, i, j] = np.concatenate(([0.0017, 0.0003, 0.0003],
-                                                   R, [gtf, 100]), axis=0)
+                                                   R, [gtf]), axis=0)
 
 
 def test_fwdti_singlevoxel():
@@ -155,7 +155,7 @@ def test_fwdti_predictions():
                                   fractions=[(1-gtf) * 100, gtf*100], snr=None)
     R = all_tensor_evecs(peaks[0])
     R = R.reshape((9))
-    model_params = np.concatenate(([0.0017, 0.0003, 0.0003], R, [gtf, 100]),
+    model_params = np.concatenate(([0.0017, 0.0003, 0.0003], R, [gtf]),
                                   axis=0)
     S_pred1 = fwdti_prediction(model_params, gtab_2s, S0=100)
     assert_array_almost_equal(S_pred1, S_conta)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -35,6 +35,29 @@ dm = dti.TensorModel(gtab_2s, 'WLS')
 dtifit = dm.fit(S_tissue)
 FAdti = dtifit.fa
 
+# Simulation of 8 voxels tested
+DWI = np.zeros((2, 2, 2, len(gtab_2s.bvals)))
+FAref = np.zeros((2, 2, 2))
+# Diffusion of tissue and water compartments are constant for all voxel
+mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
+# volume fractions
+GTF = np.array([[[0.06, 0.71], [0.33, 0.89]],
+                [[0., 0,], [0., 0.]]])
+# model_params ground truth (to be fill)
+model_params_mv = np.zeros((2, 2, 2, 13))              
+for i in range(2):
+    for j in range(2):
+        gtf = GTF[0, i, j]
+        S, p = multi_tensor(gtab_2s, mevals, S0=100,
+                            angles=[(90, 0), (90, 0)],
+                            fractions=[(1-gtf) * 100, gtf*100], snr=None)
+        DWI[0, i, j] = S
+        FAref[0, i, j] = FAdti
+        R = all_tensor_evecs(p[0])
+        R = R.reshape((9))
+        model_params_mv[0, i, j] = np.concatenate(([0.0017, 0.0003, 0.0003],
+                                                   R, [gtf]), axis=0)
+
 
 def test_fwdti_singlevoxel():
     # Simulation when water contamination is added
@@ -69,27 +92,8 @@ def test_fwdti_precision():
 
 
 def test_fwdti_multi_voxel():
-    # 8 voxels tested
-    DWI = np.zeros((2, 2, 2, len(gtab_2s.bvals)))
-    FAref = np.zeros((2, 2, 2))
-    # Diffusion of tissue and water compartments are constant for all voxel
-    mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
-
-    # volume fractions
-    GTF = np.array([[[0.06, 0.71], [0.33, 0.89]],
-                    [[0., 0,], [0., 0.]]])
-    for i in range(2):
-        for j in range(2):
-            gtf = GTF[0, i, j]
-            S, p = multi_tensor(gtab_2s, mevals, S0=100,
-                                angles=[(90, 0), (90, 0)],
-                                fractions=[(1-gtf) * 100, gtf*100], snr=None)
-            DWI[0, i, j] = S
-            FAref[0, i, j] = FAdti
-
     fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'WLS')
     fwefit = fwdm.fit(DWI)
-    FAfwe = fwefit.fa
     Ffwe = fwefit.f
 
     assert_array_almost_equal(Ffwe, GTF, decimal=2)
@@ -130,3 +134,8 @@ def test_fwdti_predictions():
     S_pred3 = fwefit.predict(gtab_2s, S0=S0)
     assert_array_almost_equal(S_pred3, S_conta_ad, decimal=5)
 
+    # Multi voxel simulation
+    S_pred1 = fwdti_prediction(model_params_mv, gtab_2s, S0)
+    assert_array_almost_equal(S_pred1, DWI)
+    S_pred2 = fwdm.predict(model_params_mv, S0=S0)
+    assert_array_almost_equal(S_pred2, DWI)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -257,6 +257,20 @@ def test_fwdti_jac_multi_voxel():
     assert_array_almost_equal(Ffwe, GTF[0, :])
 
 
+def test_standalone_functions():
+    # WLS procedure
+    params = wls_fit_tensor(gtab_2s, DWI)
+    assert_array_almost_equal(params[..., 12], GTF)
+    fa = fractional_anisotropy(params[..., :3])
+    assert_array_almost_equal(fa, FAref)
+
+    # NLS procedure
+    params = nls_fit_tensor(gtab_2s, DWI)
+    assert_array_almost_equal(params[..., 12], GTF)
+    fa = fractional_anisotropy(params[..., :3])
+    assert_array_almost_equal(fa, FAref)
+
+
 def test_md_regularization():
     # single voxel
     gtf = 0.97  # for this ground truth value, md is larger than 2.7e-3
@@ -271,16 +285,13 @@ def test_md_regularization():
     assert_array_almost_equal(fwefit.md, 0.0)
     assert_array_almost_equal(fwefit.f, 1.0)
 
+    # multi voxel
+    DWI[0, 1, 1] = S_conta
+    GTF[0, 1, 1] = 1
+    FAref[0, 1, 1] = 0
+    MDref[0, 1, 1] = 0
 
-def test_standalone_functions():
-    # WLS procedure
-    params = wls_fit_tensor(gtab_2s, DWI)
-    assert_array_almost_equal(params[..., 12], GTF)
-    fa = fractional_anisotropy(params[..., :3])
-    assert_array_almost_equal(fa, FAref)
-
-    # NLS procedure
-    params = nls_fit_tensor(gtab_2s, DWI)
-    assert_array_almost_equal(params[..., 12], GTF)
-    fa = fractional_anisotropy(params[..., :3])
-    assert_array_almost_equal(fa, FAref)
+    fwefit = fwdm.fit(DWI)
+    assert_array_almost_equal(fwefit.fa, FAref)
+    assert_array_almost_equal(fwefit.md, MDref)
+    assert_array_almost_equal(fwefit.f, GTF)

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -59,7 +59,7 @@ with the voxel reconstruction. This can be done by first instantiating the
 FreeWaterTensorModel in the following way:
 """
 
-fwdtimodel = fwdti.FreeWaterTensorModel(gtab)
+fwdtimodel = fwdti.FreeWaterTensorModel(gtab, 'NLS', cholesky=False)
 
 """
 To fit the data using the defined model object, we call the ``fit`` function of

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -38,7 +38,7 @@ data = img.get_data()
 affine = img.get_affine()
 
 """
-Before fitting the data, we preform some data pre-processing. We first compute
+Before fitting the data, we perform some data pre-processing. We first compute
 a brain mask to avoid unnecessary calculations on the background of the image.
 """
 
@@ -139,7 +139,7 @@ From the figure, we can see that ...
 
 In addition to the standard diffusion statistics, the FreeWaterDiffusionFit
 instance can be used to display the volume fraction of the free water diffusion
-componet
+component.
 """
 
 F = fwdtifit.f

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -15,8 +15,27 @@ brain tissue atrophy that occurs in pathology or aging).
 
 A way to remove this free water influences is to expand the DTI model to take
 into account two compartments representing the diffusion contributions from
-the tissue and from the CSF.
+the tissue and from the CSF. The expressing of the expanded free water 
+elimination DTI model is shown below:
 
+
+.. math::
+
+    S(\mathbf{g}, b) = S_0(1-f)e^{-b\mathbf{g}^T \mathbf{D}
+    \mathbf{g}}+S_0fe^{-b D_{iso}}
+    
+where $\mathbf{g}$ and $b$ are diffusion grandient direction and weighted
+(more information see :ref:`example_reconst_dti`), $S(\mathbf{g}, b)$ is the
+diffusion-weighted signal measured, $S_0$ is the signal conducted in a
+measurement with no diffusion weighting, $\mathbf{D}$ is the diffusion tensor,
+$f$ the volume fraction of the free water component, and $D_iso$ is the
+isotropic value of the free water diffusion (normally set to $3.0 \times
+10^{-3} mm^{2}s^{-1}$).
+
+In this example, we show how to process a diffusion weighted dataset using the
+free water elimantion.
+
+Let's start by importing the relevant modules:
 """
 
 import numpy as np
@@ -28,6 +47,7 @@ from dipy.data import read_cenir_multib
 from dipy.segment.mask import median_otsu
 
 """
+Without 
 Free water elimination DTI model requires multi-shell data, i.e. data acquired
 from more than one non-zero b-value. Here, we use fetch to download a
 multi-shell dataset with parameters.

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -1,9 +1,21 @@
 """
-=====================================================================
-Title
-=====================================================================
+==========================================================================
+Using the free water elimination model to remove free water contaminations
+==========================================================================
 
-Some background
+As shown previously (see :ref:`example_reconst_dti`), the diffusion tensor
+model is a simple way to characterize the diffusion anisotropy. However, this
+model is not specific to particular type of tissue. For example, diffusion
+anisotropy in regions near the cerebral ventricle and parenchyma can be
+underestimated by partial volume effects of the cerebral spinal fluid (CSF).
+This free water contamination can particularly corrupt diffusion tensor imaging
+analysis of microstructural changes when different groups of subject show
+different brain morphology (e.g. brain ventricle enlargement associated with
+brain tissue atrophy that occurs in pathology or aging).
+
+A way to remove this free water influences is to expand the DTI model to take
+into account two compartments representing the diffusion contributions from
+the tissue and from the CSF.
 
 """
 

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -45,7 +45,7 @@ from dipy.segment.mask import median_otsu
 """
 Without spatial constrains the free water elimination model cannot be solved
 in data acquired from one non-zero b-value _[Hoy2014]. Therefore, here we
-download a dataset that was required from multi b-values.
+download a dataset that was required from multiple b-values.
 """
 
 fetch_cenir_multib(with_raw=False)

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -105,8 +105,6 @@ free water diffusion tensor."""
 
 FA = fwdtifit.fa
 MD = fwdtifit.md
-AD = fwdtifit.ad
-RD = fwdtifit.rd
 
 """
 For comparison we also compute the same standard measures processed by the
@@ -175,6 +173,51 @@ fig1.savefig('In_vivo_free_water_DTI_and_standard_DTI_measures.png')
    while respective MD values are shown in the lower panels (D-F). In addition
    the free water volume fraction estimated from the fwDTI model is shown in
    panel G**.
+
+From the figure, one can observe that the free water elimination model
+produces in general higher values of FA and lower values of MD than the
+standard DTI model. These differences in FA and MD estimation are expected
+due to the suppression of the free water isotropic diffusion components.
+Unexpected high amplitudes of FA are however observed in the periventricular
+gray mater. This is a known artefact of regions associated to voxels with high
+water volume fraction (i.e. voxels containing basically CSF). We are able to
+remove this problematic voxels by excluding all FA values associated with
+measured volume fractions above a reasonable threshold of 0.7:
+"""
+
+FA[F > 0.7] = 0
+dti_FA[F > 0.7] = 0
+
+"""
+Above we reproduce the plots of the in vivo FA from the two DTI fits and where
+we can see that the inflated FA values were practically removed:
+"""
+
+fig1, ax = plt.subplots(1, 3, figsize=(9, 3),
+                        subplot_kw={'xticks': [], 'yticks': []})
+
+fig1.subplots_adjust(hspace=0.3, wspace=0.05)
+ax.flat[0].imshow(FA[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=1)
+ax.flat[0].set_title('A) fwDTI FA')
+ax.flat[1].imshow(dti_FA[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=1)
+ax.flat[1].set_title('B) standard DTI FA')
+
+FAdiff = abs(FA[:, :, axial_slice] - dti_FA[:, :, axial_slice])
+ax.flat[2].imshow(FAdiff.T, cmap='gray', origin='lower', vmin=0, vmax=1)
+ax.flat[2].set_title('C) FA difference')
+
+plt.show()
+fig1.savefig('In_vivo_free_water_DTI_and_standard_DTI_corrected.png')
+
+"""
+.. figure:: In_vivo_free_water_DTI_and_standard_DTI_corrected.png
+   :align: center
+   ** In vivo FA measures obtain from the free water DTI (A) and standard
+   DTI (B) and their difference (C). Problematic inflated FA values of the
+   images were removed by dismissing voxels above a volume fraction threshold
+   of 0.7 **.
 
 References:
 

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -59,7 +59,7 @@ with the voxel reconstruction. This can be done by first instantiating the
 FreeWaterTensorModel in the following way:
 """
 
-fwdtimodel = fwdti.FreeWaterTensorModel(gtab, 'NLS', cholesky=False)
+fwdtimodel = fwdti.FreeWaterTensorModel(gtab)
 
 """
 To fit the data using the defined model object, we call the ``fit`` function of

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -4,14 +4,13 @@ Using the free water elimination model to remove free water contamination
 ==========================================================================
 
 As shown previously (see :ref:`example_reconst_dti`), the diffusion tensor
-model is a simple way to characterize the diffusion anisotropy. However, this
-model is not specific to particular type of tissue. For example, diffusion
-anisotropy in regions near the cerebral ventricle and parenchyma can be
-underestimated by partial volume effects of the cerebral spinal fluid (CSF).
-This free water contamination can particularly corrupt diffusion tensor imaging
-analysis of microstructural changes when different groups of subject show
-different brain morphology (e.g. brain ventricle enlargement associated with
-brain tissue atrophy that occurs in several brain pathologies and ageing).
+model is a simple way to characterize diffusion anisotropy. However, in regions
+near the cerebral ventricle and parenchyma can be underestimated by partial
+volume effects of the cerebral spinal fluid (CSF). This free water
+contamination can particularly corrupt diffusion tensor imaging analysis of
+microstructural changes when different groups of subject show different brain
+morphology (e.g. brain ventricle enlargement associated with brain tissue
+atrophy that occurs in several brain pathologies and ageing).
 
 A way to remove this free water influences is to expand the DTI model to take
 into account an extra compartment representing the contributions of free water
@@ -22,16 +21,15 @@ diffusion. The expression of the expanded DTI model is shown below:
     S(\mathbf{g}, b) = S_0(1-f)e^{-b\mathbf{g}^T \mathbf{D}
     \mathbf{g}}+S_0fe^{-b D_{iso}}
 
-where $\mathbf{g}$ and $b$ are diffusion grandient direction and weighted
+where $\mathbf{g}$ and $b$ are diffusion gradient direction and weighted
 (more information see :ref:`example_reconst_dti`), $S(\mathbf{g}, b)$ is the
-diffusion-weighted signal measured, $S_0$ is the signal conducted in a
-measurement with no diffusion weighting, $\mathbf{D}$ is the diffusion tensor,
-$f$ the volume fraction of the free water component, and $D_iso$ is the
-isotropic value of the free water diffusion (normally set to $3.0 \times
-10^{-3} mm^{2}s^{-1}$).
+diffusion-weighted signal measured, $S_0$ is the signal in a measurement with
+no diffusion weighting, $\mathbf{D}$ is the diffusion tensor, $f$ the volume
+fraction of the free water component, and $D_iso$ is the isotropic value of the
+free water diffusion (normally set to $3.0 \times 10^{-3} mm^{2}s^{-1}$).
 
-In this example, we show how to process a diffusion weighted dataset using the
-free water elimantion.
+In this example, we show how to process a diffusion weighting dataset using the
+free water elimination.
 
 Let's start by importing the relevant modules:
 """
@@ -54,7 +52,9 @@ fetch_cenir_multib(with_raw=False)
 
 """
 From the downloaded data, we read only the data acquired with b-values up to
-2000 $s.mm^{-2} to decrease the influence of non-Gaussain _[Hoy2014].
+2000 $s.mm^{-2} to decrease the influence of non-Gaussian diffusion effects
+of the tisse which are not taken into account by the free water elimination
+model _[Hoy2014].
 """
 
 bvals = [200, 400, 1000, 2000]
@@ -83,11 +83,11 @@ mask_roi = np.zeros(data.shape[:-1], dtype=bool)
 mask_roi[:, :, axial_slice] = mask[:, :, axial_slice]
 
 """
-The free water elimantion model fit can then be initialized by instantiating
+The free water elimination model fit can then be initialized by instantiating
 a FreeWaterTensorModel class object:
 """
 
-fwdtimodel = fwdti.FreeWaterTensorModel(gtab, 'NLS', cholesky=False)
+fwdtimodel = fwdti.FreeWaterTensorModel(gtab)
 
 """
 The data can then be fitted using the ``fit`` function of the defined model
@@ -122,8 +122,8 @@ dti_MD = dtifit.md
 
 """
 Below the FA values for both free water elimnantion DTI model and standard DTI
-model are ploted in panels A and B, while the repective MD values are ploted in
-panels D and E. For a better visualization of the effect of the free water
+model are plotted in panels A and B, while the repective MD values are ploted
+in panels D and E. For a better visualization of the effect of the free water
 correction, the differences between these two metrics are shown in panels C and
 E. In addition to the standard diffusion statistics, the estimated volume
 fraction of the free water contamination is shown on panel G.

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -1,6 +1,6 @@
 """
 ==========================================================================
-Using the free water elimination model to remove free water contaminations
+Using the free water elimination model to remove free water contamination
 ==========================================================================
 
 As shown previously (see :ref:`example_reconst_dti`), the diffusion tensor
@@ -11,19 +11,17 @@ underestimated by partial volume effects of the cerebral spinal fluid (CSF).
 This free water contamination can particularly corrupt diffusion tensor imaging
 analysis of microstructural changes when different groups of subject show
 different brain morphology (e.g. brain ventricle enlargement associated with
-brain tissue atrophy that occurs in pathology or aging).
+brain tissue atrophy that occurs in several brain pathologies and ageing).
 
 A way to remove this free water influences is to expand the DTI model to take
-into account two compartments representing the diffusion contributions from
-the tissue and from the CSF. The expressing of the expanded free water 
-elimination DTI model is shown below:
-
+into account an extra compartment representing the contributions of free water
+diffusion. The expression of the expanded DTI model is shown below:
 
 .. math::
 
     S(\mathbf{g}, b) = S_0(1-f)e^{-b\mathbf{g}^T \mathbf{D}
     \mathbf{g}}+S_0fe^{-b D_{iso}}
-    
+
 where $\mathbf{g}$ and $b$ are diffusion grandient direction and weighted
 (more information see :ref:`example_reconst_dti`), $S(\mathbf{g}, b)$ is the
 diffusion-weighted signal measured, $S_0$ is the signal conducted in a
@@ -56,7 +54,7 @@ fetch_cenir_multib(with_raw=False)
 
 """
 From the downloaded data, we read only the data acquired with b-values up to
-2000 $s.mm^{-2} to decrease the influence of non-Gaussain (_[Hoy2014]).
+2000 $s.mm^{-2} to decrease the influence of non-Gaussain _[Hoy2014].
 """
 
 bvals = [200, 400, 1000, 2000]
@@ -70,14 +68,13 @@ affine = img.get_affine()
 """
 The free water DTI model can take some minutes to process the full data set.
 Thus, we remove the background of the image to avoid unnecessary calculations.
-Moreover, for illustration purposes we process only an axial slice of the
-data.
 """
 
 maskdata, mask = median_otsu(data, 4, 2, False, vol_idx=[0, 1], dilate=1)
 
 """
-Moreover, for illustration purposes we select an axial slice of the data.
+Moreover, for illustration purposes we process only an axial slice of the
+data.
 """
 
 axial_slice = 40
@@ -103,9 +100,8 @@ fwdtifit = fwdtimodel.fit(data, mask=mask_roi)
 """
 This 2-steps procedure will create a FreeWaterTensorFit object which contains
 all the diffusion tensor statistics free for free water contaminations. Below
-we extract the fractional anisotropy (FA), the mean diffusivity (MD), the
-axial diffusivity (AD) and  the radial diffusivity (RD) of the free water
-diffusion tensor."""
+we extract the fractional anisotropy (FA) and the mean diffusivity (MD) of the
+free water diffusion tensor."""
 
 FA = fwdtifit.fa
 MD = fwdtifit.md
@@ -113,85 +109,72 @@ AD = fwdtifit.ad
 RD = fwdtifit.rd
 
 """
-From comparison we also compute the same standard measures processed by the
+For comparison we also compute the same standard measures processed by the
 standard DTI model
 """
+
 dtimodel = dti.TensorModel(gtab)
 
 dtifit = dtimodel.fit(data, mask=mask_roi)
 
 dti_FA = dtifit.fa
 dti_MD = dtifit.md
-dti_AD = dtifit.ad
-dti_RD = dtifit.rd
 
 """
-Below the FA, MD, AD, and RD maps of the selected slice are ploted (upper
-panels) and compared to the FA, MD, AD and RD maps obtain from the standard
-DTI model (lower panels).
+Below the FA values for both free water elimnantion DTI model and standard DTI
+model are ploted in panels A and B, while the repective MD values are ploted in
+panels D and E. For a better visualization of the effect of the free water
+correction, the differences between these two metrics are shown in panels C and
+E. In addition to the standard diffusion statistics, the estimated volume
+fraction of the free water contamination is shown on panel G.
 """
 
 fig1, ax = plt.subplots(2, 4, figsize=(12, 6),
                         subplot_kw={'xticks': [], 'yticks': []})
 
 fig1.subplots_adjust(hspace=0.3, wspace=0.05)
+ax.flat[0].imshow(FA[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=1)
+ax.flat[0].set_title('A) fwDTI FA')
+ax.flat[1].imshow(dti_FA[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=1)
+ax.flat[1].set_title('B) standard DTI FA')
 
-ax.flat[0].imshow(FA[:, :, axial_slice], cmap='gray', vmin=0, vmax=1)
-ax.flat[0].set_title('FA (fwDTI)')
-ax.flat[1].imshow(MD[:, :, axial_slice], cmap='gray', vmin=0, vmax=2.5e-3)
-ax.flat[1].set_title('MD (fwDTI)')
-ax.flat[2].imshow(AD[:, :, axial_slice], cmap='gray', vmin=0, vmax=2.5e-3)
-ax.flat[2].set_title('AD (fwDTI)')
-ax.flat[3].imshow(RD[:, :, axial_slice], cmap='gray', vmin=0, vmax=2.5e-3)
-ax.flat[3].set_title('RD (fwDTI)')
+FAdiff = abs(FA[:, :, axial_slice] - dti_FA[:, :, axial_slice])
+ax.flat[2].imshow(FAdiff.T, cmap='gray', origin='lower', vmin=0, vmax=1)
+ax.flat[2].set_title('C) FA difference')
 
-ax.flat[4].imshow(dti_FA[:, :, axial_slice], cmap='gray', vmin=0, vmax=1)
-ax.flat[4].set_title('FA (DTI)')
-ax.flat[5].imshow(dti_MD[:, :, axial_slice], cmap='gray', vmin=0, vmax=2.5e-3)
-ax.flat[5].set_title('MD (DTI)')
-ax.flat[6].imshow(dti_AD[:, :, axial_slice], cmap='gray', vmin=0, vmax=2.5e-3)
-ax.flat[6].set_title('AD (DTI)')
-ax.flat[7].imshow(dti_RD[:, :, axial_slice], cmap='gray', vmin=0, vmax=2.5e-3)
-ax.flat[7].set_title('RD (DTI)')
+ax.flat[3].axis('off')
 
-plt.show()
-fig1.savefig('Diffusion_measures_from_free_water_DTI_and_standard_DTI.png')
+ax.flat[4].imshow(MD[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=2.5e-3)
+ax.flat[4].set_title('D) fwDTI MD')
+ax.flat[5].imshow(dti_MD[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=2.5e-3)
+ax.flat[5].set_title('E) standard DTI MD')
 
-"""
-.. figure:: Diffusion_measures_from_free_water_DTI_and_standard_DTI.png
-   :align: center
-   **Diffusion tensor measures obtain from the diffusion tensor estimated from
-   the free water DTI (upper panels) and standard DTI (lower panels).**.
-
-From the figure, we can see that ...
-
-In addition to the standard diffusion statistics, the FreeWaterDiffusionFit
-instance can be used to display the volume fraction of the free water diffusion
-component.
-"""
+MDdiff = abs(MD[:, :, axial_slice] - dti_MD[:, :, axial_slice])
+ax.flat[6].imshow(MDdiff.T, origin='lower', cmap='gray', vmin=0, vmax=2.5e-3)
+ax.flat[6].set_title('F) MD difference')
 
 F = fwdtifit.f
-S0 = fwdtifit.S0
 
-fig2, ax = plt.subplots(1, 2, figsize=(12, 6),
-                        subplot_kw={'xticks': [], 'yticks': []})
-
-fig2.subplots_adjust(hspace=0.3, wspace=0.05)
-
-ax.flat[0].imshow(F[:, :, axial_slice], cmap='gray', vmin=0, vmax=1)
-ax.flat[0].set_title('F')
-ax.flat[1].imshow(S0[:, :, axial_slice], cmap='gray')
-ax.flat[1].set_title('S0')
+ax.flat[7].imshow(F[:, :, axial_slice].T, origin='lower',
+                  cmap='gray', vmin=0, vmax=1)
+ax.flat[7].set_title('G) free water volume')
 
 plt.show()
-fig2.savefig('Volume_fraction_of_the_water_diffusion_component.png')
+fig1.savefig('In_vivo_free_water_DTI_and_standard_DTI_measures.png')
 
 """
-.. figure:: Volume_fraction_of_the_water_diffusion_component.png
+.. figure:: In_vivo_free_water_DTI_and_standard_DTI_measures.png
    :align: center
-   **Volume fraction of the water diffusion component.**.
-
-[Insert Figure explanation]
+   ** In vivo diffusion measures obtain from the free water DTI and standard
+   DTI. The values of Fractional Anisotropy for the free water DTI model and
+   standard DTI model and their difference are shown in the upper panels (A-C),
+   while respective MD values are shown in the lower panels (D-F). In addition
+   the free water volume fraction estimated from the fwDTI model is shown in
+   panel G**.
 
 References:
 


### PR DESCRIPTION
In this pull request the free water tensor model will be added to Dipy. The model's fit will be based on the method proposed in [http://www.ncbi.nlm.nih.gov/pubmed/25271843](http://www.ncbi.nlm.nih.gov/pubmed/25271843). 

As @arokem suggested this technique will be implemented in a separate reconst module which I named fwdti.py. Since this technique is an expansion of the simple DTI model, its classes will be defined from inheritance of the classes defined on Dipy's DTI module. 

At the moment, I just add the structures for the fwdti class. My very next step will be editing class FreeWaterTensorModel. 