### PR TITLE
Fix 1127

### DIFF
--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -176,23 +176,23 @@ class IvimModel(ReconstModel):
             supported for Scipy version > 0.17. When using a older Scipy
             version, this function will raise an error if bounds are different
             from None. This parameter is also used to fill nan values for out
-            of bounds parameters in the `IvimFit` class using the method fill_na.
-            default : ([0., 0., 0., 0.], [np.inf, .3, 1., 1.])
+            of bounds parameters in the `IvimFit` class using the method
+            fill_na. default : ([0., 0., 0., 0.], [np.inf, .3, 1., 1.])
 
         two_stage : bool
             Argument to specify whether to perform a non-linear fitting of all
-            parameters after the linear fitting by splitting the data based on bvalues.
-            This gives more accurate parameters but takes more time. The linear fit can
-            be used to get a quick estimation of the parameters.
-            default : False
+            parameters after the linear fitting by splitting the data based on
+            bvalues. This gives more accurate parameters but takes more time.
+            The linear fit can be used to get a quick estimation of the
+            parameters. default : False
 
         tol : float, optional
             Tolerance for convergence of minimization.
             default : 1e-15
 
         x_scale : array, optional
-            Scaling for the parameters. This is passed to `least_squares` which is
-            only available for Scipy version > 0.17.
+            Scaling for the parameters. This is passed to `least_squares` which
+            is only available for Scipy version > 0.17.
             default: [1000, 0.01, 0.001, 0.0001]
 
         options : dict, optional
@@ -228,9 +228,9 @@ class IvimModel(ReconstModel):
             e_s = "Scipy versions less than 0.17 do not support "
             e_s += "bounds. Please update to Scipy 0.17 to use bounds"
             raise ValueError(e_s)
-        elif self.bounds is None :
+        elif self.bounds is None:
             self.bounds = ((0., 0., 0., 0.), (np.inf, .3, 1., 1.))
-        else :
+        else:
             self.bounds = bounds
 
     @multi_voxel_fit
@@ -243,11 +243,11 @@ class IvimModel(ReconstModel):
         1 - S0_prime/S0. Use non-linear least squares to fit D_star and f.
 
         We do a final non-linear fitting of all four parameters and select the
-        set of parameters which make sense physically. The criteria for selecting a
-        particular set of parameters is checking the pseudo-perfusion fraction.
-        If the fraction is more than `f_threshold` (default: 25%), we will
-        reject the solution obtained from non-linear least squares fitting and
-        consider only the linear fit.
+        set of parameters which make sense physically. The criteria for
+        selecting a particular set of parameters is checking the
+        pseudo-perfusion fraction. If the fraction is more than `f_threshold`
+        (default: 25%), we will reject the solution obtained from non-linear
+        least squares fitting and consider only the linear fit.
 
 
         Parameters
