### PR TITLE
MAINT: minor cython cleanup in align/vector_fields.pyx

### DIFF
--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -2985,7 +2985,7 @@ def create_circle(cnp.npy_intp nrows, cnp.npy_intp ncols, cnp.npy_intp radius):
         for j in range(ncols):
             ii = i - mid_row
             jj = j - mid_col
-            r = np.sqrt(ii*ii + jj*jj)
+            r = sqrt(ii*ii + jj*jj)
             if r <= radius:
                 c[i, j] = 1
             else:
@@ -3029,7 +3029,7 @@ def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
                 kk = k - mid_slice
                 ii = i - mid_row
                 jj = j - mid_col
-                r = np.sqrt(ii*ii + jj*jj + kk*kk)
+                r = sqrt(ii*ii + jj*jj + kk*kk)
                 if r <= radius:
                     s[k, i, j] = 1
                 else:

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -7,12 +7,13 @@ import numpy as np
 cimport numpy as cnp
 cimport cython
 from .fused_types cimport floating, number
-from libc.math cimport cos, atan2
 
 
 cdef extern from "dpy_math.h" nogil:
     double floor(double)
     double sqrt(double)
+    double cos(double)
+    double atan2(double, double)
 
 
 def is_valid_affine(double[:, :] M, int dim):


### PR DESCRIPTION
These are minor changes to remove python interaction from within some of the loops present in `vector_fields.pyx`. 

It is easiest to verify the reduction in Python interaction via observing the reduction in yellow lines in the annotated HTML files generated by ``cython -a vector_fields.pyx`` in this PR vs master.

The following four functions receive approximately 3 orders of magnitude speedup by avoiding calls to np.cos, np.arctan2 and/or np.sqrt:
`create_circle`, `create_sphere`, `create_harmonic_fields_2d`, `create_harmonic_fields_3d`

For the rest, there is negligable difference in performance.  I have also looked at enabling parallel processing via prange in some of these functions and plan to submit that as a separate future PR.  (In the multithreaded case, the change of `_interpolate_vector_2d` and `_interpolate_vector_3d` to use `floating* out` instead of `floating[:] out` makes a huge difference to some of the routines that were passing a view of a memoryview which was causing things to actually become slower if multithreaded)