### PR TITLE
improve OMP parallelization with scheduling

### DIFF
--- a/dipy/denoise/denspeed.pyx
+++ b/dipy/denoise/denspeed.pyx
@@ -108,7 +108,7 @@ def _nlmeans_3d(double[:, :, ::1] arr, double[:, :, ::1] mask,
 
     # move the block
     with nogil, parallel():
-        for i in prange(B + P, I - B - P):
+        for i in prange(B + P, I - B - P, schedule="dynamic"):
             for j in range(B + P, J - B - P):
                 for k in range(B + P, K - B - P):
 


### PR DESCRIPTION
Many jobs deployed by prange finish very quickly when using a mask. Since the default scheduling seems to assign jobs statically to workers by creation some worker run out of jobs quickly. I tested all possible settings with default parameters, num_threads=10 on a virtualized system on an HCP dataset (HCP/994273/T1w/Diffusion). The mask was computed with dipy and covers (=1) ~25% of the dataset.
Single runs, hence high variance, but the trend is pretty clear:

default: 1990s
guided: 1065s
dynamic: 1011s
static: 2077s