### PR TITLE
TST: Test for invariance of model_params to splitting of the data.

### DIFF
--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -6,7 +6,7 @@ import numpy as np
 from dipy.reconst.dti import (TensorFit, mean_diffusivity, axial_diffusivity,
                               radial_diffusivity, from_lower_triangular,
                               lower_triangular, decompose_tensor,
-                              _min_positive_signal)
+                              MIN_POSITIVE_SIGNAL)
 
 from dipy.reconst.utils import dki_design_matrix as design_matrix
 from dipy.utils.six.moves import range
@@ -1021,7 +1021,7 @@ class DiffusionKurtosisModel(ReconstModel):
             data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
         if self.min_signal is None:
-            min_signal = _min_positive_signal(data)
+            min_signal = MIN_POSITIVE_SIGNAL
         else:
             min_signal = self.min_signal
 

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -21,6 +21,9 @@ from ..core.onetime import auto_attr
 from .base import ReconstModel
 
 
+MIN_POSITIVE_SIGNAL = 0.0001
+
+
 def _roll_evals(evals, axis=-1):
     """
     Helper function to check that the evals provided to functions calculating
@@ -47,28 +50,6 @@ def _roll_evals(evals, axis=-1):
     evals = np.rollaxis(evals, axis)
 
     return evals
-
-
-def _min_positive_signal(data):
-    """ Helper function to establish the minimum positive signal of a given
-    data
-
-    Parameters
-    ----------
-    data: array ([X, Y, Z, ...], g)
-        Data or response variables holding the data. Note that the last
-        dimension should contain the data.
-
-    Returns
-    -------
-    min_signal : float
-        Minimum positive signal of the given data
-    """
-    data = data.ravel()
-    if np.all(data == 0):
-        return 0.0001
-    else:
-        return data[data > 0].min()
 
 
 def fractional_anisotropy(evals, axis=-1):
@@ -725,7 +706,6 @@ class TensorModel(ReconstModel):
 
         Note
         -----
-
         In order to increase speed of processing, tensor fitting is done
         simultaneously over many voxels. Many fit_methods use the 'step'
         parameter to set the number of voxels that will be fit at once in each
@@ -793,7 +773,7 @@ class TensorModel(ReconstModel):
             data_in_mask = np.reshape(data[mask], (-1, data.shape[-1]))
 
         if self.min_signal is None:
-            min_signal = _min_positive_signal(data)
+            min_signal = MIN_POSITIVE_SIGNAL
         else:
             min_signal = self.min_signal
 
@@ -1157,7 +1137,6 @@ class TensorFit(object):
            all voxels.
 
         step : int
-
             The chunk size as a number of voxels. Optional parameter with
             default value 10,000.
 

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -718,3 +718,15 @@ def test_eig_from_lo_tri():
 
     lo_tri = lower_triangular(dmfit.quadratic_form)
     assert_array_almost_equal(dti.eig_from_lo_tri(lo_tri), dmfit.model_params)
+
+
+def test_min_signal_alone():
+    fdata, fbvals, fbvecs = get_data()
+    data = nib.load(fdata).get_data()
+    gtab = grad.gradient_table(fbvals, fbvecs)
+
+    idx = tuple(np.array(np.where(data == np.min(data)))[:-1, 0])
+    ten_model = dti.TensorModel(gtab)
+    fit_alone = ten_model.fit(data[idx])
+    fit_together = ten_model.fit(data)
+    npt.assert_equal(fit_together.model_params[idx], fit_alone.model_params)


### PR DESCRIPTION
This looks like a bug to me: it shouldn't matter whether you fit the
entire data array or just one.

This happens because min_signal currently depends on the entire data array
that is passed, and that varies here depending on whether only one voxel
or the entire array is passed.

For now, I only have the bug and no fix, hence the WIP. Suggestions most welcome!
