### PR TITLE
ENH: expand OpenMP utilities and move from denspeed.pyx to dipy.utils

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -98,8 +98,7 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
     J = arr.shape[1]
     K = arr.shape[2]
 
-    if have_openmp:
-        set_num_threads(num_threads)
+    set_num_threads(num_threads)
 
     # move the block
     with nogil, parallel():
@@ -112,7 +111,7 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
 
                     out[i, j, k] = process_block(arr, i, j, k, B, P, sigma)
 
-    if have_openmp and num_threads is not None:
+    if num_threads is not None:
         restore_default_num_threads()
 
     new = np.asarray(out)

--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -8,7 +8,9 @@ cimport safe_openmp as openmp
 from safe_openmp cimport have_openmp
 
 from cython.parallel import parallel, prange
-from multiprocessing import cpu_count
+# import cpu_count for backwards compatibility
+from dipy.utils.omp import cpu_count
+from dipy.utils.omp cimport set_num_threads, restore_default_num_threads
 
 from libc.math cimport sqrt, exp
 from libc.stdlib cimport malloc, free
@@ -90,21 +92,14 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
         double summ = 0
         cnp.npy_intp P = patch_radius
         cnp.npy_intp B = block_radius
-        int all_cores = openmp.omp_get_num_procs()
         int threads_to_use = -1
 
     I = arr.shape[0]
     J = arr.shape[1]
     K = arr.shape[2]
 
-    if num_threads is not None:
-        threads_to_use = num_threads
-    else:
-        threads_to_use = all_cores
-
     if have_openmp:
-        openmp.omp_set_dynamic(0)
-        openmp.omp_set_num_threads(threads_to_use)
+        set_num_threads(num_threads)
 
     # move the block
     with nogil, parallel():
@@ -118,7 +113,7 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
                     out[i, j, k] = process_block(arr, i, j, k, B, P, sigma)
 
     if have_openmp and num_threads is not None:
-        openmp.omp_set_num_threads(all_cores)
+        restore_default_num_threads()
 
     new = np.asarray(out)
 
