### PR TITLE
MRG: fix heavy dependency check; no numpy for setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,12 @@ matrix:
     - python: 2.7
       env:
         - INSTALL_TYPE=wheel
+        # Dependency checking should get all needed dependencies
+        - DEPENDS=""
     - python: 2.7
       env:
         - INSTALL_TYPE=requirements
-        - DEPENDS=
+        - DEPENDS=""
 before_install:
     - source tools/travis_tools.sh
     - virtualenv $VENV_ARGS venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,12 @@ matrix:
         - INSTALL_TYPE=sdist
     - python: 2.7
       env:
-        - INSTALL_TYPE=wheel
+        - INSTALL_TYPE=pip
         # Dependency checking should get all needed dependencies
         - DEPENDS=""
+    - python: 2.7
+      env:
+        - INSTALL_TYPE=wheel
     - python: 2.7
       env:
         - INSTALL_TYPE=requirements
@@ -70,7 +73,7 @@ before_install:
     # Needed for Python 3.5 wheel fetching
     - pip install -U pip
     - retry pip install nose;
-    - wheelhouse_pip_install $DEPENDS;
+    - if [ -n "$DEPENDS" ]; then wheelhouse_pip_install $DEPENDS; fi
     - if [ "${COVERAGE}" == "1" ]; then
       pip install coverage;
       pip install coveralls;
@@ -87,6 +90,8 @@ install:
     - |
       if [ "$INSTALL_TYPE" == "setup" ]; then
           python setup.py install
+      elif [ "$INSTALL_TYPE" == "pip" ]; then
+          wheelhouse_pip_install .
       elif [ "$INSTALL_TYPE" == "sdist" ]; then
         python setup_egg.py egg_info  # check egg_info while we're here
         python setup_egg.py sdist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include tools *
 recursive-include src *
 # setup utilities
 include setup_helpers.py
+include version_helpers.py
 include cythexts.py
 recursive-include fake_pyrex *
 # put this stuff back into setup.py (package_data) once I'm enlightened

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,12 @@ if force_setuptools:
 # MANIFEST
 from distutils.core import setup
 from distutils.extension import Extension
-from distutils.command.build_py import build_py as du_build_py
-from distutils.command.build_ext import build_ext as du_build_ext
 
-from cythexts import cyproc_exts, get_pyx_sdist, derror_maker
+from cythexts import cyproc_exts, get_pyx_sdist
 from setup_helpers import (install_scripts_bat, add_flag_checking,
                            SetupDependency, read_vars_from,
                            make_np_ext_builder)
+from version_helpers import get_comrec_build
 
 # Get version and release info, which is all stored in dipy/info.py
 info = read_vars_from(pjoin('dipy', 'info.py'))
@@ -56,18 +55,6 @@ if using_setuptools:
         extras_require = dict(
             doc=['Sphinx>=1.0'],
             test=['nose>=0.10.1']))
-    # I removed numpy and scipy from install requires because easy_install seems
-    # to want to fetch these if they are already installed, meaning of course
-    # that there's a long fragile and unnecessary compile before the install
-    # finishes.
-    # If running setuptools and nibabel is not installed, we have to force
-    # setuptools to install nibabel locally for the script to continue.  This
-    # hack is from
-    # http://stackoverflow.com/questions/12060925/best-way-to-share-code-across-several-setup-py-scripts
-    # with thanks
-    from setuptools.dist import Distribution
-    nibabel_spec = 'nibabel>=' + info.NIBABEL_MIN_VERSION
-    Distribution(dict(setup_requires=nibabel_spec))
 
 # Define extensions
 EXTS = []
