### PR TITLE
BF - peaks_from_model with nbr_processes <= 0

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -170,14 +170,23 @@ def _peaks_from_model_parallel(model, data, sphere, relative_peak_threshold,
         try:
             nbr_processes = cpu_count()
         except NotImplementedError:
-            warn("Cannot determine number of cpus. \
-                 returns peaks_from_model(..., parallel=False).")
+            warn("Cannot determine number of cpus. "
+                 "returns peaks_from_model(..., parallel=False).")
             return peaks_from_model(model, data, sphere,
                                     relative_peak_threshold,
                                     min_separation_angle, mask, return_odf,
                                     return_sh, gfa_thr, normalize_peaks,
                                     sh_order, sh_basis_type, npeaks,
                                     parallel=False)
+    elif nbr_processes <= 0:
+        warn("Invalid number of processes (%d). "
+             "returns peaks_from_model(..., parallel=False)." % nbr_processes)
+        return peaks_from_model(model, data, sphere,
+                                relative_peak_threshold,
+                                min_separation_angle, mask, return_odf,
+                                return_sh, gfa_thr, normalize_peaks,
+                                sh_order, sh_basis_type, npeaks,
+                                parallel=False)
 
     shape = list(data.shape)
     data = np.reshape(data, (-1, shape[-1]))

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -512,33 +512,44 @@ def test_peaksFromModelParallel():
                                   normalize_peaks=True, return_odf=True,
                                   return_sh=True, parallel=False)
 
-    assert_equal(pam_multi.gfa.dtype, pam_single.gfa.dtype)
-    assert_equal(pam_multi.gfa.shape, pam_single.gfa.shape)
-    assert_array_almost_equal(pam_multi.gfa, pam_single.gfa)
+    pam_multi_inv1 = peaks_from_model(model, data, _sphere, .5, 45,
+                                      normalize_peaks=True, return_odf=True,
+                                      return_sh=True, parallel=True,
+                                      nbr_processes=0)
 
-    assert_equal(pam_multi.qa.dtype, pam_single.qa.dtype)
-    assert_equal(pam_multi.qa.shape, pam_single.qa.shape)
-    assert_array_almost_equal(pam_multi.qa, pam_single.qa)
+    pam_multi_inv2 = peaks_from_model(model, data, _sphere, .5, 45,
+                                      normalize_peaks=True, return_odf=True,
+                                      return_sh=True, parallel=True,
+                                      nbr_processes=-2)
 
-    assert_equal(pam_multi.peak_values.dtype, pam_single.peak_values.dtype)
-    assert_equal(pam_multi.peak_values.shape, pam_single.peak_values.shape)
-    assert_array_almost_equal(pam_multi.peak_values, pam_single.peak_values)
+    for pam in [pam_multi, pam_multi_inv1, pam_multi_inv2]:
+        assert_equal(pam.gfa.dtype, pam_single.gfa.dtype)
+        assert_equal(pam.gfa.shape, pam_single.gfa.shape)
+        assert_array_almost_equal(pam.gfa, pam_single.gfa)
 
-    assert_equal(pam_multi.peak_indices.dtype, pam_single.peak_indices.dtype)
-    assert_equal(pam_multi.peak_indices.shape, pam_single.peak_indices.shape)
-    assert_array_equal(pam_multi.peak_indices, pam_single.peak_indices)
+        assert_equal(pam.qa.dtype, pam_single.qa.dtype)
+        assert_equal(pam.qa.shape, pam_single.qa.shape)
+        assert_array_almost_equal(pam.qa, pam_single.qa)
 
-    assert_equal(pam_multi.peak_dirs.dtype, pam_single.peak_dirs.dtype)
-    assert_equal(pam_multi.peak_dirs.shape, pam_single.peak_dirs.shape)
-    assert_array_almost_equal(pam_multi.peak_dirs, pam_single.peak_dirs)
+        assert_equal(pam.peak_values.dtype, pam_single.peak_values.dtype)
+        assert_equal(pam.peak_values.shape, pam_single.peak_values.shape)
+        assert_array_almost_equal(pam.peak_values, pam_single.peak_values)
 
-    assert_equal(pam_multi.shm_coeff.dtype, pam_single.shm_coeff.dtype)
-    assert_equal(pam_multi.shm_coeff.shape, pam_single.shm_coeff.shape)
-    assert_array_almost_equal(pam_multi.shm_coeff, pam_single.shm_coeff)
+        assert_equal(pam.peak_indices.dtype, pam_single.peak_indices.dtype)
+        assert_equal(pam.peak_indices.shape, pam_single.peak_indices.shape)
+        assert_array_equal(pam.peak_indices, pam_single.peak_indices)
 
-    assert_equal(pam_multi.odf.dtype, pam_single.odf.dtype)
-    assert_equal(pam_multi.odf.shape, pam_single.odf.shape)
-    assert_array_almost_equal(pam_multi.odf, pam_single.odf)
+        assert_equal(pam.peak_dirs.dtype, pam_single.peak_dirs.dtype)
+        assert_equal(pam.peak_dirs.shape, pam_single.peak_dirs.shape)
+        assert_array_almost_equal(pam.peak_dirs, pam_single.peak_dirs)
+
+        assert_equal(pam.shm_coeff.dtype, pam_single.shm_coeff.dtype)
+        assert_equal(pam.shm_coeff.shape, pam_single.shm_coeff.shape)
+        assert_array_almost_equal(pam.shm_coeff, pam_single.shm_coeff)
+
+        assert_equal(pam.odf.dtype, pam_single.odf.dtype)
+        assert_equal(pam.odf.shape, pam_single.odf.shape)
+        assert_array_almost_equal(pam.odf, pam_single.odf)
 
 
 def test_peaks_shm_coeff():


### PR DESCRIPTION
Fixed behavior when nbr_processes parameter of peaks_from_model is less or equal to 0.

- returns peaks_from_model(..., parallel=False) when nbr_processes <= 0
- added tests