### PR TITLE
Slice through ODF fields 

### DIFF
--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -177,6 +177,12 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
             im_actor.input_connection(self.output)
             im_actor.SetDisplayExtent(*self.GetDisplayExtent())
             im_actor.opacity(opacity)
+            if interpolation == 'nearest':
+                im_actor.SetInterpolate(False)
+            else:
+                im_actor.SetInterpolate(True)
+            if major_version >= 6:
+                im_actor.GetMapper().BorderOn()
             return im_actor
 
     image_actor = ImageActor()
@@ -545,7 +551,7 @@ def axes(scale=(1, 1, 1), colorx=(1, 0, 0), colory=(0, 1, 0), colorz=(0, 0, 1),
 def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                norm=True, radial_scale=True, opacity=1.,
                colormap='plasma', global_cm=False):
-    """ Slice spherical fields in native or wold coordinates
+    """ Slice spherical fields in native or world coordinates
 
     Parameters
     ----------
@@ -677,6 +683,8 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
         all_faces.append(faces + k * xyz.shape[0])
         all_ms.append(m)
 
+    # from ipdb import set_trace
+    # set_trace()
     all_xyz = np.ascontiguousarray(np.concatenate(all_xyz))
     all_xyz_vtk = numpy_support.numpy_to_vtk(all_xyz, deep=True)
 

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -578,13 +578,13 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     else:
         mask = mask.astype(np.bool)
 
+    I, J, K = odfs.shape[:3]
+
     class OdfSlicerActor(vtk.vtkLODActor):
 
         def display_extent(self, x1, x2, y1, y2, z1, z2):
-
             tmp_mask = np.zeros(odfs.shape[:3], dtype=np.bool)
-            tmp_mask[x1:x2, y1:y2, z1:z2] = True
-
+            tmp_mask[x1:x2 + 1, y1:y2 + 1, z1:z2 + 1] = True
             tmp_mask = np.bitwise_and(tmp_mask, mask)
 
             self.mapper = _odf_slicer_mapper(odfs=odfs,
@@ -599,10 +599,20 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                                              global_cm=global_cm)
             self.SetMapper(self.mapper)
 
+        def display(self, x=None, y=None, z=None):
+            if x is None and y is None and z is None:
+                self.display_extent(0, I - 1, 0, J - 1,
+                                    int(np.floor(K/2)), int(np.floor(K/2)))
+            if x is not None:
+                self.display_extent(x, x, 0, J - 1, 0, K - 1)
+            if y is not None:
+                self.display_extent(0, I - 1, y, y, 0, K - 1)
+            if z is not None:
+                self.display_extent(0, I - 1, 0, J - 1, z, z)
+
     odf_actor = OdfSlicerActor()
-    I, J, K = odfs.shape[:3]
-    odf_actor.display_extent(0, I, 0, J,
-                             int(np.floor(K/2)), int(np.floor(K/2 + 1)))
+    odf_actor.display_extent(0, I - 1, 0, J - 1,
+                             int(np.floor(K/2)), int(np.floor(K/2)))
 
     return odf_actor
 

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -545,7 +545,28 @@ def axes(scale=(1, 1, 1), colorx=(1, 0, 0), colory=(0, 1, 0), colorz=(0, 0, 1),
 def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                norm=True, radial_scale=True, opacity=1.,
                colormap=None):
-    """ Slice spherical fields
+    """ Slice spherical fields in native or wold coordinates
+
+    Parameters
+    ----------
+    odfs : ndarray
+        4D array of spherical functions
+    affine : array
+        4x4 transformation array from native coordinates to world coordinates
+    mask : ndarray
+        3D mask
+    sphere : Sphere
+        a sphere
+    scale : float
+        Distance between spheres.
+    norm : bool
+        Normalize `sphere_values`.
+    radial_scale : bool
+        Scale sphere points according to odf values.
+    opacity : float
+        Takes values from 0 (fully transparent) to 1 (non-transparent)
+    colormap : None or str
+        If None then no color is used.
     """
 
     if mask is None:
@@ -637,7 +658,6 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
         from dipy.viz.fvtk import create_colormap
         cols = create_colormap(all_ms.ravel(), colormap)
         # cols = np.interp(cols, [0, 1], [0, 255]).astype('ubyte')
-
         # vtk_colors = numpy_to_vtk_colors(255 * cols)
 
         vtk_colors = numpy_support.numpy_to_vtk(

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -544,7 +544,7 @@ def axes(scale=(1, 1, 1), colorx=(1, 0, 0), colory=(0, 1, 0), colorz=(0, 0, 1),
 
 def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                norm=True, radial_scale=True, opacity=1.,
-               colormap=None, global_cm=False):
+               colormap='inferno', global_cm=False):
     """ Slice spherical fields in native or wold coordinates
 
     Parameters
