### PR TITLE
Make dti reconst less memory hungry

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1218,7 +1218,7 @@ def iter_fit_tensor(step=1e4):
             if step >= size:
                 return fit_tensor(design_matrix, data, *args, **kwargs)
             data = data.reshape(-1, data.shape[-1])
-            dtiparams = np.empty((size, 12), dtype=np.float64)
+            dtiparams = np.empty((size, 12), dtype=np.float32)
             for i in range(0, size, step):
                 dtiparams[i:i+step] = fit_tensor(design_matrix, data[i:i+step],
                                                  *args, **kwargs)


### PR DESCRIPTION
Since the change to vectorized operation, it processes 1000 voxels by default instead of 1. While faster, it's also memory hungry (with the first version causing out of memory on simple datasets). Following the computing tracks as f32, here is a computing eigenvalues as f64, but returning them as f32 change. 

My plain normal dti script was using 12 go of ram on an hcp dataset (and something swapping), so this change should reduce the memory usage. It should also downgrade computed metrics to f32 precision, but as long as only the end result is returned as f32 everything should behave fine I recon.