### PR TITLE
ENH: avoid calling log() on zero-valued elements in anisotropic_power

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1037,7 +1037,8 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
     A l=2 SH coefficient matrix will then be composed of a IxJxKx6 volume.
     The power, $n$ is usually set to $n=2$.
 
-    The final AP image is then shifted by -log(norm_factor), to be strictly non-negative. Remaining values < 0 are discarded (set to 0), per default,
+    The final AP image is then shifted by -log(norm_factor), to be strictly
+    non-negative. Remaining values < 0 are discarded (set to 0), per default,
     and this option is controlled through the `non_negative` keyword argument.
 
     References

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1010,7 +1010,7 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
     ----------
     sh_coeffs : ndarray
         A ndarray where the last dimension is the
-        SH coeff estimates for that voxel.
+        SH coefficients estimates for that voxel.
     norm_factor: float, optional
         The value to normalize the ap values. Default is 10^-5.
     power : int, optional
@@ -1026,7 +1026,7 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
 
     Notes
     ----------
-    Calculate AP image based on a IxJxKxC SH coeffecient matrix based on the
+    Calculate AP image based on a IxJxKxC SH coefficient matrix based on the
     equation:
     .. math::
         AP = \sum_{l=2,4,6,...}{\frac{1}{2l+1} \sum_{m=-l}^l{|a_{l,m}|^n}}
@@ -1034,11 +1034,11 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
     Where the last dimension, C, is made of a flattened array of $l$x$m$
     coefficients, where $l$ are the SH orders, and $m = 2l+1$,
     So l=1 has 1 coeffecient, l=2 has 5, ... l=8 has 17 and so on.
-    A l=2 SH coeffecient matrix will then be composed of a IxJxKx6 volume.
+    A l=2 SH coefficient matrix will then be composed of a IxJxKx6 volume.
     The power, $n$ is usually set to $n=2$.
 
-    The final AP image is then shifted by -log(normal_factor), to be strictly non-negative. Remaining values < 0 are discarded (set to 0), per default,
-    and this option is controlled throug the `non_negative` key word argument.
+    The final AP image is then shifted by -log(norm_factor), to be strictly non-negative. Remaining values < 0 are discarded (set to 0), per default,
+    and this option is controlled through the `non_negative` keyword argument.
 
     References
     ----------

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1062,8 +1062,9 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
         n_start = n_stop
 
     # Shift the map to be mostly non-negative,
-    # only applying the log operation to non-zero elements
+    # only applying the log operation to positive elements
     # to avoid getting numpy warnings on log(0).
+    # It is impossible to get ap values smaller than 0.
     # Also avoids getting voxels with -inf when non_negative=False.
     log_ap = np.zeros_like(ap)
     log_ap[ap > 0] = np.log(ap[ap > 0]) - np.log(norm_factor)

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -1060,8 +1060,12 @@ def anisotropic_power(sh_coeffs, norm_factor=0.00001, power=2,
         ap += ap_i
         n_start = n_stop
 
-    # Shift the map to be mostly non-negative:
-    log_ap = np.log(ap) - np.log(norm_factor)
+    # Shift the map to be mostly non-negative,
+    # only applying the log operation to non-zero elements
+    # to avoid getting numpy warnings on log(0).
+    # Also avoids getting voxels with -inf when non_negative=False.
+    log_ap = np.zeros_like(ap)
+    log_ap[ap > 0] = np.log(ap[ap > 0]) - np.log(norm_factor)
 
     # Deal with residual negative values:
     if non_negative:

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -437,7 +437,7 @@ def test_anisotropic_power():
             assert_array_almost_equal(apvals, answers)
             # Test that this works for single voxel arrays as well:
             assert_array_almost_equal(
-                anisotropic_power(coeffs[1], norm_factor=norm_factor),
+                anisotropic_power(np.asarray(coeffs[1]), norm_factor=norm_factor),
                 answers[1])
 
 


### PR DESCRIPTION
In reconst.shm.anisotropic_power, there is a log() normalization, to bring back values to a reasonable range.

However, for some voxels (for example, when outside of the brain), the pre-normalized AP values are already worth 0. In this case, applying the log() call would generate a numpy warning, that could be misleading for end users.

In this patch, we simply apply the log only to elements that are > 0. Guaranteed to be >= 0, since it's a sum of absolute values.

Also, if the non_negative kw arg is set to False, those 0-valued voxels get "normalized" to -inf, which is not a really useful value. They can also create other issues if those maps are further post-processed.

Finally, a few quick typos were fixed in the doc for this function.