@@ -564,9 +564,10 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     radial_scale : bool
         Scale sphere points according to odf values.
     opacity : float
-        Takes values from 0 (fully transparent) to 1 (non-transparent)
+        Takes values from 0 (fully transparent) to 1 (opaque)
     colormap : None or str
-        If None then no color is used.
+        If None then white color is used. Otherwise the name of colormap is
+        given. Matplotlib colormaps are also supported. Try 'inferno' :).
     global_cm : bool
         If True the colormap will be applied in all ODFs. If False
         it will be applied individually at each voxel (default False).
@@ -608,7 +609,7 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
 
 def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                        norm=True, radial_scale=True, opacity=1.,
-                       colormap=None, global_cm=False):
+                       colormap='inferno', global_cm=False):
     """ Helper function for slicing spherical fields
 
     Parameters
@@ -628,9 +629,10 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     radial_scale : bool
         Scale sphere points according to odf values.
     opacity : float
-        Takes values from 0 (fully transparent) to 1 (non-transparent)
+        Takes values from 0 (fully transparent) to 1 (opaque)
     colormap : None or str
-        If None then no color is used.
+        If None then white color is used. Otherwise the name of colormap is
+        given. Matplotlib colormaps are also supported. Try 'inferno' :).
     global_cm : bool
         If True the colormap will be applied in all ODFs. If False
         it will be applied individually at each voxel (default False).

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -658,6 +658,12 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
 
     ijk = np.ascontiguousarray(np.array(np.nonzero(mask)).T)
 
+    # from ipdb import set_trace
+    # set_trace()
+
+    if len(ijk) == 0:
+        return None
+
     if affine is not None:
         ijk = np.ascontiguousarray(apply_affine(affine, ijk))
 

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -609,7 +609,32 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
 def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                        norm=True, radial_scale=True, opacity=1.,
                        colormap=None, global_cm=False):
+    """ Helper function for slicing spherical fields
 
+    Parameters
+    ----------
+    odfs : ndarray
+        4D array of spherical functions
+    affine : array
+        4x4 transformation array from native coordinates to world coordinates
+    mask : ndarray
+        3D mask
+    sphere : Sphere
+        a sphere
+    scale : float
+        Distance between spheres.
+    norm : bool
+        Normalize `sphere_values`.
+    radial_scale : bool
+        Scale sphere points according to odf values.
+    opacity : float
+        Takes values from 0 (fully transparent) to 1 (non-transparent)
+    colormap : None or str
+        If None then no color is used.
+    global_cm : bool
+        If True the colormap will be applied in all ODFs. If False
+        it will be applied individually at each voxel (default False).
+    """
     if mask is None:
         mask = np.ones(odfs.shape[:3])
 
@@ -662,16 +687,12 @@ def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     cells.SetCells(ncells, all_faces_vtk)
 
     if colormap is not None:
-        # from dipy.viz.fvtk import create_colormap
         if global_cm:
             cols = create_colormap(all_ms.ravel(), colormap)
         else:
-            from ipdb import set_trace
-            # set_trace()
             cols = np.zeros((ijk.shape[0],) + sphere.vertices.shape,
                             dtype='f4')
             for k in range(ijk.shape[0]):
-                # set_trace()
                 tmp = create_colormap(all_ms[k].ravel(), colormap)
                 cols[k] = tmp.copy()
 

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -544,7 +544,7 @@ def axes(scale=(1, 1, 1), colorx=(1, 0, 0), colory=(0, 1, 0), colorz=(0, 0, 1),
 
 def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                norm=True, radial_scale=True, opacity=1.,
-               colormap='inferno', global_cm=False):
+               colormap='plasma', global_cm=False):
     """ Slice spherical fields in native or wold coordinates
 
     Parameters
