### PR TITLE
Update deprecated function.  

### DIFF
--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -27,7 +27,7 @@ HARDI dataset
 fetch_stanford_hardi()
 nib_stanford, gtab_stanford = read_stanford_hardi()
 static = np.squeeze(nib_stanford.get_data())[..., 0]
-static_grid2world = nib_stanford.get_affine()
+static_grid2world = nib_stanford.affine
 
 """
 Now the moving image
@@ -36,7 +36,7 @@ Now the moving image
 fetch_syn_data()
 nib_syn_t1, nib_syn_b0 = read_syn_data()
 moving = np.array(nib_syn_b0.get_data())
-moving_grid2world = nib_syn_b0.get_affine()
+moving_grid2world = nib_syn_b0.affine
 
 """
 We can see that the images are far from aligned by drawing one on top of

--- a/doc/examples/brain_extraction_dwi.py
+++ b/doc/examples/brain_extraction_dwi.py
@@ -47,8 +47,8 @@ coordinates to the world coordinates is also needed. Here, we choose to save
 both images in float32.
 """
 
-mask_img = nib.Nifti1Image(mask.astype(np.float32), img.get_affine())
-b0_img = nib.Nifti1Image(b0_mask.astype(np.float32), img.get_affine())
+mask_img = nib.Nifti1Image(mask.astype(np.float32), img.affine)
+b0_img = nib.Nifti1Image(b0_mask.astype(np.float32), img.affine)
 
 fname = 'se_1.5t'
 nib.save(mask_img, fname + '_binary_mask.nii.gz')
@@ -91,8 +91,8 @@ b0_mask_crop, mask_crop = median_otsu(data, 4, 4, autocrop=True)
 Saving cropped data using nibabel as demonstrated previously.
 """
 
-mask_img_crop = nib.Nifti1Image(mask_crop.astype(np.float32), img.get_affine())
+mask_img_crop = nib.Nifti1Image(mask_crop.astype(np.float32), img.affine)
 b0_img_crop = nib.Nifti1Image(
-    b0_mask_crop.astype(np.float32), img.get_affine())
+    b0_mask_crop.astype(np.float32), img.affine)
 nib.save(mask_img_crop, fname + '_binary_mask_crop.nii.gz')
 nib.save(b0_img_crop, fname + '_mask_crop.nii.gz')

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -23,7 +23,7 @@ fetch_sherbrooke_3shell()
 img, gtab = read_sherbrooke_3shell()
 
 data = img.get_data()
-affine = img.get_affine()
+affine = img.affine
 
 mask = data[..., 0] > 80
 

--- a/doc/examples/deterministic_fiber_tracking.py
+++ b/doc/examples/deterministic_fiber_tracking.py
@@ -31,7 +31,7 @@ from dipy.tracking.local import (ThresholdTissueClassifier, LocalTracking)
 hardi_img, gtab, labels_img = read_stanford_labels()
 data = hardi_img.get_data()
 labels = labels_img.get_data()
-affine = hardi_img.get_affine()
+affine = hardi_img.affine
 
 seed_mask = labels == 2
 white_matter = (labels == 1) | (labels == 2)

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -29,7 +29,7 @@ from dipy.data import read_stanford_labels
 hardi_img, gtab, labels_img = read_stanford_labels()
 data = hardi_img.get_data()
 labels = labels_img.get_data()
-affine = hardi_img.get_affine()
+affine = hardi_img.affine
 
 """
 This dataset provides a label map in which all white matter tissues are

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -106,7 +106,7 @@ need to transform them into this space. Otherwise, if the streamline coordinates
 were in the world space (relative to the scanner iso-center, or relative to the
 mid-point of the AC-PC-connecting line), we would use this::
 
-   inv_affine = np.linalg.inv(hardi_img.get_affine())
+   inv_affine = np.linalg.inv(hardi_img.affine)
 
 the inverse transformation from world space to the voxel space as the affine for
 the following model fit.

--- a/doc/examples/piesno.py
+++ b/doc/examples/piesno.py
@@ -80,7 +80,7 @@ plt.savefig('piesno.png', bbox_inches='tight')
    background voxels (right) used to estimate the noise standard deviation**.
 """
 
