### PR TITLE
MRG: add pytables to travis-ci, Py35 full test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ language: python
 cache:
   directories:
     - $HOME/.cache/pip
+addons:
+  apt:
+    packages:
+      # For runs with pytables
+      - libhdf5-serial-dev
+
 env:
     global:
         - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt"
@@ -32,7 +38,10 @@ matrix:
         - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==1.2.0"
     - python: 2.7
       env:
-        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt scikit_learn"
+        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt scikit_learn tables"
+    - python: 3.5
+      env:
+        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt scikit_learn tables"
     # To test vtk functionality
     - python: 2.7
       sudo: true   # This is set to true for apt-get

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -362,7 +362,7 @@ def sph_harm_ind_list(sh_order):
     n_range = np.arange(0, sh_order + 1, 2, dtype=int)
     n_list = np.repeat(n_range, n_range * 2 + 1)
 
-    ncoef = (sh_order + 2) * (sh_order + 1) / 2
+    ncoef = (sh_order + 2) * (sh_order + 1) // 2
     offset = 0
     m_list = empty(ncoef, 'int')
     for ii in n_range:


### PR DESCRIPTION
Add a Python 3.5 run with full dependendencies.  Add (py)tables to full
dependencies.

Replaces #1101.