### PR TITLE
Fast computation of Cross Correlation metric

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -136,7 +136,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
     Pre-computes the separate terms of the cross correlation metric and image
     norms at each voxel considering a neighborhood of the given radius to
     efficiently compute the gradient of the metric with respect to the
-    deformation field [Ocegueda16][Avants08][Avants11].
+    deformation field [Ocegueda2016]_[Avants2008]_[Avants2011]_.
 
     Parameters
     ----------
@@ -160,16 +160,16 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
 
     References
     ----------
-    [Ocegueda16] Ocegueda, O., Dalmau, O., Garyfallidis, E., Descoteaux, M.,
-               & Rivera, M. (2016), On the computation of integrals over
-               fixed-size rectangles of arbitrary dimension, Pattern
-               Recognition Letters
-    [Avants08] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2008)
-               Symmetric Diffeomorphic Image Registration with
-               Cross-Correlation: Evaluating Automated Labeling of Elderly and
-               Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
-    [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011).
-               Advanced Normalization Tools ( ANTS ), 1-35.
+    .. [Ocegueda2016] Ocegueda, O., Dalmau, O., Garyfallidis, E., Descoteaux,
+        M., & Rivera, M. (2016). On the computation of integrals over
+        fixed-size rectangles of arbitrary dimension, Pattern Recognition
+        Letters. doi:10.1016/j.patrec.2016.05.008
+    .. [Avants2008] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C.
+        (2008). Symmetric Diffeomorphic Image Registration with
+        Cross-Correlation: Evaluating Automated Labeling of Elderly and
+        Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
+    .. [Avants2011] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+        Normalization Tools ( ANTS ), 1-35.
     """
     cdef:
         cnp.npy_intp ns = static.shape[0]
@@ -354,8 +354,8 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
     r"""Gradient of the CC Metric w.r.t. the forward transformation
 
     Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) [Avants08] w.r.t. the displacement associated to
-    the moving volume ('forward' step) as in [Avants11]
+    registration (SyN) [Avants2008] w.r.t. the displacement associated to
+    the moving volume ('forward' step) as in [Avants2011]
 
     Parameters
     ----------
@@ -378,12 +378,12 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
 
     References
     ----------
-    [Avants08] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2008)
-               Symmetric Diffeomorphic Image Registration with
-               Cross-Correlation: Evaluating Automated Labeling of Elderly and
-               Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
-    [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011).
-               Advanced Normalization Tools ( ANTS ), 1-35.
+    .. [Avants2008] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C.
+        (2008). Symmetric Diffeomorphic Image Registration with
+        Cross-Correlation: Evaluating Automated Labeling of Elderly and
+        Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
+    .. [Avants2011] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+        Normalization Tools ( ANTS ), 1-35.
     """
     cdef:
         cnp.npy_intp ns = grad_static.shape[0]
@@ -498,10 +498,10 @@ def precompute_cc_factors_2d(floating[:, :] static, floating[:, :] moving,
                              cnp.npy_intp radius):
     r"""Precomputations to quickly compute the gradient of the CC Metric
 
-    Pre-computes the separate terms of the cross correlation metric [Avants08]
-    and image norms at each voxel considering a neighborhood of the given
-    radius to efficiently [Avants11] compute the gradient of the metric with
-    respect to the deformation field.
+    Pre-computes the separate terms of the cross correlation metric
+    [Avants2008] and image norms at each voxel considering a neighborhood of
+    the given radius to efficiently [Avants2011] compute the gradient of the
+    metric with respect to the deformation field.
 
     Parameters
     ----------
