### PR TITLE
Slicer fix

### DIFF
--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -68,6 +68,7 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
         nb_components = 1
 
     # Allocate VTK Image Data
+    data = np.copy(data)
     im = vtk.vtkImageData()
     if nb_components == 1:
         if value_range is None:

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -34,12 +34,13 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
     value_range : None or tuple (2,)
         If None then the values will be interpolated from (data.min(),
         data.max()) to (0, 255). Otherwise from (value_range[0],
-        value_range[1]) to (0, 255).
+        value_range[1]) to (0, 255). This parameter is ignored if `data` is an
+        RGB volume.
     opacity : float
         Opacity of 0 means completely transparent and 1 completely visible.
     lookup_colormap : vtkLookupTable
-        If None (default) then a grayscale map is created. It doesn't apply
-        to rgb volumes where the lookup colormap is ignored.
+        If None (default) then a grayscale map is created. This parameter is
+        ignored if `data` is an RGB volume.
     interpolation : string
         If 'linear' (default) then linear interpolation is used on the final
         texture mapping. If 'nearest' then nearest neighbor interpolation is

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -378,7 +378,7 @@ def line(lines, colors=None, opacity=1, linewidth=1,
     linewidth : float, optional
         Line thickness. Default is 1.
     spline_subdiv : int, optional
-        Number of splines subdivision to smooth streamtubes. Default is None
+        Number of splines subdivision to smooth streamlines. Default is None
         which means no subdivision.
     lod : bool
         Use vtkLODActor(level of detail) rather than vtkActor. Default is True.

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -75,7 +75,7 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
         if value_range is None:
             value_range = (np.min(data), np.max(data))
         else:
-            # Rescale data
+            # Clamping data to specified value range
             data[data < value_range[0]] = value_range[0]
             data[data > value_range[1]] = value_range[1]
     else:

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -73,16 +73,15 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
     im = vtk.vtkImageData()
     if major_version <= 5:
         im.SetScalarTypeToUnsignedChar()
+        im.SetNumberOfScalarComponents(nb_components)
+        im.AllocateScalars()
+    else:
+        im.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, nb_components)
     I, J, K = data.shape[:3]
     im.SetDimensions(I, J, K)
     voxsz = (1., 1., 1.)
     # im.SetOrigin(0,0,0)
     im.SetSpacing(voxsz[2], voxsz[0], voxsz[1])
-    if major_version <= 5:
-        im.AllocateScalars()
-        im.SetNumberOfScalarComponents(nb_components)
-    else:
-        im.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, nb_components)
 
     # copy data
     # what I do below is the same as what is commented here but much faster

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -65,15 +65,15 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
         nb_components = 1
 
     if value_range is None:
-        vol = np.interp(data, xp=[data.min(), data.max()], fp=[0, 255])
+        data = np.interp(data, xp=[data.min(), data.max()], fp=[0, 255])
     else:
-        vol = np.interp(data, xp=[value_range[0], value_range[1]], fp=[0, 255])
-    vol = vol.astype('uint8')
+        data = np.interp(data, xp=[value_range[0], value_range[1]], fp=[0, 255])
+    data = data.astype('uint8')
 
     im = vtk.vtkImageData()
     if major_version <= 5:
         im.SetScalarTypeToUnsignedChar()
-    I, J, K = vol.shape[:3]
+    I, J, K = data.shape[:3]
     im.SetDimensions(I, J, K)
     voxsz = (1., 1., 1.)
     # im.SetOrigin(0,0,0)
@@ -86,18 +86,18 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
 
     # copy data
     # what I do below is the same as what is commented here but much faster
-    # for index in ndindex(vol.shape):
+    # for index in ndindex(data.shape):
     #     i, j, k = index
-    #     im.SetScalarComponentFromFloat(i, j, k, 0, vol[i, j, k])
-    vol = np.swapaxes(vol, 0, 2)
-    vol = np.ascontiguousarray(vol)
+    #     im.SetScalarComponentFromFloat(i, j, k, 0, data[i, j, k])
+    data = np.swapaxes(data, 0, 2)
+    data = np.ascontiguousarray(data)
 
     if nb_components == 1:
-        vol = vol.ravel()
+        data = data.ravel()
     else:
-        vol = np.reshape(vol, [np.prod(vol.shape[:3]), vol.shape[3]])
+        data = np.reshape(data, [np.prod(data.shape[:3]), data.shape[3]])
 
-    uchar_array = numpy_support.numpy_to_vtk(vol, deep=0)
+    uchar_array = numpy_support.numpy_to_vtk(data, deep=0)
     im.GetPointData().SetScalars(uchar_array)
 
     if affine is None:


### PR DESCRIPTION
I discovered a major contradiction and bug in the value scaling and lookup table making of the slicer feature. I found the way to make it work. Therefore, the behavior of the slicer changed and the test_fvtk_actors fails, probably with reason. It has to be adapted. I'll need help, since I don't know how to interpret the error. Also, there were some mistakes in the doc-strings. I took the occasion to clean the code. I've tested the Slicer with VTK 5 and 6 the best I could and ran the fvtk_actor test. Everything looks good.
