### PR TITLE
ENH: Add support for ArraySequence in `length` function

### DIFF
--- a/dipy/tracking/__init__.py
+++ b/dipy/tracking/__init__.py
@@ -1,6 +1,8 @@
 # Init for tracking module
 """ Tracking objects """
 
+from nibabel.streamlines import ArraySequence as Streamlines
+
 # Test callable
 from numpy.testing import Tester
 test = Tester().test

--- a/dipy/tracking/__init__.py
+++ b/dipy/tracking/__init__.py
@@ -1,10 +1,16 @@
 # Init for tracking module
 """ Tracking objects """
-
-from nibabel.streamlines import ArraySequence as Streamlines
+from distutils.version import LooseVersion
 
 # Test callable
 from numpy.testing import Tester
 test = Tester().test
 bench = Tester().bench
 del Tester
+
+import nibabel
+
+NIBABEL_LESS_2_1 = LooseVersion(nibabel.__version__) < '2.1'
+
+if not NIBABEL_LESS_2_1:
+    from nibabel.streamlines import ArraySequence as Streamlines

--- a/dipy/tracking/__init__.py
+++ b/dipy/tracking/__init__.py
@@ -1,16 +1,10 @@
 # Init for tracking module
 """ Tracking objects """
-from distutils.version import LooseVersion
+
+from nibabel.streamlines import ArraySequence as Streamlines
 
 # Test callable
 from numpy.testing import Tester
 test = Tester().test
 bench = Tester().bench
 del Tester
-
-import nibabel
-
-NIBABEL_LESS_2_1 = LooseVersion(nibabel.__version__) < '2.1'
-
-if not NIBABEL_LESS_2_1:
-    from nibabel.streamlines import ArraySequence as Streamlines

--- a/dipy/tracking/benchmarks/bench_streamline.py
+++ b/dipy/tracking/benchmarks/bench_streamline.py
@@ -28,8 +28,7 @@ from dipy.tracking.tests.test_streamline import (set_number_of_points_python,
                                                  length_python,
                                                  compress_streamlines_python)
 
-if not NIBABEL_LESS_2_1:
-    from dipy.tracking import Streamlines
+from dipy.tracking import Streamlines
 
 DATA = {}
 
@@ -99,15 +98,14 @@ def bench_length():
     assert_array_equal([length_python(s) for s in DATA["streamlines"]],
                        length(DATA["streamlines"]))
 
-    if not NIBABEL_LESS_2_1:
-        streamlines = DATA['streamlines_arrseq']
-        cython_time_arrseq = measure("length(streamlines)", repeat)
-        print("Cython time (ArrSeq): {0:.3}sec".format(cython_time_arrseq))
-        print("Speed up of {0:.2f}x".format(python_time/cython_time_arrseq))
+    streamlines = DATA['streamlines_arrseq']
+    cython_time_arrseq = measure("length(streamlines)", repeat)
+    print("Cython time (ArrSeq): {0:.3}sec".format(cython_time_arrseq))
+    print("Speed up of {0:.2f}x".format(python_time/cython_time_arrseq))
 
-        # Make sure it produces the same results.
-        assert_array_equal(length(DATA["streamlines"]),
-                           length(DATA["streamlines_arrseq"]))
+    # Make sure it produces the same results.
+    assert_array_equal(length(DATA["streamlines"]),
+                       length(DATA["streamlines_arrseq"]))
 
 
 def bench_compress_streamlines():

--- a/dipy/tracking/benchmarks/bench_streamline.py
+++ b/dipy/tracking/benchmarks/bench_streamline.py
@@ -11,19 +11,45 @@ run the doctests, let's hope they pass.
 
 Run this benchmark with:
 