@@ -609,7 +609,7 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
 
 def _odf_slicer_mapper(odfs, affine=None, mask=None, sphere=None, scale=2.2,
                        norm=True, radial_scale=True, opacity=1.,
-                       colormap='inferno', global_cm=False):
+                       colormap='plasma', global_cm=False):
     """ Helper function for slicing spherical fields
 
     Parameters

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -269,7 +269,7 @@ lowercase_cm_name = {'blues': 'Blues', 'accent': 'Accent'}
 def create_colormap(v, name='jet', auto=True):
     """Create colors from a specific colormap and return it
     as an array of shape (N,3) where every row gives the corresponding
-    r,g,b value. The colormaps we use are similar with those of pylab.
+    r,g,b value. The colormaps we use are similar with those of matplotlib.
 
     Parameters
     ----------
@@ -278,7 +278,8 @@ def create_colormap(v, name='jet', auto=True):
     name : str.
         Name of the colormap. Currently implemented: 'jet', 'blues',
         'accent', 'bone' and matplotlib colormaps if you have matplotlib
-        installed.
+        installed. For example, we suggest using 'viridis' or 'inferno'. 'jet'
+        is popular but can be often misleading.
     auto : bool,
         if auto is True then v is interpolated to [0, 10] from v.min()
         to v.max()
@@ -286,8 +287,7 @@ def create_colormap(v, name='jet', auto=True):
     Notes
     -----
     Dipy supports a few colormaps for those who do not use Matplotlib, for
-    more colormaps consider downloading Matplotlib.
-
+    more colormaps consider downloading Matplotlib (see matplotlib.org).
     """
 
     if v.ndim > 1:
@@ -304,7 +304,7 @@ def create_colormap(v, name='jet', auto=True):
 
     colormap = get_cmap(newname)
     if colormap is None:
-        e_s = "Colormap '%s' is not yet implemented " % name
+        e_s = "Colormap {} is not yet implemented ".format(name)
         raise ValueError(e_s)
 
     rgba = colormap(v)

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -291,11 +291,11 @@ def create_colormap(v, name='jet', auto=True):
     more colormaps consider downloading Matplotlib (see matplotlib.org).
     """
 
-    if name == 'jet':
-        msg = 'Jet is a popular colormap but can often be misleading and'
-        msg += 'we will remove it from being the default in the near future.'
-        msg += 'Try for example plasma, viridis, hot or inferno.'
-        print(msg)
+    # if name == 'jet':
+    #     msg = 'Jet is a popular colormap but can often be misleading and'
+    #     msg += 'we will remove it from being the default in the near future.'
+    #     msg += 'Try for example plasma, viridis, hot or inferno.'
+    #     print(msg)
 
     if v.ndim > 1:
         msg = 'This function works only with 1d arrays. Use ravel()'

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -11,6 +11,7 @@ if have_matplotlib:
     get_cmap = cm.get_cmap
 else:
     from dipy.data import get_cmap
