### PR TITLE
DO NOT MERGE: Add a test of local tracking, using data from dipy.data.

### DIFF
--- a/dipy/tracking/local/tests/test_local_data.py
+++ b/dipy/tracking/local/tests/test_local_data.py
@@ -15,28 +15,29 @@ import dipy.reconst.dti as dti
 from dipy.reconst.dti import fractional_anisotropy
 
 
-fdata, fbval, fbvec = dpd.get_data('small_101D')
-img = nib.load(fdata)
-gtab = dpg.gradient_table(fbval, fbvec)
-data = img.get_data()
-affine = img.get_affine()
+def test_local_tracking_with_data():
+    fdata, fbval, fbvec = dpd.get_data('small_101D')
+    img = nib.load(fdata)
+    gtab = dpg.gradient_table(fbval, fbvec)
+    data = img.get_data()
+    affine = img.get_affine()
 
-seed_mask = np.ones(data.shape[:3])
-seeds = utils.seeds_from_mask(seed_mask, density=1, affine=affine)
-csd_model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=6)
-csd_fit = csd_model.fit(data, mask=seed_mask)
-
-
-tensor_model = dti.TensorModel(gtab)
-tenfit = tensor_model.fit(data, mask=seed_mask)
-
-FA = fractional_anisotropy(tenfit.evals)
-classifier = ThresholdTissueClassifier(FA, .2)
+    seed_mask = np.ones(data.shape[:3])
+    seeds = utils.seeds_from_mask(seed_mask, density=1, affine=affine)
+    csd_model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=6)
+    csd_fit = csd_model.fit(data, mask=seed_mask)
 
 
-detmax_dg = DeterministicMaximumDirectionGetter.from_shcoeff(
-                                                    csd_fit.shm_coeff,
-                                                    max_angle=30.,
-                                                    sphere=default_sphere)
+    tensor_model = dti.TensorModel(gtab)
+    tenfit = tensor_model.fit(data, mask=seed_mask)
 
-streamlines = LocalTracking(detmax_dg, classifier, seeds, affine, step_size=.5)
+    FA = fractional_anisotropy(tenfit.evals)
+    classifier = ThresholdTissueClassifier(FA, .2)
+
+
+    detmax_dg = DeterministicMaximumDirectionGetter.from_shcoeff(
+                                                        csd_fit.shm_coeff,
+                                                        max_angle=30.,
+                                                        sphere=default_sphere)
+
+    streamlines = LocalTracking(detmax_dg, classifier, seeds, affine, step_size=.5)

--- a/dipy/tracking/local/tests/test_local_data.py
+++ b/dipy/tracking/local/tests/test_local_data.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from dipy.data import default_sphere
+from dipy.direction import DeterministicMaximumDirectionGetter
+from dipy.io.trackvis import save_trk
+
+from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
+from dipy.tracking import utils
+from dipy.tracking.local import (ThresholdTissueClassifier, LocalTracking)
+import dipy.data as dpd
+import dipy.core.gradients as dpg
+import nibabel as nib
+
+import dipy.reconst.dti as dti
+from dipy.reconst.dti import fractional_anisotropy
+
+
+fdata, fbval, fbvec = dpd.get_data('small_101D')
+img = nib.load(fdata)
+gtab = dpg.gradient_table(fbval, fbvec)
+data = img.get_data()
+affine = img.get_affine()
+
+seed_mask = np.ones(data.shape[:3])
+seeds = utils.seeds_from_mask(seed_mask, density=1, affine=affine)
+csd_model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=6)
+csd_fit = csd_model.fit(data, mask=seed_mask)
+
+
+tensor_model = dti.TensorModel(gtab)
+tenfit = tensor_model.fit(data, mask=seed_mask)
+
+FA = fractional_anisotropy(tenfit.evals)
+classifier = ThresholdTissueClassifier(FA, .2)
+
+
+detmax_dg = DeterministicMaximumDirectionGetter.from_shcoeff(
+                                                    csd_fit.shm_coeff,
+                                                    max_angle=30.,
+                                                    sphere=default_sphere)
+
+streamlines = LocalTracking(detmax_dg, classifier, seeds, affine, step_size=.5)


### PR DESCRIPTION
I put this here, just to demonstrate something that I have encountered. The localtracking module seems to raise a spurious error, even for data that is regularly sampled. Unless I am misunderstanding something, the script that I have added as `test_local_data.py` should run with no error, but I think that this demonstrates that there is a bug (?) in the way that localtracking.py ascertains the voxel size. According to the nifti header, this data is acquired on a regular 2.5 x 2.5 x 2.5 grid. 

Shouldn't this all run smoothly?