### PR TITLE
Do not cover files related to benchmarks.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ source = dipy
 include = */dipy/*
 omit =
     */setup.py
+    */benchmarks/*


### PR DESCRIPTION
Right now, benchmarks count towards our coverage but we are not running them on Travis. I suggest we exclude them.