### PR TITLE
FIX: Use absolute import in pkg_info

### DIFF
--- a/dipy/pkg_info.py
+++ b/dipy/pkg_info.py
@@ -4,7 +4,7 @@ import os
 import sys
 import subprocess
 
-from .utils.six.moves import configparser
+from dipy.utils.six.moves import configparser
 
 COMMIT_INFO_FNAME = 'COMMIT_INFO.txt'
 


### PR DESCRIPTION
Changed the import statement to use absolute import
Fixes https://github.com/nipy/dipy/issues/998