### PR TITLE
Define fmin() for Visual Studio

### DIFF
--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -4,7 +4,9 @@ implemented in cython.
 """
 import cython
 
-from libc.math cimport ceil, fmin, floor, fabs, sqrt
+cdef extern from "dpy_math.h" nogil:
+    double fmin(double x, double y)
+from libc.math cimport ceil, floor, fabs, sqrt
 
 import numpy as np
 cimport numpy as cnp

--- a/src/dpy_math.h
+++ b/src/dpy_math.h
@@ -18,6 +18,10 @@ double dpy_log2(double x)
 #endif
 }
 
+#if (defined(WIN32) || defined(_WIN64)) && !defined(__GNUC__)
+#define fmin min
+#endif
+
 #define dpy_floor(x) floor((double)(x))
 
 double dpy_rint(double x)


### PR DESCRIPTION
Should fix issue #1138.

As @matthew-brett wrote, `fmin()` is not defined in the "old" versions of Visual Studio.
I defined it in `dpy_math.h`, used it in `vox2track.pyx` and ran `setup.py bdist_wheel` on Windows and Linux Mint to test the broken builds. Seem good.