+from warnings import warn
 
 
 def colormap_lookup_table(scale_range=(0, 1), hue_range=(0.8, 0),
@@ -291,11 +292,11 @@ def create_colormap(v, name='jet', auto=True):
     more colormaps consider downloading Matplotlib (see matplotlib.org).
     """
 
-    # if name == 'jet':
-    #     msg = 'Jet is a popular colormap but can often be misleading and'
-    #     msg += 'we will remove it from being the default in the near future.'
-    #     msg += 'Try for example plasma, viridis, hot or inferno.'
-    #     print(msg)
+    if name == 'jet':
+        msg = 'Jet is a popular colormap but can often be misleading and'
+        msg += 'we will remove it from being the default in the near future.'
+        msg += 'Try for example plasma, viridis, hot or inferno.'
+        warn(DeprecationWarning(msg))
 
     if v.ndim > 1:
         msg = 'This function works only with 1d arrays. Use ravel()'

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -293,10 +293,9 @@ def create_colormap(v, name='jet', auto=True):
     """
 
     if name == 'jet':
-        msg = 'Jet is a popular colormap but can often be misleading and'
-        msg += 'we will remove it from being the default in the near future.'
-        msg += 'Try for example plasma, viridis, hot or inferno.'
-        warn(DeprecationWarning(msg))
+        msg = 'Jet is a popular colormap but can often be misleading'
+        msg += 'Use instead plasma, viridis, hot or inferno.'
+        warn(msg, DeprecationWarning)
 
     if v.ndim > 1:
         msg = 'This function works only with 1d arrays. Use ravel()'

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -278,8 +278,9 @@ def create_colormap(v, name='jet', auto=True):
     name : str.
         Name of the colormap. Currently implemented: 'jet', 'blues',
         'accent', 'bone' and matplotlib colormaps if you have matplotlib
-        installed. For example, we suggest using 'viridis' or 'inferno'. 'jet'
-        is popular but can be often misleading.
+        installed. For example, we suggest using 'plasma', 'viridis' or
+        'inferno'. 'jet' is popular but can be often misleading and we will
+        deprecate it the future.
     auto : bool,
         if auto is True then v is interpolated to [0, 10] from v.min()
         to v.max()
@@ -289,6 +290,12 @@ def create_colormap(v, name='jet', auto=True):
     Dipy supports a few colormaps for those who do not use Matplotlib, for
     more colormaps consider downloading Matplotlib (see matplotlib.org).
     """
+
+    if name == 'jet':
+        msg = 'Jet is a popular colormap but can often be misleading and'
+        msg += 'we will remove it from being the default in the near future.'
+        msg += 'Try for example plasma, viridis, hot or inferno.'
+        print(msg)
 
     if v.ndim > 1:
         msg = 'This function works only with 1d arrays. Use ravel()'

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -5,6 +5,12 @@ from dipy.utils.optpkg import optional_package
 
 # Allow import, but disable doctests if we don't have vtk
 vtk, have_vtk, setup_module = optional_package('vtk')
+cm, have_matplotlib, _ = optional_package('matplotlib.cm')
+
+if have_matplotlib:
+    get_cmap = cm.get_cmap
+else:
+    from dipy.data import get_cmap
 
 
 def colormap_lookup_table(scale_range=(0, 1), hue_range=(0.8, 0),
@@ -255,3 +261,52 @@ def line_colors(streamlines, cmap='rgb_standard'):
                     for streamline in streamlines]
 
     return np.vstack(col_list)
+
+
+lowercase_cm_name = {'blues': 'Blues', 'accent': 'Accent'}
+
+
+def create_colormap(v, name='jet', auto=True):
+    """Create colors from a specific colormap and return it
+    as an array of shape (N,3) where every row gives the corresponding
+    r,g,b value. The colormaps we use are similar with those of pylab.
+
+    Parameters
+    ----------
+    v : (N,) array
+        vector of values to be mapped in RGB colors according to colormap
+    name : str.
+        Name of the colormap. Currently implemented: 'jet', 'blues',
+        'accent', 'bone' and matplotlib colormaps if you have matplotlib
+        installed.
+    auto : bool,
+        if auto is True then v is interpolated to [0, 10] from v.min()
+        to v.max()
+
+    Notes
+    -----
+    Dipy supports a few colormaps for those who do not use Matplotlib, for
+    more colormaps consider downloading Matplotlib.
+
+    """
+
+    if v.ndim > 1:
+        msg = 'This function works only with 1d arrays. Use ravel()'
+        raise ValueError(msg)
+
+    if auto:
+        v = np.interp(v, [v.min(), v.max()], [0, 1])
+    else:
+        v = np.clip(v, 0, 1)
+
+    # For backwards compatibility with lowercase names
+    newname = lowercase_cm_name.get(name) or name
+
+    colormap = get_cmap(newname)
+    if colormap is None:
+        e_s = "Colormap '%s' is not yet implemented " % name
+        raise ValueError(e_s)
+
+    rgba = colormap(v)
+    rgb = rgba[:, :3].copy()
+    return rgb

--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -1,4 +1,4 @@
-''' Fvtk module implements simple visualization functions using VTK.
+""" Fvtk module implements simple visualization functions using VTK.
 
 The main idea is the following:
 A window can have one or more renderers. A renderer can have none,
@@ -16,7 +16,7 @@ Examples
 
 For more information on VTK there many neat examples in
 http://www.vtk.org/Wiki/VTK/Tutorials/External_Tutorials
-'''
+"""
 from __future__ import division, print_function, absolute_import
 from warnings import warn
 
@@ -39,6 +39,8 @@ if have_matplotlib:
     get_cmap = cm.get_cmap
 else:
     from dipy.data import get_cmap
+
+from dipy.viz.colormap import create_colormap
 
 # a track buffer used only with picking tracks
 track_buffer = []
@@ -685,55 +687,6 @@ def contour(vol, voxsz=(1.0, 1.0, 1.0), affine=None, levels=[50],
         del skinExtractor
 
     return ass
-
-
-lowercase_cm_name = {'blues': 'Blues', 'accent': 'Accent'}
-
-
-def create_colormap(v, name='jet', auto=True):
-    """Create colors from a specific colormap and return it
-    as an array of shape (N,3) where every row gives the corresponding
-    r,g,b value. The colormaps we use are similar with those of pylab.
-
-    Parameters
-    ----------
-    v : (N,) array
-        vector of values to be mapped in RGB colors according to colormap
-    name : str.
-        Name of the colormap. Currently implemented: 'jet', 'blues',
-        'accent', 'bone' and matplotlib colormaps if you have matplotlib
-        installed.
-    auto : bool,
-        if auto is True then v is interpolated to [0, 10] from v.min()
-        to v.max()
-
-    Notes
-    -----
-    Dipy supports a few colormaps for those who do not use Matplotlib, for
-    more colormaps consider downloading Matplotlib.
-
-    """
-
-    if v.ndim > 1:
-        msg = 'This function works only with 1d arrays. Use ravel()'
-        raise ValueError(msg)
-
-    if auto:
-        v = np.interp(v, [v.min(), v.max()], [0, 1])
-    else:
-        v = np.clip(v, 0, 1)
-
-    # For backwards compatibility with lowercase names
-    newname = lowercase_cm_name.get(name) or name
-
-    colormap = get_cmap(newname)
-    if colormap is None:
-        e_s = "Colormap '%s' is not yet implemented " % name
-        raise ValueError(e_s)
-
-    rgba = colormap(v)
-    rgb = rgba[:, :3].copy()
-    return rgb
 
 
 def _makeNd(array, ndim):

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -279,7 +279,7 @@ def test_bundle_maps():
 
 @npt.dec.skipif(not run_test)
 @xvfb_it
-def test_odf_slicer():
+def test_odf_slicer(interactive=False):
 
     sphere = get_sphere('symmetric362')
 
@@ -346,6 +346,44 @@ def test_odf_slicer():
         arr = window.snapshot(renderer)
         report = window.analyze_snapshot(arr, find_objects=True)
         npt.assert_equal(report.objects, 2)
+
+        renderer.clear()
+        renderer.add(odf_actor)
+        renderer.add(fa_actor)
+        odfs[:, :, :] = 1
+        mask = np.ones(odfs.shape[:3])
+        odf_actor = actor.odf_slicer(odfs, None, mask=mask,
+                                     sphere=sphere, scale=.25,
+                                     colormap='plasma',
+                                     norm=False, global_cm=True)
+
+        renderer.clear()
+        renderer.add(odf_actor)
+        renderer.add(fa_actor)
+        renderer.add(actor.axes((11, 11, 11)))
+        for i in range(11):
+            odf_actor.display(i, None, None)
+            fa_actor.display(i, None, None)
+            if interactive:
+                window.show(renderer)
+        for j in range(11):
+            odf_actor.display(None, j, None)
+            fa_actor.display(None, j, None)
+            if interactive:
+                window.show(renderer)
+        # with mask equal to zero everything should be black
+        mask = np.zeros(odfs.shape[:3])
+        odf_actor = actor.odf_slicer(odfs, None, mask=mask,
+                                     sphere=sphere, scale=.25,
+                                     colormap='plasma',
+                                     norm=False, global_cm=True)
+        renderer.clear()
+        renderer.add(odf_actor)
+        arr = window.snapshot(renderer)
+        report = window.analyze_snapshot(arr, colors=(0, 0, 0),
+                                         find_objects=True)
+        npt.assert_equal(report.objects, 0)
+        npt.assert_equal(report.colors_found[0], True)
 
 
 if __name__ == "__main__":

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -290,7 +290,6 @@ def test_odf_slicer():
         odfs = np.memmap(fname, dtype='float64', mode='w+',
                          shape=shape)
         odfs[:] = 1
-        # odfs = np.random.rand(10, 10, 10, sphere.vertices.shape[0])
 
         affine = np.eye(4)
         renderer = window.renderer()
@@ -304,7 +303,7 @@ def test_odf_slicer():
                                      mask=mask, sphere=sphere, scale=.25,
                                      colormap='jet')
 
-        fa = 0. * np.random.rand(*odfs.shape[:3])
+        fa = 0. * np.zeros(odfs.shape[:3])
         fa[:, 0, :] = 1.
         fa[:, -1, :] = 1.
         fa[0, :, :] = 1.
@@ -313,8 +312,6 @@ def test_odf_slicer():
 
         fa_actor = actor.slicer(fa, affine)
         fa_actor.display(None, None, 5)
-
-        # renderer.add(fa_actor)
         renderer.add(odf_actor)
         renderer.reset_camera()
         renderer.reset_clipping_range()
@@ -328,6 +325,27 @@ def test_odf_slicer():
         arr = window.snapshot(renderer)
         report = window.analyze_snapshot(arr, find_objects=True)
         npt.assert_equal(report.objects, 11 * 11)
+        renderer.clear()
+        renderer.add(fa_actor)
+        arr = window.snapshot(renderer)
+        report = window.analyze_snapshot(arr, find_objects=True)
+        npt.assert_equal(report.objects, 2)
+
+        mask[:] = 0
+        mask[5, 5, 5] = 1
+        fa[5, 5, 5] = 0
+        fa_actor = actor.slicer(fa, None)
+        fa_actor.display(None, None, 5)
+        odf_actor = actor.odf_slicer(odfs, None, mask=mask,
+                                     sphere=sphere, scale=.25,
+                                     colormap='jet',
+                                     norm=False, global_cm=True)
+        renderer.clear()
+        renderer.add(fa_actor)
+        renderer.add(odf_actor)
+        arr = window.snapshot(renderer)
+        report = window.analyze_snapshot(arr, find_objects=True)
+        npt.assert_equal(report.objects, 2)
 
 
 if __name__ == "__main__":

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -277,9 +277,8 @@ def test_bundle_maps():
     actor.line(bundle, colors=colors)
 
 
-@npt.dec.skipif(not actor.have_vtk)
-@npt.dec.skipif(not actor.have_vtk_colors)
-@npt.dec.skipif(not window.have_imread)
+@npt.dec.skipif(not run_test)
+@xvfb_it
 def test_odf_slicer():
 
     sphere = get_sphere('symmetric362')
@@ -289,49 +288,51 @@ def test_odf_slicer():
 
     shape = (11, 11, 11, sphere.vertices.shape[0])
 
-    odfs = np.memmap('test.mmap', dtype='float64', mode='w+',
-                     shape=shape)
+    with TemporaryDirectory() as tmpdir:
+        print(tmpdir)
+        fname = os.path.join(tmpdir, 'odf_slicer.mmap')
+        odfs = np.memmap(fname, dtype='float64', mode='w+',
+                         shape=shape)
 
-    odfs[:] = 1
-    # odfs = np.random.rand(10, 10, 10, sphere.vertices.shape[0])
+        odfs[:] = 1
+        # odfs = np.random.rand(10, 10, 10, sphere.vertices.shape[0])
 
-    affine = np.eye(4)
-    renderer = window.renderer()
+        affine = np.eye(4)
+        renderer = window.renderer()
 
-    mask = np.ones(odfs.shape[:3])
-    mask[:4, :4, :4] = 0
+        mask = np.ones(odfs.shape[:3])
+        mask[:4, :4, :4] = 0
 
-    odfs[..., 0] = 1
+        odfs[..., 0] = 1
 
-    odf_actor = actor.odf_slicer(odfs, affine,
-                                 mask=mask, sphere=sphere, scale=.25,
-                                 colormap='jet')
+        odf_actor = actor.odf_slicer(odfs, affine,
+                                     mask=mask, sphere=sphere, scale=.25,
+                                     colormap='jet')
 
-    fa = 0. * np.random.rand(*odfs.shape[:3])
-    fa[:, 0, :] = 1.
-    fa[:, -1, :] = 1.
-    fa[0, :, :] = 1.
-    fa[-1, :, :] = 1.
-    fa[5, 5, 5] = 1
+        fa = 0. * np.random.rand(*odfs.shape[:3])
+        fa[:, 0, :] = 1.
+        fa[:, -1, :] = 1.
+        fa[0, :, :] = 1.
+        fa[-1, :, :] = 1.
+        fa[5, 5, 5] = 1
 
-    fa_actor = actor.slicer(fa, affine)
-    fa_actor.display(None, None, 5)
+        fa_actor = actor.slicer(fa, affine)
+        fa_actor.display(None, None, 5)
 
-    # renderer.add(fa_actor)
-    renderer.add(odf_actor)
-    renderer.reset_camera()
-    renderer.reset_clipping_range()
+        # renderer.add(fa_actor)
+        renderer.add(odf_actor)
+        renderer.reset_camera()
+        renderer.reset_clipping_range()
 
-    # for k in range(0, 5):
-    k = 5
-    I, J, K = odfs.shape[:3]
+        k = 5
+        I, J, K = odfs.shape[:3]
 
-    odf_actor.display_extent(0, I, 0, J, k, k + 1)
-    odf_actor.GetProperty().SetOpacity(1.0)
-    # window.show(renderer, reset_camera=False)
-    arr = window.snapshot(renderer)
-    report = window.analyze_snapshot(arr, find_objects=True)
-    npt.assert_equal(report.objects, 11 * 11)
+        odf_actor.display_extent(0, I, 0, J, k, k + 1)
+        odf_actor.GetProperty().SetOpacity(1.0)
+        # window.show(renderer, reset_camera=False)
+        arr = window.snapshot(renderer)
+        report = window.analyze_snapshot(arr, find_objects=True)
+        npt.assert_equal(report.objects, 11 * 11)
 
 
 if __name__ == "__main__":

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -387,5 +387,4 @@ def test_odf_slicer(interactive=False):
 
 
 if __name__ == "__main__":
-    test_odf_slicer()
-    #npt.run_module_suite()
+    npt.run_module_suite()

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -310,16 +310,16 @@ def test_odf_slicer():
         fa[-1, :, :] = 1.
         fa[5, 5, 5] = 1
 
+        k = 5
+        I, J, K = odfs.shape[:3]
+
         fa_actor = actor.slicer(fa, affine)
-        fa_actor.display(None, None, 5)
+        fa_actor.display_extent(0, I, 0, J, k, k)
         renderer.add(odf_actor)
         renderer.reset_camera()
         renderer.reset_clipping_range()
 
-        k = 5
-        I, J, K = odfs.shape[:3]
-
-        odf_actor.display_extent(0, I, 0, J, k, k + 1)
+        odf_actor.display_extent(0, I, 0, J, k, k)
         odf_actor.GetProperty().SetOpacity(1.0)
         # window.show(renderer, reset_camera=False)
         arr = window.snapshot(renderer)

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -301,7 +301,7 @@ def test_odf_slicer():
     mask = np.ones(odfs.shape[:3])
     mask[:4, :4, :4] = 0
 
-    odfs[..., 0] = 2
+    odfs[..., 0] = 1
 
     odf_actor = actor.odf_slicer(odfs, affine,
                                  mask=mask, sphere=sphere, scale=.25,
@@ -317,7 +317,7 @@ def test_odf_slicer():
     fa_actor = actor.slicer(fa, affine)
     fa_actor.display(None, None, 5)
 
-    renderer.add(fa_actor)
+    # renderer.add(fa_actor)
     renderer.add(odf_actor)
     renderer.reset_camera()
     renderer.reset_clipping_range()
@@ -327,8 +327,11 @@ def test_odf_slicer():
     I, J, K = odfs.shape[:3]
 
     odf_actor.display_extent(0, I, 0, J, k, k + 1)
-    odf_actor.GetProperty().SetOpacity(0.6)
+    odf_actor.GetProperty().SetOpacity(1.0)
     # window.show(renderer, reset_camera=False)
+    arr = window.snapshot(renderer)
+    report = window.analyze_snapshot(arr, find_objects=True)
+    npt.assert_equal(report.objects, 11 * 11)
 
 
 if __name__ == "__main__":

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -301,6 +301,8 @@ def test_odf_slicer():
     mask = np.ones(odfs.shape[:3])
     mask[:4, :4, :4] = 0
 
+    odfs[..., 0] = 2
+
     odf_actor = actor.odf_slicer(odfs, affine,
                                  mask=mask, sphere=sphere, scale=.25,
                                  colormap='jet')
@@ -320,13 +322,13 @@ def test_odf_slicer():
     renderer.reset_camera()
     renderer.reset_clipping_range()
 
-    #for k in range(0, 5):
+    # for k in range(0, 5):
     k = 5
     I, J, K = odfs.shape[:3]
 
     odf_actor.display_extent(0, I, 0, J, k, k + 1)
     odf_actor.GetProperty().SetOpacity(0.6)
-    window.show(renderer, reset_camera=False)
+    # window.show(renderer, reset_camera=False)
 
 
 if __name__ == "__main__":

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -283,17 +283,12 @@ def test_odf_slicer():
 
     sphere = get_sphere('symmetric362')
 
-    # use memory maps
-    # odfs = np.ones((10, 10, 10, sphere.vertices.shape[0]))
-
     shape = (11, 11, 11, sphere.vertices.shape[0])
 
     with TemporaryDirectory() as tmpdir:
-        print(tmpdir)
         fname = os.path.join(tmpdir, 'odf_slicer.mmap')
         odfs = np.memmap(fname, dtype='float64', mode='w+',
                          shape=shape)
-
         odfs[:] = 1
         # odfs = np.random.rand(10, 10, 10, sphere.vertices.shape[0])
 

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -354,7 +354,7 @@ def test_odf_slicer(interactive=False):
         mask = np.ones(odfs.shape[:3])
         odf_actor = actor.odf_slicer(odfs, None, mask=mask,
                                      sphere=sphere, scale=.25,
-                                     colormap='plasma',
+                                     colormap='jet',
                                      norm=False, global_cm=True)
 
         renderer.clear()
@@ -387,5 +387,5 @@ def test_odf_slicer(interactive=False):
 
 
 if __name__ == "__main__":
-
-    npt.run_module_suite()
+    test_odf_slicer()
+    #npt.run_module_suite()

--- a/dipy/viz/tests/test_fvtk_actors.py
+++ b/dipy/viz/tests/test_fvtk_actors.py
@@ -327,6 +327,8 @@ def test_odf_slicer(interactive=False):
         npt.assert_equal(report.objects, 11 * 11)
         renderer.clear()
         renderer.add(fa_actor)
+        renderer.reset_camera()
+        # window.show(renderer)
         arr = window.snapshot(renderer)
         report = window.analyze_snapshot(arr, find_objects=True)
         npt.assert_equal(report.objects, 2)

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -186,13 +186,10 @@ csd_odf = csd_fit.odf(sphere)
 Here we visualize only a 30x30 region.
 """
 
-# fodf_spheres = fvtk.sphere_funcs(csd_odf, sphere, scale=1.3, norm=False)
-from dipy.viz.actor import odf_slicer
-fodf_spheres = odf_slicer(csd_odf, sphere=sphere, scale=1.3, norm=False,
-                          colormap='jet', global_cm=False)
+fodf_spheres = fvtk.sphere_funcs(csd_odf, sphere, scale=1.3, norm=False)
+
 fvtk.add(ren, fodf_spheres)
 
-fvtk.show(ren)
 print('Saving illustration as csd_odfs.png')
 fvtk.record(ren, out_path='csd_odfs.png', size=(600, 600))
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -186,10 +186,13 @@ csd_odf = csd_fit.odf(sphere)
 Here we visualize only a 30x30 region.
 """
 
-fodf_spheres = fvtk.sphere_funcs(csd_odf, sphere, scale=1.3, norm=False)
-
+# fodf_spheres = fvtk.sphere_funcs(csd_odf, sphere, scale=1.3, norm=False)
+from dipy.viz.actor import odf_slicer
+fodf_spheres = odf_slicer(csd_odf, sphere=sphere, scale=1.3, norm=False,
+                          colormap='jet', global_cm=False)
 fvtk.add(ren, fodf_spheres)
 
+fvtk.show(ren)
 print('Saving illustration as csd_odfs.png')
 fvtk.record(ren, out_path='csd_odfs.png', size=(600, 600))
 


### PR DESCRIPTION
This PR introduces a new viz.actor (odf_slicer) that allows to slice ODF fields in native or world coordinates  matching the underlying anatomy. So, it works nicely with the viz.actor.slicer.

Some of the new features include applying a colormap using all the voxels in the slice or volume. 
![jet_odfs](https://cloud.githubusercontent.com/assets/134276/19972774/7e15bc08-a1b9-11e6-9e04-034766f3944f.png)

Also all the previous capabilities found in sphere_func are available too. Finally, the new function works with memory mapped ODFs and masking which helps reduce memory and video memory usage. I prefer to wait for the UI elements PR (https://github.com/nipy/dipy/pull/1140)  for creating a tutorial for this function.  With the new UI elements we can nicely upgrade some of our reconstruction and viz tutorials. But in the meantime you can review this PR with the tests.