-    nosetests -s --match '(?:^|[\\b_\\.//-])[Bb]ench' /path/to/bench_streamline.py
+    nosetests -s --match '(?:^|[\\b_\\.//-])[Bb]ench' bench_streamline.py
 """
 import numpy as np
 from numpy.testing import measure
+from numpy.testing import assert_array_equal
+
 from dipy.data import get_data
 from nibabel import trackvis as tv
 
+from dipy.tracking import Streamlines
 from dipy.tracking.streamline import (set_number_of_points,
                                       length,
                                       compress_streamlines)
 from dipy.tracking.tests.test_streamline import (set_number_of_points_python,
                                                  length_python,
                                                  compress_streamlines_python)
+
+DATA = {}
+
+
+def setup():
+    global DATA
+    rng = np.random.RandomState(42)
+    nb_streamlines = 20000
+    min_nb_points = 2
+    max_nb_points = 100
+
+    DATA['rng'] = rng
+    DATA['nb_streamlines'] = nb_streamlines
+    DATA['streamlines'] = generate_streamlines(nb_streamlines,
+                                               min_nb_points, max_nb_points,
+                                               rng=rng)
+    DATA['streamlines_arrseq'] = Streamlines(DATA['streamlines'])
+
+
+def generate_streamlines(nb_streamlines, min_nb_points, max_nb_points, rng):
+    streamlines = [rng.rand(*(rng.randint(min_nb_points, max_nb_points), 3))
+                   for _ in range(nb_streamlines)]
+    return streamlines
 
 
 def bench_set_number_of_points():
@@ -53,25 +79,28 @@ def bench_set_number_of_points():
 
 
 def bench_length():
-    repeat = 1
-    nb_points_per_streamline = 100
-    nb_streamlines = int(1e5)
-    streamlines = [np.random.rand(nb_points_per_streamline,
-                                  3).astype("float32")
-                   for i in range(nb_streamlines)]
+    repeat = 10
+    nb_streamlines = DATA['nb_streamlines']
+    streamlines = DATA["streamlines"]  # Streamlines as a list of ndarrays.
 
-    print("Timing length() in Cython ({0} streamlines)".format(nb_streamlines))
-    cython_time = measure("length(streamlines)", repeat)
-    print("Cython time: {0:.3}sec".format(cython_time))
-    del streamlines
-
-    streamlines = [np.random.rand(nb_points_per_streamline,
-                                  3).astype("float32")
-                   for i in range(nb_streamlines)]
+    print("Timing length() with {0:,} streamlines.".format(nb_streamlines))
     python_time = measure("[length_python(s) for s in streamlines]", repeat)
     print("Python time: {0:.2}sec".format(python_time))
-    print("Speed up of {0}x".format(python_time/cython_time))
-    del streamlines
+
+    cython_time = measure("length(streamlines)", repeat)
+    print("Cython time: {0:.3}sec".format(cython_time))
+    print("Speed up of {0:.2f}x".format(python_time/cython_time))
+
+    streamlines = DATA['streamlines_arrseq']
+    cython_time_arrseq = measure("length(streamlines)", repeat)
+    print("Cython time (ArraySequence): {0:.3}sec".format(cython_time_arrseq))
+    print("Speed up of {0:.2f}x".format(python_time/cython_time_arrseq))
+
+    # Make sure all methods produce the same results.
+    assert_array_equal([length_python(s) for s in DATA["streamlines"]],
+                       length(DATA["streamlines"]))
+    assert_array_equal(length(DATA["streamlines"]),
+                       length(DATA["streamlines_arrseq"]))
 
 
 def bench_compress_streamlines():

--- a/dipy/tracking/benchmarks/bench_streamline.py
+++ b/dipy/tracking/benchmarks/bench_streamline.py
@@ -20,7 +20,6 @@ from numpy.testing import assert_array_equal
 from dipy.data import get_data
 from nibabel import trackvis as tv
 
-from dipy.tracking import NIBABEL_LESS_2_1
 from dipy.tracking.streamline import (set_number_of_points,
                                       length,
                                       compress_streamlines)
@@ -45,8 +44,7 @@ def setup():
     DATA['streamlines'] = generate_streamlines(nb_streamlines,
                                                min_nb_points, max_nb_points,
                                                rng=rng)
-    if not NIBABEL_LESS_2_1:
-        DATA['streamlines_arrseq'] = Streamlines(DATA['streamlines'])
+    DATA['streamlines_arrseq'] = Streamlines(DATA['streamlines'])
 
 
 def generate_streamlines(nb_streamlines, min_nb_points, max_nb_points, rng):

--- a/dipy/tracking/streamlinespeed.pxd
+++ b/dipy/tracking/streamlinespeed.pxd
@@ -1,8 +1,8 @@
 # distutils: language = c
 # cython: wraparound=False, cdivision=True, boundscheck=False
 
-ctypedef float[:,:] float2d
-ctypedef double[:,:] double2d
+ctypedef float[:, :] float2d
+ctypedef double[:, :] double2d
 
 ctypedef fused Streamline:
     float2d
@@ -11,6 +11,6 @@ ctypedef fused Streamline:
 
 cdef double c_length(Streamline streamline) nogil
 
-cdef void c_arclengths(Streamline streamline, double* out) nogil
+cdef void c_arclengths(Streamline streamline, double * out) nogil
 
 cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -5,7 +5,9 @@ import cython
 import numpy as np
 from libc.math cimport sqrt
 
-from dipy.tracking import Streamlines
+from dipy.tracking import NIBABEL_LESS_2_1
+if not NIBABEL_LESS_2_1:
+    from dipy.tracking import Streamlines
 
 cimport numpy as np
 
@@ -97,7 +99,7 @@ def length(streamlines):
     0.0
 
     '''
-    if isinstance(streamlines, Streamlines):
+    if not NIBABEL_LESS_2_1 and isinstance(streamlines, Streamlines):
         if len(streamlines) == 0:
             return 0.0
 

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -5,11 +5,10 @@ import cython
 import numpy as np
 from libc.math cimport sqrt
 
-from dipy.tracking import NIBABEL_LESS_2_1
-if not NIBABEL_LESS_2_1:
-    from dipy.tracking import Streamlines
-
 cimport numpy as np
+
+from dipy.tracking import Streamlines
+
 
 cdef extern from "dpy_math.h" nogil:
     bint dpy_isnan(double x)
@@ -99,7 +98,7 @@ def length(streamlines):
     0.0
 
     '''
-    if not NIBABEL_LESS_2_1 and isinstance(streamlines, Streamlines):
+    if isinstance(streamlines, Streamlines):
         if len(streamlines) == 0:
             return 0.0
 

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -11,10 +11,10 @@ from nose.tools import assert_true, assert_equal, assert_almost_equal
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_raises, run_module_suite)
 
-from dipy.tracking import Streamlines
+from dipy.tracking import NIBABEL_LESS_2_1
 import dipy.tracking.utils as ut
 from dipy.tracking.streamline import (set_number_of_points,
-                                      length as ds_length,
+                                      length,
                                       relist_streamlines,
                                       unlist_streamlines,
                                       center_streamlines,
@@ -24,6 +24,9 @@ from dipy.tracking.streamline import (set_number_of_points,
                                       select_by_rois,
                                       orient_by_rois,
                                       values_from_volume)
+
+if not NIBABEL_LESS_2_1:
+    from dipy.tracking import Streamlines
 
 
 streamline = np.array([[82.20181274,  91.36505890,  43.15737152],
@@ -344,36 +347,23 @@ def test_set_number_of_points_memory_leaks():
 
 def test_length():
     # Test length of only one streamline
-    length_streamline_cython = ds_length(streamline)
+    length_streamline_cython = length(streamline)
     length_streamline_python = length_python(streamline)
     assert_almost_equal(length_streamline_cython, length_streamline_python)
 
-    # ArraySequence
-    length_streamline_arrseq = ds_length(Streamlines([streamline]))
-    assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
-
-    length_streamline_cython = ds_length(streamline_64bit)
+    length_streamline_cython = length(streamline_64bit)
     length_streamline_python = length_python(streamline_64bit)
     assert_almost_equal(length_streamline_cython, length_streamline_python)
 
-    # ArraySequence
-    length_streamline_arrseq = ds_length(Streamlines([streamline_64bit]))
-    assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
-
     # Test computing length of multiple streamlines of different nb_points
-    length_streamlines_cython = ds_length(streamlines)
+    length_streamlines_cython = length(streamlines)
 
     for i, s in enumerate(streamlines):
         length_streamline_python = length_python(s)
         assert_array_almost_equal(length_streamlines_cython[i],
                                   length_streamline_python)
 
-    # ArraySequence
-    length_streamlines_arrseq = ds_length(Streamlines(streamlines))
-    assert_array_almost_equal(length_streamlines_arrseq,
-                              length_streamlines_cython)
-
-    length_streamlines_cython = ds_length(streamlines_64bit)
+    length_streamlines_cython = length(streamlines_64bit)
 
     for i, s in enumerate(streamlines_64bit):
         length_streamline_python = length_python(s)
@@ -381,32 +371,49 @@ def test_length():
                                   length_streamline_python)
 
     # ArraySequence
-    length_streamlines_arrseq = ds_length(Streamlines(streamlines_64bit))
-    assert_array_almost_equal(length_streamlines_arrseq,
-                              length_streamlines_cython)
+    if not NIBABEL_LESS_2_1:
+        # Test length of only one streamline
+        length_streamline_cython = length(streamline_64bit)
+        length_streamline_arrseq = length(Streamlines([streamline]))
+        assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
 
-    # Test on a sliced ArraySequence
-    length_streamlines_cython = ds_length(streamlines_64bit[::2])
-    length_streamlines_arrseq = ds_length(Streamlines(streamlines_64bit[::2]))
-    assert_array_almost_equal(length_streamlines_arrseq,
-                              length_streamlines_cython)
-    length_streamlines_cython = ds_length(streamlines_64bit[::-1])
-    length_streamlines_arrseq = ds_length(Streamlines(streamlines_64bit[::-1]))
-    assert_array_almost_equal(length_streamlines_arrseq,
-                              length_streamlines_cython)
+        length_streamline_cython = length(streamline_64bit)
+        length_streamline_arrseq = length(Streamlines([streamline_64bit]))
+        assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
+
+        # Test computing length of multiple streamlines of different nb_points
+        length_streamlines_cython = length(streamlines)
+        length_streamlines_arrseq = length(Streamlines(streamlines))
+        assert_array_almost_equal(length_streamlines_arrseq,
+                                  length_streamlines_cython)
+
+        length_streamlines_cython = length(streamlines_64bit)
+        length_streamlines_arrseq = length(Streamlines(streamlines_64bit))
+        assert_array_almost_equal(length_streamlines_arrseq,
+                                  length_streamlines_cython)
+
+        # Test on a sliced ArraySequence
+        length_streamlines_cython = length(streamlines_64bit[::2])
+        length_streamlines_arrseq = length(Streamlines(streamlines_64bit)[::2])
+        assert_array_almost_equal(length_streamlines_arrseq,
+                                  length_streamlines_cython)
+        length_streamlines_cython = length(streamlines[::-1])
+        length_streamlines_arrseq = length(Streamlines(streamlines)[::-1])
+        assert_array_almost_equal(length_streamlines_arrseq,
+                                  length_streamlines_cython)
 
     # Test streamlines having mixed dtype
     streamlines_mixed_dtype = [streamline,
                                streamline.astype(np.float64),
                                streamline.astype(np.int32),
                                streamline.astype(np.int64)]
-    lengths_mixed_dtype = [ds_length(s)
+    lengths_mixed_dtype = [length(s)
                            for s in streamlines_mixed_dtype]
-    assert_array_equal(ds_length(streamlines_mixed_dtype),
+    assert_array_equal(length(streamlines_mixed_dtype),
                        lengths_mixed_dtype)
 
     # Test streamlines with different shape
-    length_streamlines_cython = ds_length(
+    length_streamlines_cython = length(
         heterogeneous_streamlines)
 
     for i, s in enumerate(heterogeneous_streamlines):
@@ -415,18 +422,18 @@ def test_length():
                                   length_streamline_python)
 
     # Test streamline having integer dtype
-    length_streamline = ds_length(streamline.astype('int'))
+    length_streamline = length(streamline.astype('int'))
     assert_true(length_streamline.dtype == np.float64)
 
     # Test empty list
-    assert_equal(ds_length([]), 0.0)
+    assert_equal(length([]), 0.0)
 
     # Test streamline having only one point
-    assert_equal(ds_length(np.array([[1, 2, 3]])), 0.0)
+    assert_equal(length(np.array([[1, 2, 3]])), 0.0)
 
     # We do not support list of lists, it should be numpy ndarray.
     streamline_unsupported = [[1, 2, 3], [4, 5, 5], [2, 1, 3], [4, 2, 1]]
-    assert_raises(AttributeError, ds_length,
+    assert_raises(AttributeError, length,
                   streamline_unsupported)
 
     # Test setting computing length of a numpy with flag WRITABLE=False
@@ -435,14 +442,14 @@ def test_length():
         streamlines_readonly.append(s.copy())
         streamlines_readonly[-1].setflags(write=False)
 
-    assert_array_almost_equal(ds_length(streamlines_readonly),
+    assert_array_almost_equal(length(streamlines_readonly),
                               [length_python(s) for s in streamlines_readonly])
     streamlines_readonly = []
     for s in streamlines_64bit:
         streamlines_readonly.append(s.copy())
         streamlines_readonly[-1].setflags(write=False)
 
-    assert_array_almost_equal(ds_length(streamlines_readonly),
+    assert_array_almost_equal(length(streamlines_readonly),
                               [length_python(s) for s in streamlines_readonly])
 
 
@@ -457,10 +464,10 @@ def test_length_memory_leaks():
 
         list_refcount_before = get_type_refcount()["list"]
 
-        lengths = ds_length(streamlines)
+        lengths = length(streamlines)
         list_refcount_after = get_type_refcount()["list"]
 
-        # Calling `ds_length` shouldn't increase the refcount of `list`
+        # Calling `length` shouldn't increase the refcount of `list`
         # since the return value is a numpy array.
         assert_equal(list_refcount_after, list_refcount_before)
 
@@ -474,10 +481,10 @@ def test_length_memory_leaks():
 
     list_refcount_before = get_type_refcount()["list"]
 
-    lengths = ds_length(streamlines)
+    lengths = length(streamlines)
     list_refcount_after = get_type_refcount()["list"]
 
-    # Calling `ds_length` shouldn't increase the refcount of `list`
+    # Calling `length` shouldn't increase the refcount of `list`
     # since the return value is a numpy array.
     assert_equal(list_refcount_after, list_refcount_before)
 

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -11,6 +11,7 @@ from nose.tools import assert_true, assert_equal, assert_almost_equal
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_raises, run_module_suite)
 
+from dipy.tracking import Streamlines
 import dipy.tracking.utils as ut
 from dipy.tracking.streamline import (set_number_of_points,
                                       length as ds_length,
@@ -347,9 +348,17 @@ def test_length():
     length_streamline_python = length_python(streamline)
     assert_almost_equal(length_streamline_cython, length_streamline_python)
 
+    # ArraySequence
+    length_streamline_arrseq = ds_length(Streamlines([streamline]))
+    assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
+
     length_streamline_cython = ds_length(streamline_64bit)
     length_streamline_python = length_python(streamline_64bit)
     assert_almost_equal(length_streamline_cython, length_streamline_python)
+
+    # ArraySequence
+    length_streamline_arrseq = ds_length(Streamlines([streamline_64bit]))
+    assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
 
     # Test computing length of multiple streamlines of different nb_points
     length_streamlines_cython = ds_length(streamlines)
@@ -359,12 +368,32 @@ def test_length():
         assert_array_almost_equal(length_streamlines_cython[i],
                                   length_streamline_python)
 
+    # ArraySequence
+    length_streamlines_arrseq = ds_length(Streamlines(streamlines))
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
+
     length_streamlines_cython = ds_length(streamlines_64bit)
 
     for i, s in enumerate(streamlines_64bit):
         length_streamline_python = length_python(s)
         assert_array_almost_equal(length_streamlines_cython[i],
                                   length_streamline_python)
+
+    # ArraySequence
+    length_streamlines_arrseq = ds_length(Streamlines(streamlines_64bit))
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
+
+    # Test on a sliced ArraySequence
+    length_streamlines_cython = ds_length(streamlines_64bit[::2])
+    length_streamlines_arrseq = ds_length(Streamlines(streamlines_64bit[::2]))
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
+    length_streamlines_cython = ds_length(streamlines_64bit[::-1])
+    length_streamlines_arrseq = ds_length(Streamlines(streamlines_64bit[::-1]))
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
 
     # Test streamlines having mixed dtype
     streamlines_mixed_dtype = [streamline,

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -11,7 +11,7 @@ from nose.tools import assert_true, assert_equal, assert_almost_equal
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_raises, run_module_suite)
 
-from dipy.tracking import NIBABEL_LESS_2_1
+from dipy.tracking import Streamlines
 import dipy.tracking.utils as ut
 from dipy.tracking.streamline import (set_number_of_points,
                                       length,
@@ -24,9 +24,6 @@ from dipy.tracking.streamline import (set_number_of_points,
                                       select_by_rois,
                                       orient_by_rois,
                                       values_from_volume)
-
-if not NIBABEL_LESS_2_1:
-    from dipy.tracking import Streamlines
 
 
 streamline = np.array([[82.20181274,  91.36505890,  43.15737152],
@@ -371,36 +368,35 @@ def test_length():
                                   length_streamline_python)
 
     # ArraySequence
-    if not NIBABEL_LESS_2_1:
-        # Test length of only one streamline
-        length_streamline_cython = length(streamline_64bit)
-        length_streamline_arrseq = length(Streamlines([streamline]))
-        assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
+    # Test length of only one streamline
+    length_streamline_cython = length(streamline_64bit)
+    length_streamline_arrseq = length(Streamlines([streamline]))
+    assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
 
-        length_streamline_cython = length(streamline_64bit)
-        length_streamline_arrseq = length(Streamlines([streamline_64bit]))
-        assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
+    length_streamline_cython = length(streamline_64bit)
+    length_streamline_arrseq = length(Streamlines([streamline_64bit]))
+    assert_almost_equal(length_streamline_arrseq, length_streamline_cython)
 
-        # Test computing length of multiple streamlines of different nb_points
-        length_streamlines_cython = length(streamlines)
-        length_streamlines_arrseq = length(Streamlines(streamlines))
-        assert_array_almost_equal(length_streamlines_arrseq,
-                                  length_streamlines_cython)
+    # Test computing length of multiple streamlines of different nb_points
+    length_streamlines_cython = length(streamlines)
+    length_streamlines_arrseq = length(Streamlines(streamlines))
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
 
-        length_streamlines_cython = length(streamlines_64bit)
-        length_streamlines_arrseq = length(Streamlines(streamlines_64bit))
-        assert_array_almost_equal(length_streamlines_arrseq,
-                                  length_streamlines_cython)
+    length_streamlines_cython = length(streamlines_64bit)
+    length_streamlines_arrseq = length(Streamlines(streamlines_64bit))
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
 
-        # Test on a sliced ArraySequence
-        length_streamlines_cython = length(streamlines_64bit[::2])
-        length_streamlines_arrseq = length(Streamlines(streamlines_64bit)[::2])
-        assert_array_almost_equal(length_streamlines_arrseq,
-                                  length_streamlines_cython)
-        length_streamlines_cython = length(streamlines[::-1])
-        length_streamlines_arrseq = length(Streamlines(streamlines)[::-1])
-        assert_array_almost_equal(length_streamlines_arrseq,
-                                  length_streamlines_cython)
+    # Test on a sliced ArraySequence
+    length_streamlines_cython = length(streamlines_64bit[::2])
+    length_streamlines_arrseq = length(Streamlines(streamlines_64bit)[::2])
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
+    length_streamlines_cython = length(streamlines[::-1])
+    length_streamlines_arrseq = length(Streamlines(streamlines)[::-1])
+    assert_array_almost_equal(length_streamlines_arrseq,
+                              length_streamlines_cython)
 
     # Test streamlines having mixed dtype
     streamlines_mixed_dtype = [streamline,


### PR DESCRIPTION
This small PR is the first of a series of PRs aiming to support Nibabel's `ArraySequence` objects.

Specifically, this PR improves `dipy.tracking.streamlinespeed.length` to support `ArraySequence` objects. This gives pretty good speedup even over the current Cython version (all speedups are in respect to the Python implementation):

```
Timing length() with 20,000 streamlines.
Python time: 3.9sec
Cython time: 0.46sec
Speed up of 8.41x
Cython time (ArraySequence): 0.08sec
Speed up of 48.38x
```

Edit: of course this needs the master branch of Nibabel or eventually v2.1. 
