### PR TITLE
WIP : Multiprocessing - implemented a parallel_voxel_fit decorator 

### DIFF
--- a/dipy/multi/__init__.py
+++ b/dipy/multi/__init__.py
@@ -1,0 +1,1 @@
+# init for the parallel framework

--- a/dipy/multi/config.py
+++ b/dipy/multi/config.py
@@ -10,7 +10,7 @@ _dipy_num_cpu = 1
 manager = None
 
 
-def activate_multiprocessing(num_cpu=None):
+def activate_multithreading(num_cpu=None):
     """
     Function to activate multiprocessing.
 
@@ -30,15 +30,15 @@ def activate_multiprocessing(num_cpu=None):
         _dipy_num_cpu = num_cpu
 
     if manager is not None:
-        # manager.shut_down()
-        raise NotImplemented()
+        manager.shut_down()
+        # raise NotImplemented()
     if _dipy_num_cpu > 1:
         manager = PoolMananger(_dipy_num_cpu)
     else:
         manager = None
 
 
-def deactivate_multiprocessing():
+def deactivate_multithreading():
     """
     Function to deactivate multiprocessing.
     """

--- a/dipy/multi/config.py
+++ b/dipy/multi/config.py
@@ -1,0 +1,80 @@
+"""
+Configuration for multiprocessing
+"""
+from multiprocessing import cpu_count, Pool
+from contextlib import contextmanager
+import atexit
+
+
+_dipy_num_cpu = 1
+manager = None
+
+
+def activate_multiprocessing(num_cpu=None):
+    """
+    Function to activate multiprocessing.
+
+    Parameters
+    ----------
+    num_cpu : int
+        Number of CPU's.
+        default: None
+    """
+    global _dipy_num_cpu
+    global manager
+    if num_cpu is None:
+        _dipy_num_cpu = cpu_count()
+    elif num_cpu <= 0:
+        raise ValueError("num_cpu must be positive")
+    else:
+        _dipy_num_cpu = num_cpu
+
+    if manager is not None:
+        # manager.shut_down()
+        raise NotImplemented()
+    if _dipy_num_cpu > 1:
+        manager = PoolMananger(_dipy_num_cpu)
+    else:
+        manager = None
+
+
+def deactivate_multiprocessing():
+    """
+    Function to deactivate multiprocessing.
+    """
+    global _dipy_num_cpu
+    _dipy_num_cpu = 1
+
+
+@contextmanager
+def multithreading_on(num_cpu=None):
+    previous_state = _dipy_num_cpu
+    activate_multithreading(num_cpu)
+    try:
+        yield
+    finally:
+        activate_multithreading(previous_state)
+
+
+class PoolMananger(object):
+
+    active = False
+
+    def __init__(self, n_cpu):
+        self.n_cpu = n_cpu
+        self.pool = Pool(n_cpu)
+        self.active = True
+
+    def shut_down(self):
+        if self.active:
+            self.pool.close()
+            self.pool.join()
+            self.active = False
+            self.pool = None
+
+
+def cleanup():
+    if manager is not None:
+        manager.shut_down()
+
+atexit.register(cleanup)

--- a/dipy/multi/parallel.py
+++ b/dipy/multi/parallel.py
@@ -1,0 +1,219 @@
+"""Classes and functions to implement multiprocessing."""
+
+from __future__ import division
+
+from abc import abstractmethod
+from multiprocessing import cpu_count, Pool
+import numpy as np
+from dipy.reconst.multi_voxel import MultiVoxelFit
+from contextlib import contextmanager
+
+_dipy_num_cpu = 1
+
+
+def activate_multiprocessing(num_cpu=None):
+    """
+    Function to activate multiprocessing.
+
+    Parameters
+    ----------
+    num_cpu : int
+        Number of CPU's. 
+        default: None
+    """
+    global _dipy_num_cpu
+    if num_cpu is None:
+        _dipy_num_cpu = cpu_count()
+    elif num_cpu > 0:
+        _dipy_num_cpu = num_cpu
+
+
+def deactivate_multiprocessing():
+    """
+    Function to deactivate multiprocessing.
+    """
+    global _dipy_num_cpu
+    _dipy_num_cpu = 1
+
+
+def update_outputs(index, result, outputs):
+    for key, array in outputs.items():
+        array[index] = result[key]
+
+
+class MultiVoxelFunction(object):
+    """A function that can be applied to every voxel of a dMRI data set.
+    Subclass MultiVoxelFunction and define the _main and _default_values
+    methods to create a subclass. Both methods should return a dictionary of
+    outputs, where the keys are the names of the outputs and the values are
+    arrays.  _main will be used in voxels where mask is true, and the result
+    from _default_values will be used in voxels where mask is False.
+    """
+
+    @abstractmethod
+    def _main(self, single_voxel_data, *args, **kwargs):
+        raise NotImplementedError("Implement this method in a subclass.")
+
+    @abstractmethod
+    def _default_values(self, data, mask, *args, **kwargs):
+        raise NotImplementedError("Implement this method in a subclass.")
+
+    def _setup_outputs(self, data, mask, *args, **kwargs):
+        default_values = self._default_values(data, mask, *args, **kwargs)
+        outputs = {}
+        shape = mask.shape
+        ndim = len(shape)
+        for key, array in default_values.items():
+            out_array = np.empty(shape + array.shape, array.dtype)
+            out_array[...] = array
+            outputs[key] = out_array
+        return outputs
+
+    def _serial(self, data, mask, *args, **kwargs):
+        outputs = self._setup_outputs(data, mask, *args, **kwargs)
+        for ijk in np.ndindex(mask.shape):
+            if not mask[ijk]:
+                continue
+            vox = data[ijk]
+            result = self._main(vox, *args, **kwargs)
+            update_outputs(ijk, result, outputs)
+        return outputs
+
+    def __call__(self, data, mask, *args, **kwargs):
+        self._serial(self, data, mask, *args, **kwargs)
+
+
+class UpdateCallback(MultiVoxelFunction):
+
+    def __init__(self, index, outputs, errors):
+        self.index = index
+        self.outputs = outputs
+        self.errors = errors
+
+    def __call__(self, result):
+        update_outputs(self.index, result, self.outputs)
+        # Remove from errors to indicate successful completion and free memory.
+        self.errors.pop(repr(self.index))
+
+
+def _array_split_points(mask, num_chunks):
+    # TODO split input based on mask values so each thread gets about the same
+    # number of voxels where mask is True.
+    chunk_size = mask.size / num_chunks
+    split_points = np.arange(1, num_chunks + 1) * chunk_size
+    return np.round(split_points).astype(int)
+
+
+def call_remotely(parallel_function, *args, **kwargs):
+    return parallel_function._serial(*args, **kwargs)
+
+
+class ParallelFunction(MultiVoxelFunction):
+
+    def _parallel(self, data, mask, *args, **kwargs):
+        ndim = mask.ndim
+        shape = mask.shape
+        if data.shape[:ndim] != shape:
+            raise ValueError("mask and data shapes do not match")
+
+        # Flatten the inputs
+        data = data.reshape((-1,) + data.shape[ndim:])
+        mask = mask.ravel()
+        size = mask.size
+        outputs = self._setup_outputs(data, mask, *args, **kwargs)
+
+        num_cpu = _dipy_num_cpu
+        num_chunks = min(10 * num_cpu, mask.size)
+        end_points = _array_split_points(mask, num_chunks)
+
+        pool = Pool(num_cpu)
+        start = 0
+        errors = {}
+        for end in end_points:
+            index = slice(start, end)
+            chunk_args = (self, data[index], mask[index]) + args
+            callback = UpdateCallback(index, outputs, errors)
+            r = pool.apply_async(call_remotely, chunk_args, kwargs,
+                                 callback=callback)
+            # As of python 2.7, the async_result is the only way to track
+            # errors, in python 3 an error callback can be used.
+            errors[repr(index)] = r
+            start = end
+
+        del r
+        pool.close()
+        pool.join()
+
+        if errors:
+            index, r = errors.popitem()
+            # If errors is not empty, callbacks did not all execute, r.get()
+            # should raise an error.
+            r.get()
+            # If r.get() does not raise an error, something else went wrong.
+            msg = "Parallel function did not execute successfully."
+            raise RuntimeError(msg)
+
+        # Un-ravel the outputs
+        for key in outputs:
+            array = outputs[key]
+            outputs[key] = array.reshape(shape + array.shape[1:])
+
+        return outputs
+
+    def __call__(self, data, mask, *args, **kwargs):
+        if _dipy_num_cpu == 1:
+            return self._serial(data, mask, *args, **kwargs)
+        else:
+            return self._parallel(data, mask, *args, **kwargs)
+
+
+class ParallelFit(ParallelFunction):
+
+    def _main(self, single_voxel_data, model=None):
+        """Fit method for every voxel in data"""
+        fit = model.fit(single_voxel_data)
+        return {"fit_array": fit}
+
+    def _default_values(self, data, mask, model=None):
+        return {"fit_array": np.array(None)}
+
+
+parallel_fit = ParallelFit()
+
+
+def parallel_voxel_fit(single_voxel_fit):
+    """Wraps single_voxel_fit method to turn a model into a multi voxel model.
+    Use this decorator on the fit method of your model to take advantage of the
+    MultiVoxelFit and ParallelFit machinery of dipy.
+    Parameters:
+    -----------
+    single_voxel_fit : callable
+        Should have a signature like: model [self when a model method is being
+        wrapped], data [single voxel data].
+    Returns:
+    --------
+    multi_voxel_fit_function : callable
+    Examples:
+    ---------
+    >>> import numpy as np
+    >>> from dipy.reconst.base import ReconstModel, ReconstFit
+    >>> class Model(ReconstModel):
+    ...     @parallel_voxel_fit
+    ...     def fit(self, single_voxel_data):
+    ...         return ReconstFit(self, single_voxel_data.sum())
+    >>> model = Model(None)
+    >>> data = np.random.random((2, 3, 4, 5))
+    >>> fit = model.fit(data)
+    >>> np.allclose(fit.data, data.sum(-1))
+    True
+    """
+
+    def new_fit(model, data, mask=None):
+        if data.ndim == 1:
+            return single_voxel_fit(model, data)
+        if mask is None:
+            mask = np.ones(data.shape[:-1], bool)
+        fit = parallel_fit(data, mask, model=model)
+        return MultiVoxelFit(model, fit["fit_array"], mask)
+
+    return new_fit

--- a/dipy/multi/tests/test_parallel.py
+++ b/dipy/multi/tests/test_parallel.py
@@ -1,8 +1,8 @@
 import numpy as np
 import numpy.testing as npt
 
-from dipy.multi.parallel import (ParallelFunction, activate_multiprocessing,
-                                 deactivate_multiprocessing, parallel_voxel_fit)
+from dipy.multi.parallel import (ParallelFunction, parallel_voxel_fit)
+from dipy.multi.config import activate_multiprocessing, deactivate_multiprocessing
 from dipy.reconst.base import ReconstModel, ReconstFit
 
 

--- a/dipy/multi/tests/test_parallel.py
+++ b/dipy/multi/tests/test_parallel.py
@@ -1,0 +1,97 @@
+import numpy as np
+import numpy.testing as npt
+
+from dipy.multi.parallel import (ParallelFunction, activate_multiprocessing,
+                                 deactivate_multiprocessing, parallel_voxel_fit)
+from dipy.reconst.base import ReconstModel, ReconstFit
+
+
+class MaxCumSum(ParallelFunction):
+
+    def _main(self, data, weights=1., return_cumsum=False):
+        if data.ndim != 1:
+            raise ValueError("data must be 1d")
+        tmp = data * weights
+        cumsum = tmp.cumsum()
+        argmax = data.argmax()
+        max = data[argmax]
+        return {"argmax": argmax, "cumsum": cumsum, "max": max,
+                "flag": data[0] == 0}
+
+    def _default_values(self, data, mask, weights, return_cumsum=False):
+        res = {"argmax": np.array(-1, int),
+               "max": np.array(-999., float)}
+        if return_cumsum:
+            res["cumsum"] = np.zeros(data.shape[-1], float)
+        return res
+
+maxcumsum = MaxCumSum()
+
+
+class TestModel(ReconstModel):
+    """
+    Reconst model to test `parallel_voxel` decorator.
+    """
+    @parallel_voxel_fit
+    def fit(self, single_voxel_data):
+        return ReconstFit(self, single_voxel_data.sum())
+
+
+class BrokenFunction(ParallelFunction):
+
+    def _default_values(self, data, mask):
+        return {"out": np.zeros(data.shape[-1], float)}
+
+    def _main(self, data):
+        raise ValueError
+
+brokenfunction = BrokenFunction()
+
+
+def test_parallelFunction():
+
+    data = np.random.random((3, 4, 5)) - .5
+    mask = np.random.random((3, 4)) > .25
+    mask[0, 0] = True
+    data[0, 0, 0] = 0.
+    weights = np.random.random(5)
+    a = maxcumsum(data, mask, weights, return_cumsum=True)
+    activate_multiprocessing()
+    b = maxcumsum(data, mask, weights, return_cumsum=True)
+
+    cumsum = (data * mask[..., None] * weights).cumsum(-1)
+    max = data.max(-1)
+    argmax = data.argmax(-1)
+    max[~mask] = -999
+    argmax[~mask] = -1
+
+    npt.assert_array_almost_equal(a["cumsum"], cumsum)
+    npt.assert_array_almost_equal(a["max"], max)
+    npt.assert_array_almost_equal(a["argmax"], argmax)
+
+    for key in a.keys():
+        npt.assert_array_equal(a[key], b[key])
+
+    b = maxcumsum(data, mask, weights, return_cumsum=False)
+    assert("cumsum" not in b)
+
+
+def test_error_in_function():
+    data = np.random.random((3, 4, 5)) - .5
+    mask = np.random.random((3, 4)) > .25
+    npt.assert_raises(ValueError, brokenfunction, data, mask)
+    deactivate_multiprocessing()
+    npt.assert_raises(ValueError, brokenfunction, data, mask)
+
+
+def test_decorator():
+    """
+    Test the `parallel_voxel_fit` decorator.
+    """
+    model = TestModel(None)
+    data = np.random.random((2, 3, 4, 5))
+    fit_parallel = model.fit(data)
+    npt.assert_array_equal(fit_parallel.data, data.sum(-1))
+
+if __name__ == "__main__":
+    npt.run_module_suite

--- a/dipy/multi/tests/test_parallel.py
+++ b/dipy/multi/tests/test_parallel.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.multi.parallel import (ParallelFunction, parallel_voxel_fit)
-from dipy.multi.config import activate_multiprocessing, deactivate_multiprocessing
+from dipy.multi.config import activate_multithreading, deactivate_multithreading
 from dipy.reconst.base import ReconstModel, ReconstFit
 
 
@@ -56,9 +56,9 @@ def test_parallelFunction():
     data[0, 0, 0] = 0.
     weights = np.random.random(5)
     a = maxcumsum(data, mask, weights, return_cumsum=True)
-    activate_multiprocessing()
+    activate_multithreading()
     b = maxcumsum(data, mask, weights, return_cumsum=True)
-
+    deactivate_multithreading()
     cumsum = (data * mask[..., None] * weights).cumsum(-1)
     max = data.max(-1)
     argmax = data.argmax(-1)
@@ -80,7 +80,7 @@ def test_error_in_function():
     data = np.random.random((3, 4, 5)) - .5
     mask = np.random.random((3, 4)) > .25
     npt.assert_raises(ValueError, brokenfunction, data, mask)
-    deactivate_multiprocessing()
+    deactivate_multithreading()
     npt.assert_raises(ValueError, brokenfunction, data, mask)
 
 


### PR DESCRIPTION
This is the original work of @MrBago from his [branch](https://github.com/MrBago/dipy/tree/nf_parallel_framework/dipy/parallel). I have refactored the code a little and added a new decorator `parallel_voxel_fit` similar to the multi_voxel_fit. Both can be merged into one later.

The current implementation adopts his code in dipy/multi. The decorator `parallel_voxel_fit` can be used directly in modules such as dipy/reconst/dsi.py in the following manner (this is also a test case):

```
class TestModel(ReconstModel):
    """
    Reconst model to test `parallel_voxel_fit` decorator.
    """
    @parallel_voxel_fit
    def fit(self, single_voxel_data):
        return ReconstFit(self, single_voxel_data.sum())
```

To do:
- [ ] Discuss a better way to activate or deactivate mutiprocessing rather than setting a global _dipy_num_cpu variable. (Is it okay ?)
- [ ] Improve documenation, refactor and optimize the current code.
- [ ] Profile the performance on multicore CPU's
- [ ] Better handling of masks and splitting of voxels for fitting.
- [ ] Simplify current multi voxel models into single voxel fitting by using the decorators `parallel_voxel_fit` or `multi_voxel_fit`. (For examole in reconst/dti.py, reconst/dki.py multi voxel fitting is carried out by iterating over voxels whereas in reconst/dsi.py the mult_voxel_fit decorator is used and the fit method is written for a single voxel.)
