### PR TITLE
FIX: Use absolute import in utils and scratch

### DIFF
--- a/dipy/utils/optpkg.py
+++ b/dipy/utils/optpkg.py
@@ -12,7 +12,7 @@ except ImportError:
 else:
     have_nose = True
 
-from .tripwire import TripWire
+from dipy.utils.tripwire import TripWire
 
 if have_nose:
     class OptionalImportError(ImportError, nose.SkipTest):

--- a/dipy/utils/tests/test_arrfuncs.py
+++ b/dipy/utils/tests/test_arrfuncs.py
@@ -5,7 +5,7 @@ import sys
 
 import numpy as np
 
-from ..arrfuncs import as_native_array, pinv, eigh
+from dipy.utils.arrfuncs import as_native_array, pinv, eigh
 
 from numpy.testing import (assert_array_almost_equal,
                            assert_array_equal)

--- a/dipy/utils/tests/test_tripwire.py
+++ b/dipy/utils/tests/test_tripwire.py
@@ -1,7 +1,7 @@
 """ Testing tripwire module.
 """
 
-from ..tripwire import TripWire, is_tripwire, TripWireError
+from dipy.utils.tripwire import TripWire, is_tripwire, TripWireError
 
 from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_raises,

--- a/scratch/learning_old.py
+++ b/scratch/learning_old.py
@@ -1,7 +1,7 @@
 ''' Learning algorithms for tractography'''
 
 import numpy as np
-from . import track_metrics as tm
+from dipy.core import track_metrics as tm
 import dipy.core.track_performance as pf
 from scipy import ndimage as nd
 import itertools


### PR DESCRIPTION
Changed relative imports to absolute imports in utils and scratch.
Fixes a small part of https://github.com/nipy/dipy/issues/1002