@@ -310,10 +305,3 @@ cdef cnp.npy_intp copy_block_3d(double * dest,
             memcpy(&dest[i * J * K + j * K], &source[i + min_i, j + min_j, min_k], K * sizeof(double))
 
     return 1
-
-
-def cpu_count():
-    if have_openmp:
-        return openmp.omp_get_num_procs()
-    else:
-        return 1

--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -4,8 +4,8 @@ from numpy.testing import (run_module_suite,
                            assert_equal,
                            assert_array_almost_equal)
 from dipy.denoise.nlmeans import nlmeans
-from dipy.denoise.denspeed import (add_padding_reflection, remove_padding,
-                                   cpu_count)
+from dipy.denoise.denspeed import (add_padding_reflection, remove_padding)
+from dipy.utils.omp import cpu_count
 from time import time
 
 

--- a/dipy/utils/omp.pxd
+++ b/dipy/utils/omp.pxd
@@ -1,0 +1,4 @@
+#!python
+
+cdef void set_num_threads(num_threads)
+cdef void restore_default_num_threads()

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -1,0 +1,72 @@
+#!python
+
+import os
+cimport cython
+cimport safe_openmp as openmp
+have_openmp = <int> openmp.have_openmp
+
+__all__ = ['have_openmp', 'default_threads', 'cpu_count', 'thread_count']
+
+
+def cpu_count():
+    """Return number of cpus as determined by omp_get_num_procs."""
+    if have_openmp:
+        return openmp.omp_get_num_procs()
+    else:
+        return 1
+
+
+def thread_count():
+    """Return number of threads as determined by omp_get_max_threads."""
+    if have_openmp:
+        return openmp.omp_get_max_threads()
+    else:
+        return 1
+
+
+def _get_default_threads():
+    """Default number of threads for OpenMP.
+
+    This function prioritizes the OMP_NUM_THREADS environment variable.
+    """
+    if have_openmp:
+        try:
+            default_threads = int(os.environ.get('OMP_NUM_THREADS', None))
+            if default_threads < 1 or default_threads > openmp.omp_get_num_procs():
+                raise ValueError("invalid number of threads")
+        except (ValueError, TypeError):
+            default_threads = openmp.omp_get_num_procs()
+        return default_threads
+    else:
+        return 1
+default_threads = _get_default_threads()
+
+
+cdef void set_num_threads(num_threads):
+    """Set OpenMP to use this ``num_threads`` threads."""
+    cdef:
+        int threads_to_use
+    if num_threads is not None:
+        threads_to_use = num_threads
+    else:
+        threads_to_use = <int> default_threads
+
+    if openmp.have_openmp:
+        openmp.omp_set_dynamic(0)
+        openmp.omp_set_num_threads(threads_to_use)
+
+
+cdef void restore_default_num_threads():
+    """Restore OpenMP to using the default number of threads."""
+    if openmp.have_openmp:
+        openmp.omp_set_num_threads(<int> default_threads)
+
+
+def _set_omp_threads(num_threads):
+    """Function for testing set_num_threads."""
+    set_num_threads(num_threads)
+
+
+def _restore_omp_threads():
+    """Function for testing restore_default_num_threads."""
+    restore_default_num_threads()

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -43,7 +43,15 @@ default_threads = _get_default_threads()
 
 
 cdef void set_num_threads(num_threads):
-    """Set OpenMP to use this ``num_threads`` threads."""
+    """Set the number of threads to be used by OpenMP
+
+    This function does nothing if OpenMP is not available.
+
+    Parameters
+    ----------
+    num_threads : int
+        Desired number of threads for OpenMP accelerated code.
+    """
     cdef:
         int threads_to_use
     if num_threads is not None:
@@ -57,7 +65,10 @@ cdef void set_num_threads(num_threads):
 
 
 cdef void restore_default_num_threads():
-    """Restore OpenMP to using the default number of threads."""
+    """Restore OpenMP to using the default number of threads.
+
+    This function does nothing if OpenMP is not available
+    """
     if openmp.have_openmp:
         openmp.omp_set_num_threads(<int> default_threads)
 

--- a/dipy/utils/omp.pyx
+++ b/dipy/utils/omp.pyx
@@ -32,7 +32,7 @@ def _get_default_threads():
     if have_openmp:
         try:
             default_threads = int(os.environ.get('OMP_NUM_THREADS', None))
-            if default_threads < 1 or default_threads > openmp.omp_get_num_procs():
+            if default_threads < 1:
                 raise ValueError("invalid number of threads")
         except (ValueError, TypeError):
             default_threads = openmp.omp_get_num_procs()

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -1,0 +1,41 @@
+""" Testing OpenMP utilities
+"""
+
+import os
+from dipy.utils.omp import (cpu_count, thread_count, default_threads,
+                            _set_omp_threads, _restore_omp_threads,
+                            have_openmp)
+
+from nose.tools import assert_equal
+
+
+def test_set_omp_threads():
+    if have_openmp:
+        # set threads to default
+        _restore_omp_threads()
+        assert_equal(thread_count(), default_threads)
+
+        # change number of threads
+        nthreads_new = default_threads + 1
+        _set_omp_threads(nthreads_new)
+        assert_equal(thread_count(), nthreads_new)
+
+        # restore back to default
+        _restore_omp_threads()
+        assert_equal(thread_count(), default_threads)
+    else:
+        assert_equal(thread_count(), 1)
+        assert_equal(cpu_count(), 1)
+
+
+def test_default_threads():
+    if have_openmp:
+        try:
+            expected_threads = int(os.environ.get('OMP_NUM_THREADS', None))
+            if expected_threads < 1 or expected_threads > cpu_count():
+                raise ValueError("invalid number of threads")
+        except (ValueError, TypeError):
+            expected_threads = cpu_count()
+    else:
+        expected_threads = 1
+    assert_equal(default_threads, expected_threads)

--- a/dipy/utils/tests/test_omp.py
+++ b/dipy/utils/tests/test_omp.py
@@ -7,6 +7,7 @@ from dipy.utils.omp import (cpu_count, thread_count, default_threads,
                             have_openmp)
 
 from nose.tools import assert_equal
+from numpy.testing import run_module_suite
 
 
 def test_set_omp_threads():
@@ -32,10 +33,15 @@ def test_default_threads():
     if have_openmp:
         try:
             expected_threads = int(os.environ.get('OMP_NUM_THREADS', None))
-            if expected_threads < 1 or expected_threads > cpu_count():
+            if expected_threads < 1:
                 raise ValueError("invalid number of threads")
         except (ValueError, TypeError):
             expected_threads = cpu_count()
     else:
         expected_threads = 1
     assert_equal(default_threads, expected_threads)
+
+
+if __name__ == '__main__':
+
+    run_module_suite()

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,8 @@ for modulename, other_sources, language in (
     ('dipy.align.crosscorr', [], 'c'),
     ('dipy.align.bundlemin', [], 'c'),
     ('dipy.align.transforms', [], 'c'),
-    ('dipy.align.parzenhist', [], 'c')):
+    ('dipy.align.parzenhist', [], 'c'),
+    ('dipy.utils.omp', [], 'c')):
 
     pyx_src = pjoin(*modulename.split('.')) + '.pyx'
     EXTS.append(Extension(modulename, [pyx_src] + other_sources,


### PR DESCRIPTION
I was recently working on adding OpenMP support to some functions in dipy.align and needed some utilities similar to the ones defined within `denoise/denspeed.pyx`.

I propose moving these to a common location `dipy.utils.omp` where they can be more easily found and reused.

The only change in functionality to `nlmeans` would be the default number of threads set when `num_threads` is not specified,but the user has also defined the `OMP_NUM_THREADS` environement variable.  Previously the default number of threads was always `openmp.omp_get_num_procs()`, but now it will try to default to the `OMP_NUM_THREADS` instead.  At least on my system, `omp_get_num_procs` returns the total number of possible threads including hyperthreading which actually makes things slower than just using the number of physical cores.
