### PR TITLE
NF - Add PMF Threshold to Tractography

### DIFF
--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -81,7 +81,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
 
     """
     @classmethod
-    def from_pmf(klass, pmf, max_angle, sphere, **kwargs):
+    def from_pmf(klass, pmf, max_angle, sphere, pmf_threshold=0, **kwargs):
         """Constructor for making a DirectionGetter from an array of Pmfs
 
         Parameters
@@ -93,6 +93,9 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
             direction.
         sphere : Sphere
             The set of directions to be used for tracking.
+        pmf_threshold : float [0., 1.]
+            Used to remove direction from the probability mass function for
+            selecting the tracking direction.
         relative_peak_threshold : float in [0., 1.]
             Used for extracting initial tracking directions. Passed to
             peak_directions.
@@ -114,11 +117,11 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
                    "points in sphere.")
             raise ValueError(msg)
         pmf_gen = SimplePmfGen(pmf)
-        return klass(pmf_gen, max_angle, sphere, **kwargs)
+        return klass(pmf_gen, max_angle, sphere, pmf_threshold, **kwargs)
 
     @classmethod
-    def from_shcoeff(klass, shcoeff, max_angle, sphere, basis_type=None,
-                     **kwargs):
+    def from_shcoeff(klass, shcoeff, max_angle, sphere, pmf_threshold=0,
+                     basis_type=None, **kwargs):
         """Probabilistic direction getter from a distribution of directions
         on the sphere.
 
@@ -136,6 +139,9 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
             direction.
         sphere : Sphere
             The set of directions to be used for tracking.
+        pmf_threshold : float [0., 1.]
+            Used to remove direction from the probability mass function for
+            selecting the tracking direction.
         basis_type : name of basis
             The basis that ``shcoeff`` are associated with.
             ``dipy.reconst.shm.real_sym_sh_basis`` is used by default.
@@ -152,21 +158,28 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
 
         """
         pmf_gen = SHCoeffPmfGen(shcoeff, sphere, basis_type)
-        return klass(pmf_gen, max_angle, sphere, **kwargs)
+        return klass(pmf_gen, max_angle, sphere, pmf_threshold, **kwargs)
 
-    def __init__(self, pmf_gen, max_angle, sphere=None, **kwargs):
+    def __init__(self, pmf_gen, max_angle, sphere=None, pmf_threshold=0,
+                 **kwargs):
         """Direction getter from a pmf generator.
 
         Parameters
         ----------
         pmf_gen : PmfGen
-            Used to get probability mass function for choosing tracking
+            Used to get probability mass function for selecting tracking
             directions.
         max_angle : float, [0, 90]
             The maximum allowed angle between incoming direction and new
             direction.
+        mpmf_threshold : float, [0, 1.]
+            The maximum allowed angle between incoming direction and new
+            direction.
         sphere : Sphere
             The set of directions to be used for tracking.
+        pmf_threshold : float [0., 1.]
+            Used to remove direction from the probability mass function for
+            selecting the tracking direction.
         relative_peak_threshold : float in [0., 1.]
             Used for extracting initial tracking directions. Passed to
             peak_directions.
@@ -181,6 +194,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
         """
         PeakDirectionGetter.__init__(self, sphere, **kwargs)
         self.pmf_gen = pmf_gen
+        self.pmf_threshold = pmf_threshold
         # The vertices need to be in a contiguous array
         self.vertices = self.sphere.vertices.copy()
         cos_similarity = np.cos(np.deg2rad(max_angle))
@@ -235,6 +249,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
         """
         # point and direction are passed in as cython memory views
         pmf = self.pmf_gen.get_pmf(point)
+        pmf.clip(self.pmf_threshold, out=pmf)
         cdf = (self._adj_matrix[tuple(direction)] * pmf).cumsum()
         if cdf[-1] == 0:
             return 1
@@ -271,6 +286,7 @@ class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
         """
         # point and direction are passed in as cython memory views
         pmf = self.pmf_gen.get_pmf(point)
+        pmf.clip(self.pmf_threshold, out=pmf)
         cdf = self._adj_matrix[tuple(direction)] * pmf
         idx = np.argmax(cdf)
 

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -81,7 +81,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
 
     """
     @classmethod
-    def from_pmf(klass, pmf, max_angle, sphere, pmf_threshold=0, **kwargs):
+    def from_pmf(klass, pmf, max_angle, sphere, pmf_threshold=0.1, **kwargs):
         """Constructor for making a DirectionGetter from an array of Pmfs
 
         Parameters
@@ -120,7 +120,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
         return klass(pmf_gen, max_angle, sphere, pmf_threshold, **kwargs)
 
     @classmethod
