### PR TITLE
BW: skimage.filter module name warning

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -8,7 +8,7 @@ from dipy.reconst.dti import fractional_anisotropy, color_fa
 
 from scipy.ndimage.filters import median_filter
 try:
-    from skimage.filter import threshold_otsu as otsu
+    from skimage.filters import threshold_otsu as otsu
 except:
     from .threshold import otsu
 


### PR DESCRIPTION
When using crop tools, I get this warning message. My fix solves it.

```
skimage_deprecation: The `skimage.filter` module has been renamed to `skimage.filters`.  This placeholder module will be removed in v0.13.
  warn(skimage_deprecation('The `skimage.filter` module has been renamed '
```