### PR TITLE
Fix: denspeed.pyx to give correct output for nlmeans

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -197,7 +197,7 @@ cdef double process_block(double [:, :, ::1] arr,
                             summ += d * d
                             sigm += sigma_block[(P + B + m + a) * TS * TS + (P + B + n + b) * TS + (P + B + o + c)]
 
-                denom = (sigm / block_vol_size)**2
+                denom = sqrt(2) * (sigm / block_vol_size)**2
                 w = exp(-(summ / block_vol_size) / denom)
                 sumw += w
                 W[cnt] = w

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -172,9 +172,9 @@ cdef double process_block(double[:, :, ::1] arr,
     patch_vol_size = (P + P + 1) * (P + P + 1) * (P + P + 1)
     block_vol_size = (B + B + 1) * (B + B + 1) * (B + B + 1)
 
-    W = <double * > malloc(PS * PS * PS * sizeof(double))
-    cache = <double * > malloc(TS * TS * TS * sizeof(double))
-    sigma_block = <double * > malloc(TS * TS * TS * sizeof(double))
+    W = <double *> malloc(PS * PS * PS * sizeof(double))
+    cache = <double *> malloc(TS * TS * TS * sizeof(double))
+    sigma_block = <double *> malloc(TS * TS * TS * sizeof(double))
 
     # (i, j, k) coordinates are the center of the static patch
     # copy block in cache
@@ -307,7 +307,7 @@ cdef cnp.npy_intp copy_block_3d(double * dest,
 
     for i in range(I):
         for j in range(J):
-            memcpy(& dest[i * J * K + j * K], & source[i + min_i, j + min_j, min_k], K * sizeof(double))
+            memcpy(&dest[i * J * K + j * K], &source[i + min_i, j + min_j, min_k], K * sizeof(double))
 
     return 1
 


### PR DESCRIPTION
The bugfix in the implementation of denspeed in reference to #1011 
Now we can use any patch_radius and block_radius for denoising purpose

- The implementation follows the block weighing approach which is then averaged for each voxel.
- Does not exactly follow the [coupe2008](http://www.ncbi.nlm.nih.gov/pubmed/18390341) block      averaging approach
- To follow the [coupe2008] approach, the existing code by @omarocegueda [here](https://github.com/omarocegueda/denoise/blob/master/ornlm/ornlm.pyx) is accurate, but it needs to be optimized (I am working on that currently!)