### PR TITLE
Publishing in JOSS : Added paper summary for IVIM

### DIFF
--- a/paper/joss/reconst_ivim/paper.bib
+++ b/paper/joss/reconst_ivim/paper.bib
@@ -1,0 +1,153 @@
+@article{le1986mr,
+  title={MR imaging of intravoxel incoherent motions: application to diffusion and perfusion in neurologic disorders.},
+  author={Le Bihan, Denis and Breton, Eric and Lallemand, Denis and Grenier, Philippe and Cabanis, Emmanuel and Laval-Jeantet, Maurice},
+  journal={Radiology},
+  volume={161},
+  number={2},
+  pages={401--407},
+  year={1986}
+}
+
+
+
+@article{LeBihan1986,
+  doi = {10.1148/radiology.161.2.3763909},
+  url = {http://dx.doi.org/10.1148/radiology.161.2.3763909},
+  year  = {1986},
+  month = {nov},
+  publisher = {Radiological Society of North America ({RSNA})},
+  volume = {161},
+  number = {2},
+  pages = {401--407},
+  author = {D Le Bihan and E Breton and D Lallemand and P Grenier and E Cabanis and M Laval-Jeantet},
+  title = {{MR} imaging of intravoxel incoherent motions: application to diffusion and perfusion in neurologic disorders.},
+  journal = {Radiology}
+}
+
+
+
+@article{LeBihan2008,
+  doi = {10.1148/radiol.2493081301},
+  url = {http://dx.doi.org/10.1148/radiol.2493081301},
+  year  = {2008},
+  month = {dec},
+  publisher = {Radiological Society of North America ({RSNA})},
+  volume = {249},
+  number = {3},
+  pages = {748--752},
+  author = {Denis Le Bihan},
+  title = {Intravoxel Incoherent Motion Perfusion {MR} Imaging: A Wake-Up Call},
+  journal = {Radiology}
+}
+
+@article{Powers1991,
+  doi = {10.1148/radiology.178.2.1987621},
+  url = {http://dx.doi.org/10.1148/radiology.178.2.1987621},
+  year  = {1991},
+  month = {feb},
+  publisher = {Radiological Society of North America ({RSNA})},
+  volume = {178},
+  number = {2},
+  pages = {543--548},
+  author = {T A Powers and C H Lorenz and G E Holburn and R R Price},
+  title = {Renal artery stenosis: in vivo perfusion {MR} imaging.},
+  journal = {Radiology}
+}
+
+@article {PMID:9038058,
+	Title = {[Preliminary evaluation of the apparent diffusion coefficient of the kidney with a spiral IVIM sequence]},
+	Author = {Tsuda, K and Murakami, T and Sakurai, K and Harada, K and Kim, T and Takahashi, S and Tomoda, K and Narumi, Y and Nakamura, H and Izumi, M and Tsukamoto, T},
+	Number = {1},
+	Volume = {57},
+	Month = {January},
+	Year = {1997},
+	Journal = {Nihon Igaku Hoshasen Gakkai zasshi. Nippon acta radiologica},
+	ISSN = {0048-0428},
+	Pages = {19—22},
+	URL = {http://europepmc.org/abstract/MED/9038058}
+}
+
+@article{Callot2003,
+  doi = {10.1002/mrm.10568},
+  url = {http://dx.doi.org/10.1002/mrm.10568},
+  year  = {2003},
+  month = {aug},
+  publisher = {Wiley-Blackwell},
+  volume = {50},
+  number = {3},
+  pages = {531--540},
+  author = {Virginie Callot and Eric Bennett and Ulrich K.M. Decking and Robert S. Balaban and Han Wen},
+  title = {In vivo study of microcirculation in canine myocardium using the {IVIM} method},
+  journal = {Magnetic Resonance in Medicine}
+}
+
+@article{Koh2011,
+  doi = {10.2214/ajr.10.5515},
+  url = {http://dx.doi.org/10.2214/AJR.10.5515},
+  year  = {2011},
+  month = {jun},
+  publisher = {American Roentgen Ray Society},
+  volume = {196},
+  number = {6},
+  pages = {1351--1361},
+  author = {Dow-Mu Koh and David J. Collins and Matthew R. Orton},
+  title = {Intravoxel Incoherent Motion in Body Diffusion-Weighted {MRI}: Reality and Challenges},
+  journal = {American Journal of Roentgenology}
+}
+
+@article{Moore2000,
+  doi = {10.1053/plac.2000.0567},
+  url = {http://dx.doi.org/10.1053/plac.2000.0567},
+  year  = {2000},
+  month = {sep},
+  publisher = {Elsevier {BV}},
+  volume = {21},
+  number = {7},
+  pages = {726--732},
+  author = {R.J. Moore and B.K. Strachan and D.J. Tyler and K.R. Duncan and P.N. Baker and B.S. Worthington and I.R. Johnson and P.A. Gowland},
+  title = {In utero Perfusing Fraction Maps in Normal and Growth Restricted Pregnancy Measured Using {IVIM} Echo-Planar {MRI}},
+  journal = {Placenta}
+}
+
+@article{moore2000vivo,
+  title={In vivo intravoxel incoherent motion measurements in the human placenta using echo-planar imaging at 0.5 T},
+  author={Moore, RJ and Issa, B and Tokarczuk, P and Duncan, KR and Boulby, P and Baker, PN and Bowtell, RW and Worthington, BS and Johnson, IR and Gowland, PA},
+  journal={Magnetic resonance in medicine},
+  volume={43},
+  number={2},
+  pages={295--302},
+  year={2000},
+  publisher={Wiley Online Library}
+}
+
+@article{Federau2012,
+  doi = {10.1148/radiol.12120584},
+  url = {http://dx.doi.org/10.1148/radiol.12120584},
+  year  = {2012},
+  month = {dec},
+  publisher = {Radiological Society of North America ({RSNA})},
+  volume = {265},
+  number = {3},
+  pages = {874--881},
+  author = {Christian Federau and Philippe Maeder and Kieran O'Brien and Patrick Browaeys and Reto Meuli and Patric Hagmann},
+  title = {Quantitative Measurement of Brain Perfusion with Intravoxel Incoherent Motion {MR} Imaging},
+  journal = {Radiology}
+}
+
+@article{CRUZ2014,
+   title = {{Potential application of ivim and dwi imaging in parkinson's disease}},
+   journal = {{Tecnura}},
+   author={Cruz, Gloria M AND Shengdong, Nie AND Wang, Lijia},
+   ISSN = {0123-921X},
+   language = {en},
+   URL = {http://www.scielo.org.co/scielo.php?script=sci_arttext&pid=S0123-921X2014000500008&nrm=iso},
+   volume = {18},
+   year = {2014},
+   month = {12},
+   pages = {80 - 89},
+   publisher = {scieloco},
+   crossref = {10.14483/udistrital.jour.tecnura.2014.DSE1.a07},
+}
+
+
+

--- a/paper/joss/reconst_ivim/paper.bib
+++ b/paper/joss/reconst_ivim/paper.bib
@@ -8,6 +8,21 @@
   year={1986}
 }
 
+@article{le1988ra,
+ title = {Separation of diffusion and perfusion in intravoxel incoherent motion MR imaging.},
+ author = {D Le Bihan and E Breton and D Lallemand and M L Aubin and J Vignaud and M Laval-Jeantet},
+ journal = {Radiology},
+ volume = {168},
+ number = {2},
+ pages = {497-505},
+ year = {1988},
+ doi = {10.1148/radiology.168.2.3393671},
+ note ={PMID: 3393671},
+ URL = {http://dx.doi.org/10.1148/radiology.168.2.3393671},
+ eprint = {http://dx.doi.org/10.1148/radiology.168.2.3393671},
+ abstract = { Intravoxel incoherent motion (IVIM) imaging is a method the authors developed to visualize microscopic motions of water. In biologic tissues, these motions include molecular diffusion and microcirculation of blood in the capillary network. IVIM images are quantified by an apparent diffusion coefficient (ADC), which integrates the effects of both diffusion and perfusion. The aim of this work was to demonstrate how much perfusion contributes to the ADC and to present a method for obtaining separate images of diffusion and perfusion. Images were obtained at 0.5 T with high-resolution multisection sequences and without the use of contrast material. Results in a phantom made of resin microspheres demonstrated the ability of the method to separately evaluate diffusion and perfusion. The method was then applied in patients with brain and bone tumors and brain ischemia. Clinical results showed significant promise of the method for tissue characterization by perfusion patterns and for functional studies in the evaluation of the microcirculation in physiologic and pathologic conditions, as, for instance, in brain ischemia. }
+}
+
 
 
 @article{LeBihan1986,
@@ -23,8 +38,6 @@
   title = {{MR} imaging of intravoxel incoherent motions: application to diffusion and perfusion in neurologic disorders.},
   journal = {Radiology}
 }
-
-
 
 @article{LeBihan2008,
   doi = {10.1148/radiol.2493081301},
@@ -148,6 +161,3 @@
    publisher = {scieloco},
    crossref = {10.14483/udistrital.jour.tecnura.2014.DSE1.a07},
 }
-
-
-

--- a/paper/joss/reconst_ivim/paper.md
+++ b/paper/joss/reconst_ivim/paper.md
@@ -28,7 +28,7 @@ affiliations:
    index: 2
  - name: SRI International
    index: 3
- - name: Cognition and Brain Sciences Unit (CBU)
+ - name: MRC Cognition and Brain Sciences Unit, Cambridge, UK
    index: 4
 date: 6 October 2016
 bibliography: paper.bib
@@ -36,19 +36,7 @@ bibliography: paper.bib
 
 # Summary
 
-Intra-voxel incoherent motion (IVIM) is a biophysical model that describes diffusion
-and perfusion in the signal acquired with a multi-diffusion value MRI
-acquisition [@le1986mr]. This method was originally developed to study the
-fast and slow motion of water molecules in the human brain -- an indication of brain
-microstructure, and brain health more generally. But more recently, interest in
-this model has expanded and applications have emerged throughout the body
-[@LeBihan2008] including kidneys, liver, and heart [@Powers1991, @PMID:9038058,
-@Callot2003, ]. Many more applications are now under investigation such as
-cancer imaging (prostate, liver, kidney, pancreas, etc.) [@Koh2011] and
-imaging of the human placenta [@Moore2000, @moore2000vivo]. One of its most
-common applications still remains brain mapping for neuroscience research
-[@Federau2012]. An example of this is Parkinson’s disease, where it is
-used to study aging and structural degeneration of fibre pathways in the brain
-[@CRUZ2014].
+Intra-voxel incoherent motion (IVIM) is a technique that aims to separate effects of perfusion (microcirculation of blood in the capillary network) from the effects of molecular diffusion [@le1986mr, @le1988ra] in the signal acquired with a multi-diffusion value MRI acquisition [@le1986mr]. This method was originally developed to study the perfusion and diffusion in the human brain [@le1986mr], but more recently, interest in this technique has expanded and applications have emerged throughout the body [@LeBihan2008] including kidneys, liver, and heart [@Powers1991, @PMID:9038058, @Callot2003, ]. Many more applications are now under investigation such as cancer imaging (prostate, liver, kidney, pancreas, etc.) [@Koh2011] and imaging of the human placenta [@Moore2000, @moore2000vivo]. One of its most common applications still remains brain mapping for neuroscience research
+[@Federau2012]. An example of this is Parkinson’s disease, where it is used to study aging and structural degeneration of fibre pathways in the brain [@CRUZ2014].
 
 # References

--- a/paper/joss/reconst_ivim/paper.md
+++ b/paper/joss/reconst_ivim/paper.md
@@ -1,0 +1,41 @@
+---
+title: 'Ivim: a model for diffusion and perfusion analysis of MRI'
+tags:
+  - dipy
+  - ivim
+  - diffusion
+  - perfusion
+  - intravoxel incoherent motion
+  - MRI
+  - bi-exponential fitting
+authors:
+ - name: Shahnawaz Ahmed
+   orcid: 0000-0003-1145-7279
+   affiliation: 1
+ - name: Ariel Rokem
+   orcid: 0000-0000-0000-1234
+   affiliation: 2
+ - name: Eric Peterson
+   orcid: 0000-0000-0000-1234
+   affiliation: 3
+ - name: Rafael Neto Henriques
+   orcid: 0000-0000-0000-1234
+   affiliation: 4
+affiliations:
+ - name: Birla Institute of Technology and Science Pilani
+   index: 1
+ - name: Washington e-Science Institute
+   index: 2
+ - name: SRI International
+   index: 3
+ - name: Cognition and Brain Sciences Unit (CBU)
+   index: 4
+date: 6 October 2016
+bibliography: paper.bib
+---
+
+# Summary
+
+The intra­-voxel incoherent motion (IVIM) model describes diffusion and perfusion in the signal acquired with diffusion (Le Bihan et al. 1986). MRI.​ Recently, the interest has expanded and applications have emerged throughout the body (Le Bihan 2008) including kidneys, ​liver, and even the heart (Powers, Lorenz, Holburn, Price 1991; Tsuda, Murakami, Sakurai, Harada, Kim, Takahashi, Tomoda, Narumi, Nakamura, Izumi, Tsukamoto 1997;  Callot, Bennett, Decking, Ulrich, Balaban, Wen, Han 2003). ​Many more applications are now under investigation such as imaging for cancer (prostate, liver, kidney, pancreas, etc.) (Koh, Collins, Orton 2011) and human placenta (Moore, Strachan, Tyler, Duncan, Baker, Worthington, Johnson, Gowland 2000; Moore Issa, Tokarczuk, Duncan, Boulby, Baker, Bowtell, Worthington, Johnson, Gowland 2000). ​One of its largest uses is in brain mapping​ and neuroscience research (Federau, Maeder, O'Brien, Browaeys, Meuli, Hagmann 2012) such as Parkinson’s disease (Cruz, Nie & Wang 2014) ​where it is used to study aging and ​structural degeneration of fibre pathways in the ​brain.
+
+# References

--- a/paper/joss/reconst_ivim/paper.md
+++ b/paper/joss/reconst_ivim/paper.md
@@ -45,7 +45,7 @@ this model has expanded and applications have emerged throughout the body
 [@LeBihan2008] including kidneys, liver, and heart [@Powers1991, @PMID:9038058,
 @Callot2003, ]. Many more applications are now under investigation such as
 imaging for cancer (prostate, liver, kidney, pancreas, etc.) [@Koh2011] and
-imaging of human placenta [@Moore2000, @moore2000vivo]. Still, one of its mort
+imaging of human placenta [@Moore2000, @moore2000vivo]. Still, one of its most
 common applications is in brain mapping neuroscience research
 [@Federau2012]. For example in research on Parkinson’s disease, where it is
 used to study aging and structural degeneration of fibre pathways in the brain

--- a/paper/joss/reconst_ivim/paper.md
+++ b/paper/joss/reconst_ivim/paper.md
@@ -19,7 +19,7 @@ authors:
    orcid: 0000-0002-3530-9652
    affiliation: 3
  - name: Rafael Neto Henriques
-   orcid: 0000-0000-0000-1234
+   orcid: 0000-0002-3891-8189
    affiliation: 4
 affiliations:
  - name: Birla Institute of Technology and Science Pilani
@@ -36,7 +36,7 @@ bibliography: paper.bib
 
 # Summary
 
-Intra-voxel incoherent motion (IVIM) is a technique that aims to separate effects of perfusion (microcirculation of blood in the capillary network) from the effects of molecular diffusion [@le1986mr, @le1988ra] in the signal acquired with a multi-diffusion value MRI acquisition [@le1986mr]. This method was originally developed to study the perfusion and diffusion in the human brain [@le1986mr], but more recently, interest in this technique has expanded and applications have emerged throughout the body [@LeBihan2008] including kidneys, liver, and heart [@Powers1991, @PMID:9038058, @Callot2003, ]. Many more applications are now under investigation such as cancer imaging (prostate, liver, kidney, pancreas, etc.) [@Koh2011] and imaging of the human placenta [@Moore2000, @moore2000vivo]. One of its most common applications still remains brain mapping for neuroscience research
+Intra-voxel incoherent motion (IVIM) is a technique that aims to separate effects of perfusion (microcirculation of blood in the capillary network) from the effects of molecular diffusion in MRI images acquired with a multi-diffusion weights [@le1986mr, @le1988ra]. This method was originally developed to study perfusion and diffusion in the human brain [@le1986mr], but more recently, interest in this technique has expanded and applications have emerged throughout the body [@LeBihan2008] including kidneys, liver, and heart [@Powers1991, @PMID:9038058, @Callot2003, ]. Many more applications are now under investigation such as cancer imaging (prostate, liver, kidney, pancreas, etc.) [@Koh2011] and imaging of the human placenta [@Moore2000, @moore2000vivo]. One of its most common applications still remains brain mapping for neuroscience research
 [@Federau2012]. An example of this is Parkinson’s disease, where it is used to study aging and structural degeneration of fibre pathways in the brain [@CRUZ2014].
 
 # References


### PR DESCRIPTION
As per the discussion in https://github.com/nipy/dipy/pull/1110 and guidelines given by "The Journal of Open Source Software", I have made the first draft to submit a paper for the ivim module. I think this can be done for others too. JOSS asks for a "paper.md" for publishing and you can find the draft for ivim under "dipy/paper/joss/reconst_ivim/". The idea is that for other modules, one can add new folders accordingly. (dipy/paper/joss/denoise_adaptive_soft_matching/). More details can be found at http://joss.theoj.org