-nib.save(nib.Nifti1Image(mask, img.get_affine(), img.get_header()),
+nib.save(nib.Nifti1Image(mask, img.affine, img.header),
          'mask_piesno.nii.gz')
 
 print('The noise standard deviation is sigma= ', sigma)

--- a/doc/examples/probabilistic_fiber_tracking.py
+++ b/doc/examples/probabilistic_fiber_tracking.py
@@ -27,7 +27,7 @@ from dipy.tracking.local import (ThresholdTissueClassifier, LocalTracking)
 hardi_img, gtab, labels_img = read_stanford_labels()
 data = hardi_img.get_data()
 labels = labels_img.get_data()
-affine = hardi_img.get_affine()
+affine = hardi_img.affine
 
 seed_mask = labels == 2
 white_matter = (labels == 1) | (labels == 2)

--- a/doc/examples/quick_start.py
+++ b/doc/examples/quick_start.py
@@ -81,7 +81,7 @@ print(data.shape)
 We can also check the dimensions of each voxel in the following way:
 """
 
-print(img.get_header().get_zooms()[:3])
+print(img.header.get_zooms()[:3])
 
 """
 ``(2.0, 2.0, 2.0)``
@@ -206,7 +206,7 @@ print(S0s.shape)
 Just, for fun let's save this in a new Nifti file.
 """
 
-nib.save(nib.Nifti1Image(S0s, img.get_affine()), 'HARDI193_S0.nii.gz')
+nib.save(nib.Nifti1Image(S0s, img.affine), 'HARDI193_S0.nii.gz')
 
 """
 Now, that we learned how to load dMRI datasets we can start the analysis. 

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -94,7 +94,7 @@ img, gtab = read_cenir_multib(bvals)
 
 data = img.get_data()
 
-affine = img.get_affine()
+affine = img.affine
 
 """
 Function ``read_cenir_multib`` return img and gtab which contains respectively

--- a/doc/examples/reconst_dsi.py
+++ b/doc/examples/reconst_dsi.py
@@ -36,13 +36,13 @@ data.shape ``(96, 96, 60, 203)``
 This dataset has anisotropic voxel sizes, therefore reslicing is necessary.
 """
 
-affine = img.get_affine()
+affine = img.affine
 
 """
 Read the voxel size from the image header.
 """
 
-voxel_size = img.get_header().get_zooms()[:3]
+voxel_size = img.header.get_zooms()[:3]
 
 """
 Instantiate the Model and apply it to the data.

--- a/doc/examples/reconst_dsi_metrics.py
+++ b/doc/examples/reconst_dsi_metrics.py
@@ -31,7 +31,7 @@ Load the raw diffusion data and the affine.
 """
 
 data = img.get_data()
-affine = img.get_affine()
+affine = img.affine
 print('data.shape (%d, %d, %d, %d)' % data.shape)
 
 """

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -163,7 +163,7 @@ affine matrix which transform the image's coordinates to the world coordinates.
 Here, we choose to save the FA in float32.
 """
 
-fa_img = nib.Nifti1Image(FA.astype(np.float32), img.get_affine())
+fa_img = nib.Nifti1Image(FA.astype(np.float32), img.affine)
 nib.save(fa_img, 'tensor_fa.nii.gz')
 
 """
@@ -172,7 +172,7 @@ using matplotlib_'s imshow. In the same way you can save the eigen values, the
 eigen vectors or any other properties of the Tensor.
 """
 
-evecs_img = nib.Nifti1Image(tenfit.evecs.astype(np.float32), img.get_affine())
+evecs_img = nib.Nifti1Image(tenfit.evecs.astype(np.float32), img.affine)
 nib.save(evecs_img, 'tensor_evecs.nii.gz')
 
 """
@@ -186,7 +186,7 @@ eigen-values of the TensorFit class instance:
 """
 
 MD1 = dti.mean_diffusivity(tenfit.evals)
-nib.save(nib.Nifti1Image(MD1.astype(np.float32), img.get_affine()), 'tensors_md.nii.gz')
+nib.save(nib.Nifti1Image(MD1.astype(np.float32), img.affine), 'tensors_md.nii.gz')
 
 """
 The other is to call the TensorFit class method:
@@ -203,7 +203,7 @@ that the FA is scaled between 0 and 1, we compute the RGB map and save it.
 
 FA = np.clip(FA, 0, 1)
 RGB = color_fa(FA, tenfit.evecs)
-nib.save(nib.Nifti1Image(np.array(255 * RGB, 'uint8'), img.get_affine()), 'tensor_rgb.nii.gz')
+nib.save(nib.Nifti1Image(np.array(255 * RGB, 'uint8'), img.affine), 'tensor_rgb.nii.gz')
 
 """
 Let's try to visualize the tensor ellipsoids of a small rectangular

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -63,7 +63,7 @@ img, gtab = read_cenir_multib(bvals)
 
 data = img.get_data()
 
-affine = img.get_affine()
+affine = img.affine
 
 """
 The free water DTI model can take some minutes to process the full data set.

--- a/doc/examples/reconst_gqi.py
+++ b/doc/examples/reconst_gqi.py
@@ -39,13 +39,13 @@ data.shape ``(96, 96, 60, 203)``
 This dataset has anisotropic voxel sizes, therefore reslicing is necessary.
 """
 
-affine = img.get_affine()
+affine = img.affine
 
 """
 Read the voxel size from the image header.
 """
 
-voxel_size = img.get_header().get_zooms()[:3]
+voxel_size = img.header.get_zooms()[:3]
 
 """
 Instantiate the Model and apply it to the data.

--- a/doc/examples/reconst_shore_metrics.py
+++ b/doc/examples/reconst_shore_metrics.py
@@ -34,7 +34,7 @@ Load the raw diffusion data and the affine.
 """
 
 data = img.get_data()
-affine = img.get_affine()
+affine = img.affine
 print('data.shape (%d, %d, %d, %d)' % data.shape)
 
 """

--- a/doc/examples/reslice_datasets.py
+++ b/doc/examples/reslice_datasets.py
@@ -44,13 +44,13 @@ Load the affine of the image. The affine is the transformation matrix
 which maps image coordinates to world (mm) coordinates.
 """
 
-affine = img.get_affine()
+affine = img.affine
 
 """
 Load and show the zooms which hold the voxel size.
 """
 
-zooms = img.get_header().get_zooms()[:3]
+zooms = img.header.get_zooms()[:3]
 zooms
 
 """

--- a/doc/examples/sfm_tracking.py
+++ b/doc/examples/sfm_tracking.py
@@ -17,7 +17,7 @@ from dipy.data import read_stanford_labels
 hardi_img, gtab, labels_img = read_stanford_labels()
 data = hardi_img.get_data()
 labels = labels_img.get_data()
-affine = hardi_img.get_affine()
+affine = hardi_img.affine
 
 """
 This dataset provides a label map (generated using Freesurfer), in which the
@@ -112,7 +112,7 @@ from dipy.tracking.utils import move_streamlines
 from numpy.linalg import inv
 t1 = read_stanford_t1()
 t1_data = t1.get_data()
-t1_aff = t1.get_affine()
+t1_aff = t1.affine
 color = line_colors(streamlines)
 
 """

--- a/doc/examples/snr_in_cc.py
+++ b/doc/examples/snr_in_cc.py
@@ -42,7 +42,7 @@ from dipy.reconst.dti import TensorModel
 fetch_stanford_hardi()
 img, gtab = read_stanford_hardi()
 data = img.get_data()
-affine = img.get_affine()
+affine = img.affine
 
 print('Computing brain mask...')
 b0_mask, mask = median_otsu(data)

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -214,11 +214,11 @@ To do that, we will use tools available in [nibabel](http://nipy.org/nibabel)
 import nibabel as nib
 
 # Save density map
-dm_img = nib.Nifti1Image(dm.astype("int16"), hardi_img.get_affine())
+dm_img = nib.Nifti1Image(dm.astype("int16"), hardi_img.affine)
 dm_img.to_filename("lr-superiorfrontal-dm.nii.gz")
 
 # Make a trackvis header so we can save streamlines
-voxel_size = labels_img.get_header().get_zooms()
+voxel_size = labels_img.header.get_zooms()
 trackvis_header = nib.trackvis.empty_header()
 trackvis_header['voxel_size'] = voxel_size
 trackvis_header['dim'] = shape

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -46,9 +46,9 @@ stanford_b0_masked, stanford_b0_mask = median_otsu(stanford_b0, 4, 4)
 syn_b0_masked, syn_b0_mask = median_otsu(syn_b0, 4, 4)
 
 static = stanford_b0_masked
-static_affine = nib_stanford.get_affine()
+static_affine = nib_stanford.affine
 moving = syn_b0_masked
-moving_affine = nib_syn_b0.get_affine()
+moving_affine = nib_syn_b0.affine
 
 """
 Suppose we have already done a linear registration to roughly align the two

--- a/doc/examples/tracking_eudx_tensor.py
+++ b/doc/examples/tracking_eudx_tensor.py
@@ -81,7 +81,7 @@ TrackVis format (``*.trk``). First, we need to create a header.
 """
 
 hdr = nib.trackvis.empty_header()
-hdr['voxel_size'] = fa_img.get_header().get_zooms()[:3]
+hdr['voxel_size'] = fa_img.header.get_zooms()[:3]
 hdr['voxel_order'] = 'LAS'
 hdr['dim'] = FA.shape
 

--- a/doc/examples/tracking_quick_start.py
+++ b/doc/examples/tracking_quick_start.py
@@ -163,7 +163,7 @@ Finally, let's save the streamlines as a (.trk) file and FA as a Nifti image.
 import nibabel as nib
 
 hdr = nib.trackvis.empty_header()
-hdr['voxel_size'] = img.get_header().get_zooms()[:3]
+hdr['voxel_size'] = img.header.get_zooms()[:3]
 hdr['voxel_order'] = 'LAS'
 hdr['dim'] = FA.shape[:3]
 
@@ -173,7 +173,7 @@ csd_sl_fname = 'csd_streamline.trk'
 
 nib.trackvis.write(csd_sl_fname, csd_streamlines_trk, hdr, points_space='voxel')
 
-nib.save(nib.Nifti1Image(FA, img.get_affine()), 'FA_map.nii.gz')
+nib.save(nib.Nifti1Image(FA, img.affine), 'FA_map.nii.gz')
 
 """
 

--- a/doc/examples/tracking_tissue_classifier.py
+++ b/doc/examples/tracking_tissue_classifier.py
@@ -43,7 +43,7 @@ hardi_img, gtab, labels_img = read_stanford_labels()
 _, _, img_pve_wm = read_stanford_pve_maps()
 data = hardi_img.get_data()
 labels = labels_img.get_data()
-affine = hardi_img.get_affine()
+affine = hardi_img.affine
 white_matter = img_pve_wm.get_data()
 
 seed_mask = np.logical_and(labels == 2, white_matter == 1)

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -28,7 +28,7 @@ fname_t1 = os.path.join(os.path.expanduser('~'), '.dipy',
 
 img = nib.load(fname_t1)
 data = img.get_data()
-affine = img.get_affine()
+affine = img.affine
 
 """
 Create a Renderer object which holds all the actors which we want to visualize.


### PR DESCRIPTION
get_header() / get_affine() method is deprecated from nibabel 2.1, we use header / affine property instead
