### PR TITLE
BF - fix CSD.predict to work with nd inputs.

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -214,7 +214,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         S0 = np.asarray(S0)[..., None]
         scaling = S0 / self.response_scaling
         # This is the key operation: convolve and multiply by S0:
-        pre_pred_sig = scaling * np.dot(predict_matrix, sh_coeff)
+        pre_pred_sig = scaling * np.dot(sh_coeff, predict_matrix.T)
 
         # Now put everything in its right place:
         pred_sig = np.zeros(pre_pred_sig.shape[:-1] + (gtab.bvals.shape[0],))

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -417,6 +417,14 @@ def test_csd_predict():
     csd_fit = csd.fit(S)
     npt.assert_array_almost_equal(coeff, csd_fit.shm_coeff)
 
+    # Test predict on nd-data set
+    S_nd = np.zeros((2, 3, 4, S.size))
+    S_nd[:] = S
+    fit = csd.fit(S_nd)
+    predict1 = fit.predict()
+    predict2 = csd.predict(fit.shm_coeff)
+    npt.assert_array_almost_equal(predict1, predict2)
+
 
 def test_csd_predict_multi():
     """


### PR DESCRIPTION
This small change should allow the csd.predict method to accept nd-arrays of coefficients.