### PR TITLE
Fetcher for ivim data, needs md5

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -392,6 +392,14 @@ fetch_bundles_2_subjects = _make_fetcher(
     doc="Download 2 subjects from the SNAIL dataset with their bundles",
     unzip=True)
 
+fetch_ivim = _make_fetcher(
+    "fetch_ivim",
+    pjoin(dipy_home, 'ivim'),
+    'https://ndownloader.figshare.com/files/',
+    ['5305243', '5305246', '5305249'],
+    ['ivim.nii.gz', 'ivim.bval', 'ivim.bvec'],
+    doc="Download IVIM dataset")
+
 
 def read_scil_b0():
     """ Load GE 3T b0 image form the scil b0 dataset.
@@ -839,3 +847,22 @@ def read_bundles_2_subjects(subj_id='subj_1', metrics=['fa'],
         res[bun] = streamlines
 
     return res
+
+def read_ivim():
+    """ Load IVIM dataset
+
+    Returns
+    -------
+    img : obj,
+        Nifti1Image
+    gtab : obj,
+        GradientTable
+    """
+    files, folder = fetch_ivim()
+    fraw = pjoin(folder, 'ivim.nii.gz')
+    fbval = pjoin(folder, 'ivim.bval')
+    fbvec = pjoin(folder, 'ivim.bvec')
+    bvals, bvecs = read_bvals_bvecs(fbval, fbvec)
+    gtab = gradient_table(bvals, bvecs)
+    img = nib.load(fraw)
+    return img, gtab

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -398,7 +398,7 @@ fetch_ivim = _make_fetcher(
     'https://ndownloader.figshare.com/files/',
     ['5305243', '5305246', '5305249'],
     ['ivim.nii.gz', 'ivim.bval', 'ivim.bvec'],
-    ['0b523e606fad898e44d6c249deaa0d70', 
+    ['cda596f89dc2676af7d9bf1cabccf600', 
     'f03d89f84aa9a9397103a400e43af43a',
     'fb633a06b02807355e49ccd85cb92565'],
     doc="Download IVIM dataset")
@@ -869,3 +869,4 @@ def read_ivim():
     gtab = gradient_table(bvals, bvecs)
     img = nib.load(fraw)
     return img, gtab
+

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -398,6 +398,9 @@ fetch_ivim = _make_fetcher(
     'https://ndownloader.figshare.com/files/',
     ['5305243', '5305246', '5305249'],
     ['ivim.nii.gz', 'ivim.bval', 'ivim.bvec'],
+    ['0b523e606fad898e44d6c249deaa0d70', 
+    'f03d89f84aa9a9397103a400e43af43a',
+    'fb633a06b02807355e49ccd85cb92565'],
     doc="Download IVIM dataset")
 
 


### PR DESCRIPTION
Needs the hashes, but otherwise good to go. This is for the upcoming ivim module currently being developed in https://github.com/nipy/dipy/pull/1058. 