### PR TITLE
BF: Predict DKI with a volume of S0

### DIFF
--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -926,13 +926,22 @@ def dki_prediction(dki_params, gtab, S0=150):
     fevecs = evecs.reshape((-1,) + evecs.shape[-2:])
     fkt = kt.reshape((-1, kt.shape[-1]))
     pred_sig = np.zeros((len(fevals), len(gtab.bvals)))
-
-    # lopping for all voxels
+    if isinstance(S0, np.ndarray):
+        S0_vol = np.reshape(S0, (len(fevals)))
+    else:
+        S0_vol = S0
+    # looping for all voxels
     for v in range(len(pred_sig)):
         DT = np.dot(np.dot(fevecs[v], np.diag(fevals[v])), fevecs[v].T)
         dt = lower_triangular(DT)
         MD = (dt[0] + dt[2] + dt[5]) / 3
-        X = np.concatenate((dt, fkt[v]*MD*MD, np.array([np.log(S0)])), axis=0)
+        if isinstance(S0_vol, np.ndarray):
+            this_S0 = S0_vol[v]
+        else:
+            this_S0 = S0_vol
+        X = np.concatenate((dt, fkt[v]*MD*MD,
+                            np.array([np.log(this_S0)])),
+                           axis=0)
         pred_sig[v] = np.exp(np.dot(A, X))
 
     # Reshape data according to the shape of dki_params

--- a/dipy/reconst/tests/test_dki.py
+++ b/dipy/reconst/tests/test_dki.py
@@ -146,6 +146,12 @@ def test_dki_predict():
     pred_multi = dkiM.predict(multi_params, S0=100)
     assert_array_almost_equal(pred_multi, DWI)
 
+    # Check that it works with more than one voxel, and with a different S0
+    # in each voxel:
+    pred_multi = dkiM.predict(multi_params,
+                              S0=100*np.ones(pred_multi.shape[:3]))
+    assert_array_almost_equal(pred_multi, DWI)
+
     # check the function predict of the DiffusionKurtosisFit object
     dkiF = dkiM.fit(DWI)
     pred_multi = dkiF.predict(gtab_2s, S0=100)
@@ -154,6 +160,15 @@ def test_dki_predict():
     dkiF = dkiM.fit(pred_multi)
     pred_from_fit = dkiF.predict(dkiM.gtab, S0=100)
     assert_array_almost_equal(pred_from_fit, DWI)
+
+    # Test the module function:
+    pred = dki.dki_prediction(crossing_ref, gtab_2s, S0=100)
+    assert_array_almost_equal(pred, signal_cross)
+
+    # Test the module function with S0 volume:
+    pred = dki.dki_prediction(multi_params, gtab_2s,
+                              S0=100 * np.ones(multi_params.shape[:3]))
+    assert_array_almost_equal(pred, DWI)
 
 
 def test_carlson_rf():


### PR DESCRIPTION
The first commit introduces a test that demonstrates the bug: if the `S0` input to DKI prediction is provided as a ndarray (which should be possible!), this raises an error. 

The second commit fixes this bug, by separating into two cases: one when `S0` is an ndarray (assumed to have the right shape!), and one when it is a float. 