@@ -116,29 +103,21 @@ for modulename, other_sources, language in (
 # building, rather than unconditionally in the setup.py import or exec
 # We may make tripwire versions of build_ext, build_py, install
 need_cython = True
-try:
-    from nisext.sexts import get_comrec_build
-except ImportError: # No nibabel
-    msg = ('Need nisext package from nibabel installation'
-           ' - please install nibabel first')
-    pybuilder = derror_maker(du_build_py, msg)
-    extbuilder = derror_maker(du_build_ext, msg)
-else: # We have nibabel
-    pybuilder = get_comrec_build('dipy')
-    # Cython is a dependency for building extensions, iff we don't have stamped
-    # up pyx and c files.
-    build_ext, need_cython = cyproc_exts(EXTS,
-                                         info.CYTHON_MIN_VERSION,
-                                         'pyx-stamps')
-    # Add openmp flags if they work
-    simple_test_c = """int main(int argc, char** argv) { return(0); }"""
-    omp_test_c = """#include <omp.h>
-    int main(int argc, char** argv) { return(0); }"""
-    extbuilder = add_flag_checking(
-        build_ext, [[['/arch:SSE2'], [], simple_test_c, 'USING_VC_SSE2'],
-            [['-msse2', '-mfpmath=sse'], [], simple_test_c, 'USING_GCC_SSE2'],
-            [['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP']], 'dipy')
-
+pybuilder = get_comrec_build('dipy')
+# Cython is a dependency for building extensions, iff we don't have stamped
+# up pyx and c files.
+build_ext, need_cython = cyproc_exts(EXTS,
+                                     info.CYTHON_MIN_VERSION,
+                                     'pyx-stamps')
+# Add openmp flags if they work
+simple_test_c = """int main(int argc, char** argv) { return(0); }"""
+omp_test_c = """#include <omp.h>
+int main(int argc, char** argv) { return(0); }"""
+extbuilder = add_flag_checking(
+    build_ext, [
+        [['/arch:SSE2'], [], simple_test_c, 'USING_VC_SSE2'],
+        [['-msse2', '-mfpmath=sse'], [], simple_test_c, 'USING_GCC_SSE2'],
+        [['-fopenmp'], ['-fopenmp'], omp_test_c, 'HAVE_OPENMP']], 'dipy')
 
 # Use ext builder to add np.get_include() at build time, not during setup.py
 # execution.

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -291,7 +291,7 @@ class SetupDependency(object):
         # Using setuptools; add packages to given section of
         # setup/install_requires, unless it's a heavy dependency for which we
         # already have an acceptable importable version.
-        if self.heavy and ver_err_msg:
+        if self.heavy and ver_err_msg is None:
             return
         new_req = '{0}>={1}'.format(self.import_name, self.min_ver)
         old_reqs = setuptools_kwargs.get(self.req_type, [])
@@ -325,3 +325,36 @@ def read_vars_from(ver_file):
     with open(ver_file, 'rt') as fobj:
         exec(fobj.read(), ns)
     return Bunch(ns)
+
+
+def make_np_ext_builder(build_ext_class):
+    """ Override input `build_ext_class` to add numpy includes to extension
+
+    This is useful to delay call of ``np.get_include`` until the extension is
+    being built.
+
+    Parameters
+    ----------
+    build_ext_class : class
+        Class implementing ``distutils.command.build_ext.build_ext`` interface,
+        with a ``build_extensions`` method.
+
+    Returns
+    -------
+    np_build_ext_class : class
+        A class with similar interface to
+        ``distutils.command.build_ext.build_ext``, that adds libraries in
+        ``np.get_include()`` to include directories of extension.
+    """
+    class NpExtBuilder(build_ext_class):
+
+        def build_extensions(self):
+            """ Hook into extension building to add np include dirs
+            """
+            # Delay numpy import until last moment
+            import numpy as np
+            for ext in self.extensions:
+                ext.include_dirs.append(np.get_include())
+            build_ext_class.build_extensions(self)
+
+    return NpExtBuilder

--- a/version_helpers.py
+++ b/version_helpers.py
@@ -1,0 +1,72 @@
+''' Distutils / setuptools helpers for versioning
+
+This code started life in the nibabel package as nisexts/sexts.py
+
+Code transferred by Matthew Brett, who holds copyright.
+
+This version under the standard dipy BSD license.
+'''
+
+from os.path import join as pjoin
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+from distutils.command.build_py import build_py
+
+
+def get_comrec_build(pkg_dir, build_cmd=build_py):
+    """ Return extended build command class for recording commit
+
+    The extended command tries to run git to find the current commit, getting
+    the empty string if it fails.  It then writes the commit hash into a file
+    in the `pkg_dir` path, named ``COMMIT_INFO.txt``.
+
+    In due course this information can be used by the package after it is
+    installed, to tell you what commit it was installed from if known.
+
+    To make use of this system, you need a package with a COMMIT_INFO.txt file -
+    e.g. ``myproject/COMMIT_INFO.txt`` - that might well look like this::
+
+        # This is an ini file that may contain information about the code state
+        [commit hash]
+        # The line below may contain a valid hash if it has been substituted during 'git archive'
+        archive_subst_hash=$Format:%h$
+        # This line may be modified by the install process
+        install_hash=
+
+    The COMMIT_INFO file above is also designed to be used with git substitution
+    - so you probably also want a ``.gitattributes`` file in the root directory
+    of your working tree that contains something like this::
+
+       myproject/COMMIT_INFO.txt export-subst
+
+    That will cause the ``COMMIT_INFO.txt`` file to get filled in by ``git
+    archive`` - useful in case someone makes such an archive - for example with
+    via the github 'download source' button.
+
+    Although all the above will work as is, you might consider having something
+    like a ``get_info()`` function in your package to display the commit
+    information at the terminal.  See the ``pkg_info.py`` module in the nipy
+    package for an example.
+    """
+    class MyBuildPy(build_cmd):
+        ''' Subclass to write commit data into installation tree '''
+        def run(self):
+            build_cmd.run(self)
+            import subprocess
+            proc = subprocess.Popen('git rev-parse --short HEAD',
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    shell=True)
+            repo_commit, _ = proc.communicate()
+            # Fix for python 3
+            repo_commit = str(repo_commit)
+            # We write the installation commit even if it's empty
+            cfg_parser = ConfigParser()
+            cfg_parser.read(pjoin(pkg_dir, 'COMMIT_INFO.txt'))
+            cfg_parser.set('commit hash', 'install_hash', repo_commit)
+            out_pth = pjoin(self.build_lib, pkg_dir, 'COMMIT_INFO.txt')
+            cfg_parser.write(open(out_pth, 'wt'))
+    return MyBuildPy


### PR DESCRIPTION
Fix a bug in dependency checking for heavy dependencies.

Make numpy an install dependency using extension builder that pulls in
include directories as late as possible.