### PR TITLE
Updates for upcoming numpy 1.11 release

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -243,7 +243,7 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
                            mode='w+',
                            shape=(data.shape[0], npeaks))
         if return_sh:
-            nbr_shm_coeff = (sh_order + 2) * (sh_order + 1) / 2
+            nbr_shm_coeff = (sh_order + 2) * (sh_order + 1) // 2
             pam.shm_coeff = np.memmap(path.join(tmpdir, 'shm.npy'),
                                       dtype=pam_res[0].shm_coeff.dtype,
                                       mode='w+',

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -278,7 +278,7 @@ def test_SphHarmFit():
     assert_equal(item.shape, ())
     slice = fit[0]
     assert_equal(slice.shape, (4, 5))
-    slice = fit[..., 0]
+    slice = fit[:, :, 0]
     assert_equal(slice.shape, (3, 4))
 
 

--- a/dipy/tracking/local/tests/test_local_tracking.py
+++ b/dipy/tracking/local/tests/test_local_tracking.py
@@ -39,7 +39,7 @@ def test_stop_conditions():
         def initial_direction(self, point):
             # Test tracking along the rows (z direction)
             # of the tissue array above
-            p = np.round(point)
+            p = np.round(point).astype(int)
             if (any(p < 0) or
                 any(p >= tissue.shape) or
                 tissue[p[0], p[1], p[2]] == TissueTypes.INVALIDPOINT):
@@ -154,7 +154,7 @@ def test_stop_conditions():
     bad_affine = np.eye(3)
     npt.assert_raises(ValueError, LocalTracking, dg, tc, seeds, bad_affine, 1.)
 
-    bad_affine = np.eye(4.)
+    bad_affine = np.eye(4)
     bad_affine[0, 1] = 1.
     npt.assert_raises(ValueError, LocalTracking, dg, tc, seeds, bad_affine, 1.)
 

--- a/dipy/tracking/local/tests/test_local_tracking.py
+++ b/dipy/tracking/local/tests/test_local_tracking.py
@@ -151,7 +151,7 @@ def test_stop_conditions():
     npt.assert_equal(sl[-1], seeds[y])
     npt.assert_equal(len(sl), 1)
 
-    bad_affine = np.eye(3.)
+    bad_affine = np.eye(3)
     npt.assert_raises(ValueError, LocalTracking, dg, tc, seeds, bad_affine, 1.)
 
     bad_affine = np.eye(4.)

--- a/dipy/tracking/tests/test_markov.py
+++ b/dipy/tracking/tests/test_markov.py
@@ -250,7 +250,7 @@ def test_ProbabilisticOdfWeightedTracker():
 
     class MyFit(object):
         def __init__(self, n):
-            self.n = n
+            self.n = int(n)
 
         def odf(self, sphere):
             return odf_list[self.n]


### PR DESCRIPTION
Is coming down the pipes quick. 

Bringing with it the following errors: 

```
======================================================================
ERROR: dipy.reconst.tests.test_shm.test_SphHarmFit
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/reconst/tests/test_shm.py", line 281, in test_SphHarmFit
    slice = fit[..., 0]
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/reconst/shm.py", line 577, in __getitem__
    new_coef = self._shm_coef[coef_index]
IndexError: an index can only have a single ellipsis ('...')

======================================================================
ERROR: This tests that the Local Tracker behaves as expected for the
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/local/tests/test_local_tracking.py", line 92, in test_stop_conditions
    bad_affine = np.eye(3.)
  File "/usr/lib/python2.7/dist-packages/numpy/lib/twodim_base.py", line 233, in eye
    m = zeros((N, M), dtype=dtype)
TypeError: 'float' object cannot be interpreted as an index

======================================================================
ERROR: dipy.tracking.tests.test_markov.test_ProbabilisticOdfWeightedTracker
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/tests/test_markov.py", line 285, in test_ProbabilisticOdfWeightedTracker
    for streamline in pwt:
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/utils.py", line 898, in move_streamlines
    for sl in streamlines:
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/markov.py", line 220, in _generate_streamlines
    directions = self._next_step(s, prev_step=None)
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/markov.py", line 391, in _next_step
    return self._get_directions(fit)
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/markov.py", line 31, in __call__
    discrete_odf = fit.odf(self.sphere)
  File "/build/dipy-0.10.1/debian/tmp/usr/lib/python2.7/dist-packages/dipy/tracking/tests/test_markov.py", line 256, in odf
    return odf_list[self.n]
TypeError: only integer scalar arrays can be converted to a scalar index
```

For now, this PR fixes the second of these. 
