### PR TITLE
Contextual Enhancement update: fix SNR issue, fix reference

### DIFF
--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -48,7 +48,7 @@ cdef class EnhancementKernel:
         [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis, 
                              J. Portegies, R. Duits. (2015) Fast implementations 
                              of contextual PDE’s for HARDI data processing in 
-                             DIPY. ISMRM 2016 conf. (submitted)
+                             DIPY. ISMRM 2016 conference.
         [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 
                         on the space of positions and orientations and their 
                         application to crossing-preserving smoothing of HARDI 

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -49,9 +49,10 @@ cdef class EnhancementKernel:
                              J. Portegies, R. Duits. (2015) Fast implementations 
                              of contextual PDE’s for HARDI data processing in 
                              DIPY. ISMRM 2016 conf. (submitted)
-        [DuitsAndFranken2011] R. Duits and E. Franken (2011) Morphological and
-                              Linear Scale Spaces for Fiber Enhancement in 
-                              DWI-MRI. J Math Imaging Vis, 46(3):326-368.
+        [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 
+                        on the space of positions and orientations and their 
+                        application to crossing-preserving smoothing of HARDI 
+                        images. International Journal of Computer Vision, 92:231-264.
         [Portegies2015] J. Portegies, G. Sanguinetti, S. Meesters, and R. Duits.
                         (2015) New Approximation of a Scale Space Kernel on SE(3) 
                         and Applications in Neuroimaging. Fifth International

--- a/dipy/denoise/enhancement_kernel.pyx
+++ b/dipy/denoise/enhancement_kernel.pyx
@@ -46,7 +46,7 @@ cdef class EnhancementKernel:
         References
         ----------
         [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis, 
-                             J. Portegies, R. Duits. (2015) Fast implementations 
+                             J. Portegies, R. Duits. (2016) Fast implementations 
                              of contextual PDE’s for HARDI data processing in 
                              DIPY. ISMRM 2016 conference.
         [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -64,9 +64,9 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None):
                                  kernel.get_lookup_table(),
                                  test_mode,
                                  num_threads)
-
+    
     # normalize the output
-    output_norm = output * np.amax(odfs_dsf)/np.amax(output)
+    output_norm = np.multiply(output, np.amax(odfs_dsf)/np.amax(output))
     
     # convert back to SH
     output_sh = sf_to_sh(output_norm, sphere, sh_order=sh_order)

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -39,10 +39,11 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None):
     [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis, 
                          J. Portegies, R. Duits. (2015) Fast implementations of 
                          contextual PDE’s for HARDI data processing in DIPY. 
-                         ISMRM 2016 conf. (submitted)
-    [DuitsAndFranken2011] R. Duits and E. Franken (2011) Morphological and
-                          Linear Scale Spaces for Fiber Enhancement in DWI-MRI.
-                          J Math Imaging Vis, 46(3):326-368.
+                         ISMRM 2016 conference.
+    [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 
+                        on the space of positions and orientations and their 
+                        application to crossing-preserving smoothing of HARDI 
+                        images. International Journal of Computer Vision, 92:231-264.
     [Portegies2015] J. Portegies, G. Sanguinetti, S. Meesters, and R. Duits. 
                     (2015) New Approximation of a Scale Space Kernel on SE(3) and
                     Applications in Neuroimaging. Fifth International

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -11,6 +11,11 @@ from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.data import get_sphere
 from dipy.reconst.shm import sh_to_sf, sf_to_sh
 
+def numpy_mult():
+    m = np.ones(3, np.float64)
+    m * np.amax(m)
+    np.multiply(m, np.amax(m))
+
 def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.
@@ -54,7 +59,7 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None):
                      Combining Contextual PDE flow with Constrained Spherical 
                      Deconvolution. PLoS One.
     """
-    
+
     # convert the ODFs from SH basis to DSF
     sphere = kernel.get_sphere()
     odfs_dsf = sh_to_sf(odfs_sh, sphere, sh_order=sh_order, basis_type=None)
@@ -73,7 +78,7 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None):
     
     return output_sh
     
-def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None):
+def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None, numpy_test=False):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.
 
@@ -99,7 +104,14 @@ def convolve_sf(odfs_sf, kernel, test_mode=False, num_threads=None):
                                  kernel.get_lookup_table(),
                                  test_mode,
                                  num_threads)
-    return output
+
+    # numpy test (temporary)
+    if numpy_test:
+        output_norm = output * np.amax(output)/np.amax(output)
+    else:
+        output_norm = np.multiply(output, np.amax(output)/np.amax(output))
+
+    return output_norm
     
 @cython.wraparound(False)
 @cython.boundscheck(False)

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -40,7 +40,7 @@ def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None, norma
     References
     ----------
     [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis, 
-                         J. Portegies, R. Duits. (2015) Fast implementations of 
+                         J. Portegies, R. Duits. (2016) Fast implementations of 
                          contextual PDE’s for HARDI data processing in DIPY. 
                          ISMRM 2016 conference.
     [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 

--- a/dipy/denoise/shift_twist_convolution.pyx
+++ b/dipy/denoise/shift_twist_convolution.pyx
@@ -11,11 +11,6 @@ from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.data import get_sphere
 from dipy.reconst.shm import sh_to_sf, sf_to_sh
 
-def numpy_mult():
-    m = np.ones(3, np.float64)
-    m * np.amax(m)
-    np.multiply(m, np.amax(m))
-
 def convolve(odfs_sh, kernel, sh_order, test_mode=False, num_threads=None):
     """ Perform the shift-twist convolution with the ODF data and 
     the lookup-table of the kernel.

--- a/dipy/denoise/tests/test_kernel.py
+++ b/dipy/denoise/tests/test_kernel.py
@@ -1,5 +1,5 @@
 from dipy.denoise.enhancement_kernel import EnhancementKernel
-from dipy.denoise.shift_twist_convolution import convolve_sf
+from dipy.denoise.shift_twist_convolution import convolve, convolve_sf
 from dipy.reconst.shm import sh_to_sf, sf_to_sh
 from dipy.core.sphere import Sphere
 from dipy.data import get_sphere
@@ -67,7 +67,7 @@ def test_spike():
     spike[3, 3, 3, 0] = 1
 
     # convolve kernel with delta spike
-    csd_enh = convolve_sf(spike, k, test_mode=True)
+    csd_enh = convolve_sf(spike, k, test_mode=True, normalize=False)
 
     # check if kernel matches with the convolved delta spike
     totalsum = 0.0
@@ -75,6 +75,31 @@ def test_spike():
         totalsum += np.sum(np.array(k.get_lookup_table())[i, 0, :, :, :] - \
                     np.array(csd_enh)[:, :, :, i])    
     npt.assert_equal(totalsum, 0.0)
+
+def test_normalization():
+    """ Test the normalization routine applied after a convolution"""
+    # create kernel
+    D33 = 1.0
+    D44 = 0.04
+    t = 1
+    num_orientations = 5
+    k = EnhancementKernel(D33, D44, t, orientations=num_orientations, force_recompute=True)
+
+    # create a constant dataset
+    numorientations = k.get_orientations().shape[0]
+    spike = np.ones((7, 7, 7, numorientations), dtype=np.float64)
+
+    # convert dataset to SH
+    spike_sh = sf_to_sh(spike, k.get_sphere(), sh_order=8)
+
+    # convolve kernel with delta spike and apply normalization
+    csd_enh = convolve(spike_sh, k, sh_order=8, test_mode=True, normalize=True)
+
+    # convert dataset to DSF
+    csd_enh_dsf = sh_to_sf(csd_enh, k.get_sphere(), sh_order=8, basis_type=None)
+
+    # test if the normalization is performed correctly
+    npt.assert_almost_equal(np.amax(csd_enh_dsf), np.amax(spike))
 
 def test_kernel_input():
     """ Test the kernel for inputs of type Sphere, type int and for input None"""
@@ -92,25 +117,6 @@ def test_kernel_input():
 
     k = EnhancementKernel(D33, D44, t, orientations=0, force_recompute=True)
     npt.assert_equal(k.get_lookup_table().shape, (0, 0, 7, 7, 7))
-
-def test_numpy_mult():
-    """ Temporary test for array multiplication in Cython with Numpy 1.12.0"""
-    
-    # create kernel
-    D33 = 1.0
-    D44 = 0.04
-    t = 1
-    num_orientations = 5
-    k = EnhancementKernel(D33, D44, t, orientations=num_orientations, force_recompute=True)
-
-    # create a delta spike
-    numorientations = k.get_orientations().shape[0]
-    spike = np.zeros((7, 7, 7, numorientations), dtype=np.float64)
-    spike[3, 3, 3, 0] = 1
-
-    # convolve kernel with delta spike
-    csd_enh = convolve_sf(spike, k, test_mode=True, numpy_test=True)
-
 
 if __name__ == '__main__':
     npt.run_module_suite()

--- a/dipy/denoise/tests/test_kernel.py
+++ b/dipy/denoise/tests/test_kernel.py
@@ -93,6 +93,24 @@ def test_kernel_input():
     k = EnhancementKernel(D33, D44, t, orientations=0, force_recompute=True)
     npt.assert_equal(k.get_lookup_table().shape, (0, 0, 7, 7, 7))
 
+def test_numpy_mult():
+    """ Temporary test for array multiplication in Cython with Numpy 1.12.0"""
+    
+    # create kernel
+    D33 = 1.0
+    D44 = 0.04
+    t = 1
+    num_orientations = 5
+    k = EnhancementKernel(D33, D44, t, orientations=num_orientations, force_recompute=True)
+
+    # create a delta spike
+    numorientations = k.get_orientations().shape[0]
+    spike = np.zeros((7, 7, 7, numorientations), dtype=np.float64)
+    spike[3, 3, 3, 0] = 1
+
+    # convolve kernel with delta spike
+    csd_enh = convolve_sf(spike, k, test_mode=True, numpy_test=True)
+
 
 if __name__ == '__main__':
     npt.run_module_suite()

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -51,7 +51,7 @@ onto :math:`{\bf n}`.
 Note that the shift-twist convolution differs from a Euclidean convolution and
 takes into account the non-flat structure of the space :math:`\mathbb{R}^3\rtimes S^2`.
 
-The kernel :math:`P_t` has a stochastic interpretation [DuitsAndFranken_JMIV]_.
+The kernel :math:`P_t` has a stochastic interpretation [DuitsAndFranken_IJCV]_.
 It can be seen as the limiting distribution obtained by accumulating random
 walks of particles in the position/orientation domain, where in each step the
 particles can (randomly) move forward/backward along their current orientation,
@@ -267,7 +267,7 @@ References
                         and Applications in Neuroimaging. Fifth International
                         Conference on Scale Space and Variational Methods in
                         Computer Vision
-.. [DuitsAndFranken_JMIV] R. Duits and E. Franken (2011) Left-invariant diffusions 
+.. [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 
                         on the space of positions and orientations and their 
                         application to crossing-preserving smoothing of HARDI 
                         images. International Journal of Computer Vision, 92:231-264.

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -41,9 +41,9 @@ This equation is solved via a shift-twist convolution (denoted by :math:`\ast_{\
 
 .. math::
 
-  W(\vec{y},\vec{n},t) = (P_t \ast_{\mathbb{R}^3 \rtimes S^2} U)(\vec{y},\vec{n})
-  = \int_{\mathbb{R}^3} \int_{S^2} P_t (R^T_{\vec{n}^\prime}(\vec{y}-\vec{y}^\prime),
-   R^T_{\vec{n}^\prime} \vec{n} ) U(\vec{y}^\prime, \vec{n}^\prime)
+  W({\bf y},{\bf n},t) = (P_t \ast_{\mathbb{R}^3 \rtimes S^2} U)({\bf y},{\bf n})
+  = \int_{\mathbb{R}^3} \int_{S^2} P_t (R^T_{{\bf n}^\prime}({\bf y}-{\bf y}^\prime),
+   R^T_{{\bf n}^\prime} {\bf n} ) U({\bf y}^\prime, {\bf n}^\prime)
 
 Here, :math:`R_{\bf n}` is any 3D rotation that maps the vector :math:`(0,0,1)`
 onto :math:`{\bf n}`.

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -91,7 +91,7 @@ from dipy.segment.mask import median_otsu
 b0_slice = data[:, :, :, 1]
 b0_mask, mask = median_otsu(b0_slice)
 np.random.seed(2)
-data_noisy = add_noise(data, 7.5, np.mean(b0_slice[mask]), noise_type='rician')
+data_noisy = add_noise(data, 10.0, np.mean(b0_slice[mask]), noise_type='rician')
 
 # Select a small part of it
 data_small = data[25:40, 65:80, 35:42]

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -90,12 +90,13 @@ data = img.get_data()
 from dipy.segment.mask import median_otsu
 b0_slice = data[:, :, :, 1]
 b0_mask, mask = median_otsu(b0_slice)
-np.random.seed(2)
+np.random.seed(1)
 data_noisy = add_noise(data, 10.0, np.mean(b0_slice[mask]), noise_type='rician')
 
-# Select a small part of it
-data_small = data[25:40, 65:80, 35:42]
-data_noisy_small = data_noisy[25:40, 65:80, 35:42]
+# Select a small part of it.
+padding = 3 # Include a larger region to avoid boundary effects
+data_small = data[25-padding:40+padding, 65-padding:80+padding, 35:42]
+data_noisy_small = data_noisy[25-padding:40+padding, 65-padding:80+padding, 35:42]
 
 """
 Fit an initial model to the data, in this case Constrained Spherical
@@ -189,17 +190,17 @@ csd_sf_enh = sh_to_sf(csd_shm_enh, sphere, sh_order=8)
 csd_sf_enh_sharp = sh_to_sf(csd_shm_enh_sharp, sphere, sh_order=8)
 
 # Normalize the sharpened ODFs
-csd_sf_enh_sharp = csd_sf_enh_sharp * np.amax(csd_sf_orig)/np.amax(csd_sf_enh_sharp)
+csd_sf_enh_sharp = csd_sf_enh_sharp * np.amax(csd_sf_orig)/np.amax(csd_sf_enh_sharp) * 1.25
 
 """
 The end results are visualized. It can be observed that the end result after
 diffusion and sharpening is closer to the original noiseless dataset.
 """
 
-csd_sf_orig_slice = csd_sf_orig[:, :, [3], :]
-csd_sf_noisy_slice = csd_sf_noisy[:, :, [3], :]
-csd_sf_enh_slice = csd_sf_enh[:, :, [3], :]
-csd_sf_enh_sharp_slice = csd_sf_enh_sharp[:, :, [3], :]
+csd_sf_orig_slice = csd_sf_orig[padding:-padding, padding:-padding, [3], :]
+csd_sf_noisy_slice = csd_sf_noisy[padding:-padding, padding:-padding, [3], :]
+csd_sf_enh_slice = csd_sf_enh[padding:-padding, padding:-padding, [3], :]
+csd_sf_enh_sharp_slice = csd_sf_enh_sharp[padding:-padding, padding:-padding, [3], :]
 
 ren = fvtk.ren()
 
@@ -231,7 +232,7 @@ fodf_spheres_enh.SetPosition(35, 0, 0)
 fvtk.add(ren, fodf_spheres_enh)
 
 # Additional sharpening
-fodf_spheres_enh_sharp = fvtk.sphere_funcs(csd_sf_enh_sharp_slice * 1.5,
+fodf_spheres_enh_sharp = fvtk.sphere_funcs(csd_sf_enh_sharp_slice,
                                            sphere,
                                            scale=2,
                                            norm=False,

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -90,8 +90,8 @@ data = img.get_data()
 from dipy.segment.mask import median_otsu
 b0_slice = data[:, :, :, 1]
 b0_mask, mask = median_otsu(b0_slice)
-np.random.seed(1)
-data_noisy = add_noise(data, 4.5, np.mean(b0_slice[mask]), noise_type='rician')
+np.random.seed(2)
+data_noisy = add_noise(data, 7.5, np.mean(b0_slice[mask]), noise_type='rician')
 
 # Select a small part of it
 data_small = data[25:40, 65:80, 35:42]
@@ -257,7 +257,7 @@ References
 .. [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis,
                         J. Portegies, R. Duits. (2015) Fast implementations of
                         contextual PDE’s for HARDI data processing in DIPY.
-                        ISMRM 2016 conf. (submitted)
+                        ISMRM 2016 conference.
 .. [Portegies2015_PLoSOne] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters,
                            G.Girard, and R. Duits. (2015) Improving Fiber
                            Alignment in HARDI by Combining Contextual PDE flow

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -248,7 +248,7 @@ fvtk.record(ren, out_path='enhancements.png', size=(900, 900))
    :align: center
 
    The results after enhancements. Top-left: original noiseless data.
-   Bottom-left: original data with added Rician noise (SNR=4.5). Bottom-right:
+   Bottom-left: original data with added Rician noise (SNR=10). Bottom-right:
    After enhancement of noisy data. Top-right: After enhancement and sharpening
    of noisy data.
 
@@ -256,7 +256,7 @@ References
 ~~~~~~~~~~
 
 .. [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis,
-                        J. Portegies, R. Duits. (2015) Fast implementations of
+                        J. Portegies, R. Duits. (2016) Fast implementations of
                         contextual PDE’s for HARDI data processing in DIPY.
                         ISMRM 2016 conference.
 .. [Portegies2015_PLoSOne] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters,

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -88,9 +88,10 @@ data = img.get_data()
 
 # Add Rician noise
 from dipy.segment.mask import median_otsu
-b0_mask, mask = median_otsu(data)
+b0_slice = data[:, :, :, 1]
+b0_mask, mask = median_otsu(b0_slice)
 np.random.seed(1)
-data_noisy = add_noise(data, 1, np.mean(data[mask]), noise_type='rician')
+data_noisy = add_noise(data, 4.5, np.mean(b0_slice[mask]), noise_type='rician')
 
 # Select a small part of it
 data_small = data[25:40, 65:80, 35:42]
@@ -246,7 +247,7 @@ fvtk.record(ren, out_path='enhancements.png', size=(900, 900))
    :align: center
 
    The results after enhancements. Top-left: original noiseless data.
-   Bottom-left: original data with added Rician noise (SNR=2). Bottom-right:
+   Bottom-left: original data with added Rician noise (SNR=4.5). Bottom-right:
    After enhancement of noisy data. Top-right: After enhancement and sharpening
    of noisy data.
 
@@ -266,10 +267,12 @@ References
                         and Applications in Neuroimaging. Fifth International
                         Conference on Scale Space and Variational Methods in
                         Computer Vision
-.. [DuitsAndFranken_JMIV] R. Duits and E. Franken (2011) Morphological and
-                          Linear Scale Spaces for Fiber Enhancement in DWI-MRI.
-                          J Math Imaging Vis, 46(3):326-368.
-
+.. [DuitsAndFranken_JMIV] R. Duits and E. Franken (2011) Left-invariant diffusions 
+                        on the space of positions and orientations and their 
+                        application to crossing-preserving smoothing of HARDI 
+                        images. International Journal of Computer Vision, 92:231-264.
 .. [RodriguesEurographics] P. Rodrigues, R. Duits, B. Romeny, A. Vilanova
-                           (2010). Accelerated Diffusion Operators for Enhancing DW-MRI. Eurographics Workshop on Visual Computing for Biology and Medicine. The Eurographics Association.
+                           (2010). Accelerated Diffusion Operators for Enhancing DW-MRI. 
+                           Eurographics Workshop on Visual Computing for Biology and Medicine. 
+                           The Eurographics Association.
 """


### PR DESCRIPTION
This update fixes the SNR issue in the demo which was wrongly calculated. The SNR is now based on the b=0 volume instead of the entire diffusion volume. The SNR after applying noise should now be around 4.5.

One reference at the bottom of the demo has errors in it and was corrected.