### PR TITLE
miscellaneous Python 3 compatibility problem fixes in fvtk

### DIFF
--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -1,4 +1,4 @@
-# from __future__ import division, print_function, absolute_import
+from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
@@ -157,7 +157,7 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
 
         def display(self, x=None, y=None, z=None):
             if x is None and y is None and z is None:
-                self.display_extent(ex1, ex2, ey1, ey2, ez2/2, ez2/2)
+                self.display_extent(ex1, ex2, ey1, ey2, ez2//2, ez2//2)
             if x is not None:
                 self.display_extent(x, x, ey1, ey2, ez1, ez2)
             if y is not None:

--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -67,6 +67,12 @@ if have_vtk:
                                  show, record, snapshot)
     from dipy.viz.actor import line, streamtube, slicer, axes
 
+    try:
+        from vtk import vtkVolumeTextureMapper2D
+        have_vtk_texture_mapper2D = True
+    except:
+        have_vtk_texture_mapper2D = False
+
 
 def dots(points, color=(1, 0, 0), opacity=1, dot_size=5):
     """ Create one or more 3d points
@@ -479,6 +485,9 @@ def volume(vol, voxsz=(1.0, 1.0, 1.0), affine=None, center_origin=1,
             colormap[i, 0], colormap[i, 1], colormap[i, 2], colormap[i, 3])
 
     if(maptype == 0):
+        if not have_vtk_texture_mapper2D:
+            raise ValueError("VolumeTextureMapper2D is not available in your "
+                             "version of VTK")
 
         property = vtk.vtkVolumeProperty()
         property.SetColor(color)

--- a/dipy/viz/window.py
+++ b/dipy/viz/window.py
@@ -35,6 +35,8 @@ vtk, have_vtk, setup_module = optional_package('vtk')
 colors, have_vtk_colors, _ = optional_package('vtk.util.colors')
 numpy_support, have_ns, _ = optional_package('vtk.util.numpy_support')
 _, have_imread, _ = optional_package('Image')
+if not have_imread:
+    _, have_imread, _ = optional_package('PIL')
 
 if have_vtk:
     version = vtk.vtkVersion.GetVTKSourceVersion().split(' ')[-1]

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -102,15 +102,18 @@ streamlines = list(streamlines)
 
 # Prepare the display objects.
 color = line_colors(streamlines)
-streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
 
-# Create the 3d display.
-r = fvtk.ren()
-fvtk.add(r, streamlines_actor)
+if fvtk.have_vtk:
+    streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
 
-# Save still images for this static example. Or for interactivity use fvtk.show
-fvtk.record(r, n_frames=1, out_path='deterministic.png',
-            size=(800, 800))
+    # Create the 3d display.
+    r = fvtk.ren()
+    fvtk.add(r, streamlines_actor)
+
+    # Save still images for this static example. Or for interactivity use
+    # fvtk.show
+    fvtk.record(r, n_frames=1, out_path='deterministic.png',
+                size=(800, 800))
 
 """
 .. figure:: deterministic.png
@@ -189,15 +192,17 @@ streamlines = list(streamlines)
 
 # Prepare the display objects.
 color = line_colors(streamlines)
-streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
 
-# Create the 3d display.
-r = fvtk.ren()
-fvtk.add(r, streamlines_actor)
+if fvtk.have_vtk:
+    streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
 
-# Save still images for this static example.
-fvtk.record(r, n_frames=1, out_path='probabilistic.png',
-            size=(800, 800))
+    # Create the 3d display.
+    r = fvtk.ren()
+    fvtk.add(r, streamlines_actor)
+
+    # Save still images for this static example.
+    fvtk.record(r, n_frames=1, out_path='probabilistic.png',
+                size=(800, 800))
 
 """
 .. figure:: probabilistic.png

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -11,7 +11,7 @@ with higher angular resolution.
 In this example we will show with simulated data how this method's ODF performs
 against standard DSI ODF and a ground truth multi tensor ODF.
 """
-
+import numpy as np
 from dipy.sims.voxel import multi_tensor, multi_tensor_odf
 from dipy.data import get_data, get_sphere
 from dipy.core.gradients import gradient_table

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -7,6 +7,7 @@ Simple volume slicing
 Here we present an example for visualizing slices from 3D images.
 
 """
+from __future__ import division
 
 import os
 import nibabel as nib
@@ -73,7 +74,7 @@ Now we have a new ``slice_actor`` which displays the middle slice of saggital
 plane.
 """
 
-slice_actor2.display(slice_actor2.shape[0]/2, None, None)
+slice_actor2.display(slice_actor2.shape[0]//2, None, None)
 
 renderer.add(slice_actor2)
 

--- a/doc/examples/viz_widgets.py
+++ b/doc/examples/viz_widgets.py
@@ -9,7 +9,7 @@ In this example we will create: a) two parallel steamtubes, b) add some buttons
 which will change the opacity of these tubes and c) move the streamtubes using
 a slider.
 """
-
+from __future__ import print_function
 import numpy as np
 from dipy.viz import window, actor, widget
 from dipy.data import fetch_viz_icons, read_viz_icons
@@ -99,7 +99,7 @@ And we add a simple clickable text overlay at the bottom left corner.
 
 
 def text_clicked(obj, event):
-    print "Awesome!"
+    print("Awesome!")
 
 text = widget.text(show_manager.iren, show_manager.ren,
                    message="Powered by DIPY",


### PR DESCRIPTION
I was testing out `fvtk` (which is very nice by the way!) and encountered a number of small issues related to integer division, etc on Python 3 in both `dipy.viz` and a few of the examples.

I can omit b99d107227058b7e8bc58c8f1f64810f69d74235 if you don't want that one here.  It is related to future VTK 7.0 compatibility which I will discuss in a separate issue.