### PR TITLE
BF: correct handling of output paths in dipy_quickbundles.

### DIFF
--- a/bin/dipy_quickbundles
+++ b/bin/dipy_quickbundles
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
 
             if params.out_file:
-                this_split = params.out_file.split('.')
+                this_split = os.path.splitext(params.out_file)
                 out_fname_clust = this_split[0] + '_%s'%(c + 1) + '.trk'
             else:
                 out_fname_clust = split[0] + '_%s'%(c + 1) + split[1]
@@ -63,7 +63,7 @@ if __name__ == "__main__":
             trackvis.write(out_fname_clust, new_streamlines, hdr)
 
         if params.out_file:
-            this_split = params.out_file.split('.')
+            this_split = os.path.splitext(params.out_file)
             out_fname_cent = this_split[0] + '_centroids' + '.trk'
         else:
             out_fname_cent = split[0] + '_centroids' + split[1]

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -6,6 +6,7 @@ Run scripts and check outputs
 """
 from __future__ import division, print_function, absolute_import
 
+import glob
 import os
 import shutil
 
@@ -121,3 +122,25 @@ def test_qb_commandline():
                '--out_file', 'tracks300.trk']
         out = run_command(cmd)
         assert_equal(out[0], 0)
+
+@nt.dec.skipif(no_mpl)
+def test_qb_commandline_output_path_handling():
+    with InTemporaryDirectory():
+        # Create temporary subdirectory for input and for output
+        os.mkdir('work')
+        os.mkdir('output')
+
+        os.chdir('work')
+        tracks_file = get_data('fornix')
+
+        # Need to specify an output directory with a "../" style path
+        # to trigger old bug.
+        cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
+               '--out_file', '../output/tracks300.trk']
+        out = run_command(cmd)
+        assert_equal(out[0], 0)
+
+        # Make sure the files were created in the output directory
+        os.chdir('../')
+        output_files_list = glob.glob('output/tracks300_*.trk')
+        assert_true(output_files_list)

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -136,7 +136,7 @@ def test_qb_commandline_output_path_handling():
         # Need to specify an output directory with a "../" style path
         # to trigger old bug.
         cmd = ["dipy_quickbundles", tracks_file, '--pkl_file', 'mypickle.pkl',
-               '--out_file', '../output/tracks300.trk']
+               '--out_file', os.path.join('..', 'output', 'tracks300.trk')]
         out = run_command(cmd)
         assert_equal(out[0], 0)
 


### PR DESCRIPTION
Now using a splitext call to correctly get the full path of the output file.

Previously, setting the output_file as something in another directory (by using a path like "../other_dir/output.trk") would still output all files in the current directory, with a broken name.

EDIT: I also checked that the other scripts do not have a similar behavior. They don't.