-    def from_shcoeff(klass, shcoeff, max_angle, sphere, pmf_threshold=0,
+    def from_shcoeff(klass, shcoeff, max_angle, sphere, pmf_threshold=0.1,
                      basis_type=None, **kwargs):
         """Probabilistic direction getter from a distribution of directions
         on the sphere.
@@ -160,7 +160,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
         pmf_gen = SHCoeffPmfGen(shcoeff, sphere, basis_type)
         return klass(pmf_gen, max_angle, sphere, pmf_threshold, **kwargs)
 
-    def __init__(self, pmf_gen, max_angle, sphere=None, pmf_threshold=0,
+    def __init__(self, pmf_gen, max_angle, sphere=None, pmf_threshold=0.1,
                  **kwargs):
         """Direction getter from a pmf generator.
 

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -172,9 +172,6 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
         max_angle : float, [0, 90]
             The maximum allowed angle between incoming direction and new
             direction.
-        mpmf_threshold : float, [0, 1.]
-            The maximum allowed angle between incoming direction and new
-            direction.
         sphere : Sphere
             The set of directions to be used for tracking.
         pmf_threshold : float [0., 1.]

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -249,7 +249,7 @@ class ProbabilisticDirectionGetter(PeakDirectionGetter):
         """
         # point and direction are passed in as cython memory views
         pmf = self.pmf_gen.get_pmf(point)
-        pmf.clip(self.pmf_threshold, out=pmf)
+        pmf[pmf < self.pmf_threshold] = 0
         cdf = (self._adj_matrix[tuple(direction)] * pmf).cumsum()
         if cdf[-1] == 0:
             return 1
@@ -286,7 +286,7 @@ class DeterministicMaximumDirectionGetter(ProbabilisticDirectionGetter):
         """
         # point and direction are passed in as cython memory views
         pmf = self.pmf_gen.get_pmf(point)
-        pmf.clip(self.pmf_threshold, out=pmf)
+        pmf[pmf < self.pmf_threshold] = 0
         cdf = self._adj_matrix[tuple(direction)] * pmf
         idx = np.argmax(cdf)
 

--- a/dipy/direction/tests/test_prob_direction_getter.py
+++ b/dipy/direction/tests/test_prob_direction_getter.py
@@ -55,8 +55,10 @@ def test_ProbabilisticDirectionGetter():
     # Check basis_type keyword
     dg = ProbabilisticDirectionGetter.from_shcoeff(fit.shm_coeff, 90,
                                                    unit_octahedron,
+                                                   pmf_threshold=0.1,
                                                    basis_type="mrtrix")
 
     npt.assert_raises(ValueError, ProbabilisticDirectionGetter.from_shcoeff,
                       fit.shm_coeff, 90, unit_octahedron,
+                      pmf_threshold=0.1,
                       basis_type="not a basis")

--- a/dipy/tracking/local/tests/test_local_tracking.py
+++ b/dipy/tracking/local/tests/test_local_tracking.py
@@ -267,7 +267,7 @@ def test_ProbabilisticOdfWeightedTracker():
     for sl in streamlines:
         npt.assert_(np.allclose(sl, expected[1]))
 
-    # The first path is not possible if pmf_threshold > 0.4 degree
+    # The first path is not possible if pmf_threshold > 0.4
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, sphere,
                                                pmf_threshold=0.5)
     streamlines = LocalTracking(dg, tc, seeds, np.eye(4), 1.)

--- a/dipy/tracking/local/tests/test_local_tracking.py
+++ b/dipy/tracking/local/tests/test_local_tracking.py
@@ -267,7 +267,7 @@ def test_ProbabilisticOdfWeightedTracker():
     for sl in streamlines:
         npt.assert_(np.allclose(sl, expected[1]))
 
-    # The first path is not possible if pmf_threshold>0.4 degree turns are excluded
+    # The first path is not possible if pmf_threshold > 0.4 degree
     dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, sphere,
                                                pmf_threshold=0.5)
     streamlines = LocalTracking(dg, tc, seeds, np.eye(4), 1.)
@@ -338,7 +338,7 @@ def test_MaximumDeterministicTracker():
         npt.assert_(np.allclose(sl, expected[1]))
 
     # Both path are not possible if 90 degree turns are exclude and
-    # if pmf_threhold is superior to 0.4. Streamlines should stop at
+    # if pmf_threhold is larger than 0.4. Streamlines should stop at
     # the crossing
 
     dg = DeterministicMaximumDirectionGetter.from_pmf(pmf, 80, sphere,

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,16 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+Dipy 0.12 Changes
+-----------------
+
+**Tracking**
+``probabilistic_direction_getter.ProbabilisticDirectionGetter`` input parameters
+have changed. Now the optional parameter ``pmf_threshold=0.1`` (previously fixed
+to 0.0) removes directions with probability lower than ``pmf_threshold`` from
+the probability mass function (pmf) when selecting the tracking direction.
+
+
 Dipy 0.10 Changes
 -----------------
 


### PR DESCRIPTION
This PR adds pmf_threshold parameter to ProbabilisticDirectionGetter, which set to 0 all directions with probability mass function value < pmf_threshold.. It is common to remove low CSD-ODF value (e.g. mrtrix)  from the probability mass function used in probabilistic tractography. Increasing pmf_threshold tends to reduce erroneous streamlines by following 'less noisy' directions of the CSD-ODF.

I set the default to 0.1 as suggested by [Tournier et al. 2012, Girard et al. 2014]. However, this will change probabilistic streamline output of current scripts. 