@@ -265,12 +265,14 @@ class IvimModel(ReconstModel):
         -------
         IvimFit object
         """
-        # Get S0_prime and D - paramters assuming a single exponential decay for
+        # Get S0_prime and D - paramters assuming a single exponential decay
         # for signals for bvals greater than `split_b_D`
         S0_prime, D = self.estimate_linear_fit(
             data, self.split_b_D, less_than=False)
-        # Get S0 and D_star_prime - paramters assuming a single exponential decay for
-        # for signals for bvals greater than `split_b_S0`.
+
+        # Get S0 and D_star_prime - paramters assuming a single exponential
+        # decay for for signals for bvals greater than `split_b_S0`.
+
         S0, D_star_prime = self.estimate_linear_fit(data, self.split_b_S0,
                                                     less_than=True)
         # Estimate f
@@ -375,9 +377,9 @@ class IvimModel(ReconstModel):
                 f, D_star = res[0]
                 return f, D_star
             except ValueError:
-                warningMsg = "x0 obtained from linear fitting is not feasibile as "
-                warningMsg += "initial guess for leastsq. Parameters are returned only "
-                warningMsg += "from the linear fit."
+                warningMsg = "x0 obtained from linear fitting is not feasibile"
+                warningMsg += " as initial guess for leastsq. Parameters are"
+                warningMsg += " returned only from the linear fit."
                 warnings.warn(warningMsg, UserWarning)
                 f, D_star = params_f_D
                 return f, D_star
@@ -395,8 +397,8 @@ class IvimModel(ReconstModel):
                 f, D_star = res.x
                 return f, D_star
             except ValueError:
-                warningMsg = "x0 obtained from linear fitting is not feasibile "
-                warningMsg += "as initial guess for leastsq while estimating "
+                warningMsg = "x0 obtained from linear fitting is not feasibile"
+                warningMsg += " as initial guess for leastsq while estimating "
                 warningMsg += "f and D_star. Using parameters from the "
                 warningMsg += "linear fit."
                 warnings.warn(warningMsg, UserWarning)

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -489,6 +489,8 @@ class IvimModel(ReconstModel):
                                     args=(self.gtab, data),
                                     x_scale=self.x_scale)
                 ivim_params = res.x
+                if np.all(np.isnan(ivim_params)):
+                    return np.array([-1, -1, -1, -1])
                 return ivim_params
             except ValueError:
                 warningMsg = "x0 is unfeasible for leastsq fitting."

--- a/dipy/reconst/ivim.py
+++ b/dipy/reconst/ivim.py
@@ -469,6 +469,8 @@ class IvimModel(ReconstModel):
                               epsfcn=epsfcn,
                               maxfev=maxfev)
                 ivim_params = res[0]
+                if np.all(np.isnan(ivim_params)):
+                    return np.array([-1, -1, -1, -1])
                 return ivim_params
             except ValueError:
                 warningMsg = "x0 is unfeasible for leastsq fitting."

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -75,17 +75,21 @@ bvecs_with_multiple_b0 = generate_bvecs(N)
 gtab_with_multiple_b0 = gradient_table(bvals_with_multiple_b0,
                                        bvecs_with_multiple_b0.T)
 
-noisy_single = np.array([4243.71728516, 4317.81298828, 4244.35693359, 4439.36816406, 4420.06201172,
-                         4152.30078125, 4114.34912109, 4104.59375, 4151.61914062, 4003.58374023,
-                         4013.68408203, 3906.39428711, 3909.06079102, 3495.27197266, 3402.57006836,
-                         3163.10180664, 2896.04003906, 2663.7253418, 2614.87695312, 2316.55371094,
-                         2267.7722168])
+noisy_single = np.array([4243.71728516, 4317.81298828, 4244.35693359,
+                         4439.36816406, 4420.06201172, 4152.30078125, 4114.34912109, 4104.59375, 4151.61914062,
+                         4003.58374023, 4013.68408203, 3906.39428711,
+                         3909.06079102, 3495.27197266, 3402.57006836,
+                         3163.10180664, 2896.04003906, 2663.7253418,
+                         2614.87695312, 2316.55371094, 2267.7722168])
 
 noisy_multi = np.zeros((2, 2, 1, len(gtab.bvals)))
 noisy_multi[0, 1, 0] = noisy_multi[
     1, 0, 0] = noisy_multi[1, 1, 0] = noisy_single
 noisy_multi[0, 0, 0] = data_single
-single_exponential = lambda S0, D, bvals: S0 * np.exp(-bvals * D)
+
+
+def single_exponential(S0, D, bvals):
+    return S0 * np.exp(-bvals * D)
 
 
 def test_single_voxel_fit():
@@ -265,8 +269,9 @@ def test_fit_object():
     assert_raises(IndexError, ivim_fit_multi.__getitem__, [-100, 0])
     assert_raises(IndexError, ivim_fit_multi.__getitem__, (1, 0, 0, 3, 4))
     # Check if the get item returns the S0 value for voxel (1,0,0)
-    assert_array_almost_equal(ivim_fit_multi.__getitem__((1, 0, 0)).model_params[0],
-                              data_multi[1, 0, 0][0])
+    assert_array_almost_equal(
+        ivim_fit_multi.__getitem__((1, 0, 0)).model_params[0],
+        data_multi[1, 0, 0][0])
 
 
 def test_shape():
@@ -384,11 +389,13 @@ def test_fit_one_stage():
     linear_fit_params = [9.88834140e+02, 1.19707191e-01, 7.91176970e-03,
                          9.30095210e-04]
 
-    linear_fit_signal = [988.83414044, 971.77122546, 955.46786293, 939.87125905, 924.93258982,
-                         896.85182201, 870.90346447, 846.81187693, 824.34108781, 803.28900104,
-                         783.48245048, 764.77297789, 747.03322866, 669.54798887, 605.03328304,
-                         549.00852235, 499.21077611, 454.40299244, 413.83192296, 376.98072773,
-                         343.45531017]
+    linear_fit_signal = [988.83414044, 971.77122546, 955.46786293,
+                         939.87125905, 924.93258982, 896.85182201,
+                         870.90346447, 846.81187693, 824.34108781,
+                         803.28900104, 783.48245048, 764.77297789,
+                         747.03322866, 669.54798887, 605.03328304,
+                         549.00852235, 499.21077611, 454.40299244,
+                         413.83192296, 376.98072773, 343.45531017]
 
     assert_array_almost_equal(fit.model_params, linear_fit_params)
     assert_array_almost_equal(fit.predict(gtab), linear_fit_signal)
@@ -396,7 +403,8 @@ def test_fit_one_stage():
 
 def test_leastsq_failing():
     """
