### PR TITLE
Small fix in free water DTI model

### DIFF
--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -279,7 +279,7 @@ def wls_iter(design_matrix, sig, S0, Diso=3e-3, mdreg=2.7e-3,
 
     md = (params[0] + params[2] + params[5]) / 3
     # Process voxel if it has significant signal from tissue
-    if md < mdreg and np.mean(sig) > min_signal:
+    if md < mdreg and np.mean(sig) > min_signal and S0 > min_signal:
         # General free-water signal contribution
         fwsig = np.exp(np.dot(design_matrix,
                               np.array([Diso, 0, Diso, 0, 0, Diso, 0])))
@@ -596,7 +596,7 @@ def nls_iter(design_matrix, sig, S0, Diso=3e-3, mdreg=2.7e-3,
                       min_signal=min_signal, Diso=Diso, mdreg=mdreg)
 
     # Process voxel if it has significant signal from tissue
-    if params[12] < 0.99 and np.mean(sig) > min_signal:
+    if params[12] < 0.99 and np.mean(sig) > min_signal and S0 > min_signal:
         # converting evals and evecs to diffusion tensor elements
         evals = params[:3]
         evecs = params[3:12].reshape((3, 3))

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -295,3 +295,18 @@ def test_md_regularization():
     assert_array_almost_equal(fwefit.fa, FAref)
     assert_array_almost_equal(fwefit.md, MDref)
     assert_array_almost_equal(fwefit.f, GTF)
+
+
+def test_zero_s0():
+    # single voxel
+    gtf = 0.55
+    mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
+    S_conta, peaks = multi_tensor(gtab_2s, mevals, S0=100,
+                                  angles=[(90, 0), (90, 0)],
+                                  fractions=[(1-gtf) * 100, gtf*100], snr=None)
+    S_conta[gtab_2s.bvals == 0] = -100
+    fwdm = fwdti.FreeWaterTensorModel(gtab_2s, 'NLS')
+    fwefit = fwdm.fit(S_conta)
+    assert_array_almost_equal(fwefit.fa, 0.0)
+    assert_array_almost_equal(fwefit.md, 0.0)
+    assert_array_almost_equal(fwefit.f, 0.0)

--- a/dipy/reconst/tests/test_fwdti.py
+++ b/dipy/reconst/tests/test_fwdti.py
@@ -297,7 +297,7 @@ def test_md_regularization():
     assert_array_almost_equal(fwefit.f, GTF)
 
 
-def test_zero_s0():
+def test_negative_s0():
     # single voxel
     gtf = 0.55
     mevals = np.array([[0.0017, 0.0003, 0.0003], [0.003, 0.003, 0.003]])
@@ -310,3 +310,13 @@ def test_zero_s0():
     assert_array_almost_equal(fwefit.fa, 0.0)
     assert_array_almost_equal(fwefit.md, 0.0)
     assert_array_almost_equal(fwefit.f, 0.0)
+
+    # multi voxel
+    DWI[0, 0, 1, gtab_2s.bvals == 0] = -100
+    GTF[0, 0, 1] = 0
+    FAref[0, 0, 1] = 0
+    MDref[0, 0, 1] = 0
+    fwefit = fwdm.fit(DWI)
+    assert_array_almost_equal(fwefit.fa, FAref)
+    assert_array_almost_equal(fwefit.md, MDref)
+    assert_array_almost_equal(fwefit.f, GTF)


### PR DESCRIPTION
Procedure was crashing when negative S0 are present. In theory such values are implausible. However, in practice this values can be present in datasets! For example, I found this cases when processing the full CENIR dataset.

When such cases are detected all parameters are directly set to zero.