### PR TITLE
BF: fix test error on Python 3

### DIFF
--- a/dipy/segment/tests/test_metric.py
+++ b/dipy/segment/tests/test_metric.py
@@ -2,9 +2,9 @@ import numpy as np
 import dipy.segment.metric as dipymetric
 import itertools
 
-from nose.tools import (assert_true, assert_false,
-                        assert_equal, assert_almost_equal)
-from numpy.testing import assert_array_equal, assert_raises, run_module_suite
+from nose.tools import (assert_true, assert_false, assert_equal)
+from numpy.testing import (assert_array_equal, assert_raises, run_module_suite,
+                           assert_almost_equal)
 
 
 def norm(x, ord=None, axis=None):


### PR DESCRIPTION
Numpy does not implement the `__round__` method, causing the following
error when trying to use builtin `round`:

    >>> round(np.array([1]))
    Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    TypeError: type numpy.ndarray doesn't define __round__ method

For the test error in dipy, see:
https://travis-ci.org/MacPython/dipy-wheels/jobs/140257955#L357

Use numpy's `assert_almost_equal` instead of the version from nose, to
avoid this problem.