-    Test for cases where leastsq fitting fails and the results from a linear fit is returned.
+    Test for cases where leastsq fitting fails and the results from a linear
+    fit is returned.
     """
     fit_single = ivim_model.fit(noisy_single)
     # Test for the S0 and D values
@@ -406,9 +414,9 @@ def test_leastsq_failing():
 
 def test_leastsq_error():
     """
-     Test error handling of the `_leastsq` method works when unfeasible x0 is passed.
-     If an unfeasible x0 value is passed using which leastsq fails, the x0 value is returned
-     as it is.
+    Test error handling of the `_leastsq` method works when unfeasible x0 is
+    passed. If an unfeasible x0 value is passed using which leastsq fails, the
+    x0 value is returned as it is.
     """
     fit = ivim_model._leastsq(data_single, [-1, -1, -1, -1])
     assert_array_almost_equal(fit, [-1, -1, -1, -1])

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -54,11 +54,11 @@ ivim_params[1, 0, 0] = ivim_params[1, 1, 0] = params
 
 ivim_model = IvimModel(gtab)
 ivim_model_one_stage = IvimModel(gtab)
-#ivim_fit_single = ivim_model.fit(data_single)
-#ivim_fit_multi = ivim_model.fit(data_multi)
+ivim_fit_single = ivim_model.fit(data_single)
+ivim_fit_multi = ivim_model.fit(data_multi)
 
-#ivim_fit_single_one_stage = ivim_model_one_stage.fit(data_single)
-#ivim_fit_multi_one_stage = ivim_model_one_stage.fit(data_multi)
+ivim_fit_single_one_stage = ivim_model_one_stage.fit(data_single)
+ivim_fit_multi_one_stage = ivim_model_one_stage.fit(data_multi)
 
 bvals_no_b0 = np.array([5., 10., 20., 30., 40., 60., 80., 100.,
                         120., 140., 160., 180., 200., 300., 400.,

--- a/dipy/reconst/tests/test_ivim.py
+++ b/dipy/reconst/tests/test_ivim.py
@@ -54,11 +54,11 @@ ivim_params[1, 0, 0] = ivim_params[1, 1, 0] = params
 
 ivim_model = IvimModel(gtab)
 ivim_model_one_stage = IvimModel(gtab)
-ivim_fit_single = ivim_model.fit(data_single)
-ivim_fit_multi = ivim_model.fit(data_multi)
+#ivim_fit_single = ivim_model.fit(data_single)
+#ivim_fit_multi = ivim_model.fit(data_multi)
 
-ivim_fit_single_one_stage = ivim_model_one_stage.fit(data_single)
-ivim_fit_multi_one_stage = ivim_model_one_stage.fit(data_multi)
+#ivim_fit_single_one_stage = ivim_model_one_stage.fit(data_single)
+#ivim_fit_multi_one_stage = ivim_model_one_stage.fit(data_multi)
 
 bvals_no_b0 = np.array([5., 10., 20., 30., 40., 60., 80., 100.,
                         120., 140., 160., 180., 200., 300., 400.,


### PR DESCRIPTION
This addresses #1127. It seems that scipy optimize returns nans instead of -1 on Windows, for non-converging inputs. This converts these nan results into the expected all `-1`. 

See try_branch here: http://nipy.bic.berkeley.edu/builders/dipy-bdist64-35-win2016/builds/42/steps/shell_11/logs/stdio

Fixed plenty of PEP8 violations while I was at it. 
