### PR TITLE
Line-based version of streamline_mapping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ for modulename, other_sources, language in (
     ('dipy.tracking.local.direction_getter', [], 'c'),
     ('dipy.tracking.local.tissue_classifier', [], 'c'),
     ('dipy.tracking.local.interpolation', [], 'c'),
-    ('dipy.tracking.vox2track', [], 'c'),
+    ('dipy.tracking.vox2track', [], 'c++'),
     ('dipy.tracking.propspeed', [], 'c'),
     ('dipy.tracking.fbcmeasures', [], 'c'),
     ('dipy.segment.cythonutils', [], 'c'),


### PR DESCRIPTION
I refactored the already existing line-based functions (`_streamlines_in_mask()`, `_streamline_in_mask()`) to re-use Bresenham's algorithm. This made it possible to add a line-based version of `streamline_mapping()` without too much trouble.

I'm not totally satisfied with the code because
- there's a little code copy
- `_streamline_info` is used with 2 differents goals. (useless parameters and return)
- It's somewhat slow. I don't see how I could be faster than `streamline_mapping` though because I do what it's doing + more stuff + with bigger data because we found more positions and more index.

I added a toy test AND tested with our reporting program which shows intersecting fibers. We had a lot of missing streamlines using `streamline_mapping()` on compressed fibers. The libe-based version fixes our problem perfectly; I obtain the same results as when I test all streamlines.