### PR TITLE
Update .travis.yml and README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,9 @@ python:
 matrix:
   include:
     - python: 2.7
-      env:
-        - COVERAGE=1
     # To test minimum dependencies
     - python: 2.7
       env:
-        - COVERAGE=1
         # Check these values against requirements.txt and dipy/info.py
         - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==1.2.0"
     - python: 2.7
@@ -37,16 +34,9 @@ matrix:
     - python: 2.7
       sudo: true   # This is set to true for apt-get
       env:
+        - COVERAGE=1
         - VTK=1
         - VTK_VER="python-vtk"
-        - LIBGL_ALWAYS_INDIRECT=y
-        - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
-        - TEST_WITH_XVFB=true
-    - python: 2.7
-      sudo: true   # This is set to true for apt-get
-      env:
-        - VTK=1
-        - VTK_VER="python-vtk6"
         - LIBGL_ALWAYS_INDIRECT=y
         - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
         - TEST_WITH_XVFB=true

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@
  DIPY
 ======
 
-.. image:: https://coveralls.io/repos/github/nipy/dipy/badge.svg?branch=master :target: https://coveralls.io/github/nipy/dipy?branch=master 
-
 .. image:: https://codecov.io/gh/nipy/dipy/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/nipy/dipy
 


### PR DESCRIPTION
This PR: 
- removes coveralls badge from README.md. It is currently displaying unknown and codecov seems better (see https://www.slant.co/versus/7928/7929/~coveralls_vs_codecov).
- makes sure we use COVERAGE=1 only in one Travis build. Having multiple builds with COVERAGE=1 generate several unnecessary coveralls posts in PRs. Also, currently no builds with COVERAGE=1 were running VTK tests, so the code coverage being reported wasn't accurate. 
- removes unnecessary Travis build which was supposedly testing with VTK6. However, Ubuntu 12.04 (the one use by Travis) doesn't offer the package python-vtk6 (see my comments in #759). So, that particular build was equivalent to another one that wasn't testing VTK code at all.