### PR TITLE
Fix typo

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -751,7 +751,7 @@ def read_bundles_2_subjects(subj_id='subj_1', metrics=['fa'],
     References
     ----------
 
-    .. [1] Renaud, E., M. Descoteaux, M. Bernier, E. Garyfallidis,
+    .. [1] Renauld, E., M. Descoteaux, M. Bernier, E. Garyfallidis,
     K. Whittingstall, "Morphology of thalamus, LGN and optic radiation do not
     influence EEG alpha waves", Plos One (under submission), 2015.
 


### PR DESCRIPTION
So found a small typo in the name of someone, see http://savoirs.usherbrooke.ca/handle/11143/6810?show=full to double check it is the right way.