### PR TITLE
FIX: Use absolute imports in testing,tests and segment files

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -10,7 +10,7 @@ from scipy.ndimage.filters import median_filter
 try:
     from skimage.filter import threshold_otsu as otsu
 except:
-    from .threshold import otsu
+    from dipy.segment.threshold import otsu
 
 from scipy.ndimage import binary_dilation, generate_binary_structure
 

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -5,7 +5,7 @@ from os.path import dirname, abspath, join as pjoin
 IO_DATA_PATH = abspath(pjoin(dirname(__file__),
                              '..', 'io', 'tests', 'data'))
 
-from dipy.testing.spherepoints import sphere_points
+from .spherepoints import sphere_points
 from dipy.testing.decorators import doctest_skip_parser
 from numpy.testing import assert_array_equal
 

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -5,8 +5,8 @@ from os.path import dirname, abspath, join as pjoin
 IO_DATA_PATH = abspath(pjoin(dirname(__file__),
                              '..', 'io', 'tests', 'data'))
 
-from .spherepoints import sphere_points
-from .decorators import doctest_skip_parser
+from dipy.testing.spherepoints import sphere_points
+from dipy.testing.decorators import doctest_skip_parser
 from numpy.testing import assert_array_equal
 
 # Allow failed import of nose if not now running tests

--- a/dipy/testing/tests/test_decorators.py
+++ b/dipy/testing/tests/test_decorators.py
@@ -10,7 +10,7 @@ from nose.tools import (assert_true, assert_false, assert_raises,
                         assert_equal, assert_not_equal)
 
 
-from ..decorators import doctest_skip_parser
+from dipy.testing.decorators import doctest_skip_parser
 
 
 def test_skipper():

--- a/dipy/tests/scriptrunner.py
+++ b/dipy/tests/scriptrunner.py
@@ -3,7 +3,7 @@
 Provides class to be instantiated in tests that check scripts.  Usually works
 something like this in a test module::
 
-    from .scriptrunner import ScriptRunner
+    from dipy.tests.scriptrunner import ScriptRunner
     runner = ScriptRunner()
 
 Then, in the tests, something like::

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     no_mpl = True
 
-from .scriptrunner import ScriptRunner
+from dipy.tests.scriptrunner import ScriptRunner
 
 runner = ScriptRunner(
     script_sdir='bin',


### PR DESCRIPTION
Changed some of the relative imports in testing and tests to use absolute imports.
Fixes a small part of https://github.com/nipy/dipy/issues/969