### PR TITLE
Updating release dates

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -24,14 +24,14 @@ Dipy
 
 The code found in Dipy was created by the people found in the AUTHOR file.
 
-* 0.11 (Friday, February 12th, 2016)
+* 0.11 (Sunday, February 21st, 2016)
 
 - New framework for contextual enhancement of ODFs.
 - Compatibility with numpy (1.11).
 - Compatibility with VTK 7.0 which supports Python 3.x.
 - Faster PIESNO for noise estimation.
 - Reorient gradient directions according to motion correction parameters.
-- Dropped support for Python 3.2.
+- Supporting Python 3.3+ but not 3.2.
 - Reduced memory usage in DTI.
 - DSI now can use datasets with multiple b0s.
 - Fixed different issues with Windows 64bit and Python 3.5.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ Highlights
 - Compatibility with VTK 7.0 which supports Python 3.x.
 - Faster PIESNO for noise estimation.
 - Reorient gradient directions according to motion correction parameters.
-- Dropped support for Python 3.2.
+- Supporting Python 3.3+ but not 3.2.
 - Reduced memory usage in DTI.
 - DSI now can use datasets with multiple b0s.
 - Fixed different issues with Windows 64bit and Python 3.5.
@@ -41,7 +41,7 @@ See :ref:`older highlights <old_highlights>`.
 Announcements
 *************
 
-- :ref:`Dipy 0.11 <release0.11>` released February 15, 2015.
+- :ref:`Dipy 0.11 <release0.11>` released February 21, 2015.
 - :ref:`Dipy 0.10 <release0.10>` released December 4, 2015.
 - :ref:`Dipy 0.9.2 <release0.9>` released, March 18, 2015.
 - :ref:`Dipy 0.8.0 <release0.8>` released, January 6, 2015.


### PR DESCRIPTION
We need to update also the release notes...

Release notes for Dipy version 0.11
GitHub stats for 2015/12/03 - 2016/02/12 (tag: 0.10)

The following 16 authors contributed 230 commits.