### PR TITLE
Add reference to gitter chat room in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ https://mail.python.org/mailman/listinfo/neuroimaging
 Please see the users' forum at
 https://neurostars.org
 
+Please join the gitter chatroom `here <https://gitter.im/nipy/dipy>`_.
+
 Code
 ====
 


### PR DESCRIPTION
As a new contributor, I believe it is helpful if the chat room is mentioned in the README.