@@ -525,12 +525,12 @@ def precompute_cc_factors_2d(floating[:, :] static, floating[:, :] moving,
 
     References
     ----------
-    [Avants08] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2008)
-               Symmetric Diffeomorphic Image Registration with
-               Cross-Correlation: Evaluating Automated Labeling of Elderly and
-               Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
-    [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011).
-               Advanced Normalization Tools ( ANTS ), 1-35.
+    .. [Avants2008] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C.
+        (2008). Symmetric Diffeomorphic Image Registration with
+        Cross-Correlation: Evaluating Automated Labeling of Elderly and
+        Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
+    .. [Avants2011] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+        Normalization Tools ( ANTS ), 1-35.
     """
     ftype = np.asarray(static).dtype
     cdef:
@@ -665,8 +665,8 @@ def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
     r"""Gradient of the CC Metric w.r.t. the forward transformation
 
     Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) [Avants08] w.r.t. the displacement associated to
-    the moving image ('backward' step) as in [Avants11]
+    registration (SyN) [Avants2008] w.r.t. the displacement associated to
+    the moving image ('backward' step) as in [Avants2011]
 
     Parameters
     ----------
@@ -692,12 +692,12 @@ def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
 
     References
     ----------
-    [Avants08] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2008)
-               Symmetric Diffeomorphic Image Registration with
-               Cross-Correlation: Evaluating Automated Labeling of Elderly and
-               Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
-    [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011).
-               Advanced Normalization Tools ( ANTS ), 1-35.
+    .. [Avants2008] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C.
+        (2008). Symmetric Diffeomorphic Image Registration with
+        Cross-Correlation: Evaluating Automated Labeling of Elderly and
+        Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
+    .. [Avants2011] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+        Normalization Tools ( ANTS ), 1-35.
     """
     cdef:
         cnp.npy_intp nr = grad_static.shape[0]
@@ -738,8 +738,8 @@ def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
     r"""Gradient of the CC Metric w.r.t. the backward transformation
 
     Computes the gradient of the Cross Correlation metric for symmetric
-    registration (SyN) [Avants08] w.r.t. the displacement associated to
-    the static image ('forward' step) as in [Avants11]
+    registration (SyN) [Avants2008] w.r.t. the displacement associated to
+    the static image ('forward' step) as in [Avants2011]
 
     Parameters
     ----------
@@ -758,12 +758,12 @@ def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
 
     References
     ----------
-    [Avants08] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2008)
-               Symmetric Diffeomorphic Image Registration with
-               Cross-Correlation: Evaluating Automated Labeling of Elderly and
-               Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
-    [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011).
-               Advanced Normalization Tools ( ANTS ), 1-35.
+    .. [Avants2008] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C.
+        (2008). Symmetric Diffeomorphic Image Registration with
+        Cross-Correlation: Evaluating Automated Labeling of Elderly and
+        Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
+    .. [Avants2011] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+        Normalization Tools ( ANTS ), 1-35.
     """
     ftype = np.asarray(grad_moving).dtype
     cdef:


### PR DESCRIPTION
This PR implements a new algorithm for computing the Cross Correlation metric, which is substantially faster than the original algorithm implemented in ANTS. The computational complexity of the original algorithm for a volume of size N^3 using rectangular windows of size K^3 is Theta(N^3 * K^2). This means that the time increases quadratically with the window radius. 

The computational complexity of this new algorithm is Theta(N^3), it does not depend on the window size, so we observe a substantial speed up, especially for large rectangular windows. After a conversation with @grlee77, the plan would be to add this algorithm instead of #1051, and then after #1050 is in, we can go ahead and use that framework to parallelize this sequential algorithm to obtain even higher speed up.

These are some results on a 4-Core i5-4200H CPU @ 2.80GHz:
Old algorithm, parallel (using #1051):
1 thread
  pre: 1.23728 s
2 threads
  pre: 0.72080 s
4 threads (default)
  pre: 0.69974 s

New algorithm (this PR)
1 thread
  pre: 0.15835 s
2 threads
  pre: 0.15837 s
4 threads (default)
  pre: 0.15925 s
(of course it doesn't depend on the number of threads, it's not parallel right now)

Reference: http://www.sciencedirect.com/science/article/pii/S0167865516300861
