### PR TITLE
Replace `get_affine` with `affine` and `get_header` with `header`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - python: 2.7
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==1.2.0"
+        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==2.0"
     - python: 2.7
       env:
         - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt scikit_learn tables"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - python: 2.7
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==2.0"
+        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==2.0.1"
     - python: 2.7
       env:
         - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt scikit_learn tables"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - python: 2.7
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==2.0.1"
+        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==2.1.0"
     - python: 2.7
       env:
         - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt scikit_learn tables"

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -93,7 +93,7 @@ def get_direction_and_spacings(affine, dim):
     affine4x4[:dim, :dim] = affine[:dim, :dim]
     affine4x4[:dim, 3] = affine[:dim, dim-1]
     nib_nifti = nib.Nifti1Image(empty_volume, affine4x4)
-    scalings = np.asarray(nib_nifti.get_header().get_zooms())
+    scalings = np.asarray(nib_nifti.header.get_zooms())
     scalings = np.asarray(scalings[:dim], dtype=np.float64)
     A = affine[:dim, :dim]
     return A.dot(np.diag(1.0/scalings)), scalings

--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -55,8 +55,8 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     >>> data = img.get_data()
     >>> data.shape == (58, 58, 24)
     True
-    >>> affine = img.get_affine()
-    >>> zooms = img.get_header().get_zooms()[:3]
+    >>> affine = img.affine
+    >>> zooms = img.header.get_zooms()[:3]
     >>> zooms
     (4.0, 4.0, 5.0)
     >>> new_zooms = (3.,3.,3.)

--- a/dipy/align/tests/test_reslice.py
+++ b/dipy/align/tests/test_reslice.py
@@ -13,15 +13,15 @@ def test_resample():
     fimg, _, _ = get_data("small_25")
     img = nib.load(fimg)
     data = img.get_data()
-    affine = img.get_affine()
-    zooms = img.get_header().get_zooms()[:3]
+    affine = img.affine
+    zooms = img.header.get_zooms()[:3]
 
     # test that new zooms are correctly from the affine (check with 3D volume)
     new_zooms = (1, 1.2, 2.1)
     data2, affine2 = reslice(data[..., 0], affine, zooms, new_zooms, order=1,
                              mode='constant')
     img2 = nib.Nifti1Image(data2, affine2)
-    new_zooms_confirmed = img2.get_header().get_zooms()[:3]
+    new_zooms_confirmed = img2.header.get_zooms()[:3]
     assert_almost_equal(new_zooms, new_zooms_confirmed)
 
     # test that shape changes correctly for the first 3 dimensions (check 4D)

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -778,7 +778,7 @@ def read_cenir_multib(bvals=None):
         bvec_list.append(np.loadtxt(file_dict[bval]['bvecs']))
 
     # All affines are the same, so grab the last one:
-    aff = nib.load(file_dict[bval]['DWI']).get_affine()
+    aff = nib.load(file_dict[bval]['DWI']).affine
     return (nib.Nifti1Image(np.concatenate(data, -1), aff),
             gradient_table(bval_list, np.concatenate(bvec_list, -1)))
 
@@ -863,13 +863,13 @@ def read_bundles_2_subjects(subj_id='subj_1', metrics=['fa'],
     if 't1' in metrics:
         img = nib.load(pjoin(dname, subj_id, 't1_warped.nii.gz'))
         data = img.get_data()
-        affine = img.get_affine()
+        affine = img.affine
         res['t1'] = data
 
     if 'fa' in metrics:
         img_fa = nib.load(pjoin(dname, subj_id, 'fa_1x1x1.nii.gz'))
         fa = img_fa.get_data()
-        affine = img_fa.get_affine()
+        affine = img_fa.affine
         res['fa'] = fa
 
     res['affine'] = affine

--- a/dipy/external/fsl.py
+++ b/dipy/external/fsl.py
@@ -128,14 +128,14 @@ def flirt2aff(mat, in_img, ref_img):
     ``ref_x_flip`` is the matrix above with ``N_i`` given by the reference
     image first axis length.
     """
-    in_hdr = in_img.get_header()
-    ref_hdr = ref_img.get_header()
+    in_hdr = in_img.header
+    ref_hdr = ref_img.header
     # get_zooms gets the positive voxel sizes as returned in the header
     inspace = np.diag(in_hdr.get_zooms() + (1,))
     refspace = np.diag(ref_hdr.get_zooms() + (1,))
-    if npl.det(in_img.get_affine()) >= 0:
+    if npl.det(in_img.affine) >= 0:
         inspace = np.dot(inspace, _x_flipper(in_hdr.get_data_shape()[0]))
-    if npl.det(ref_img.get_affine()) >= 0:
+    if npl.det(ref_img.affine) >= 0:
         refspace = np.dot(refspace, _x_flipper(ref_hdr.get_data_shape()[0]))
     # Return voxel to voxel mapping
     return np.dot(npl.inv(refspace), np.dot(mat, inspace))
@@ -184,11 +184,11 @@ def warp_displacements(ffa, flaff, fdis, fref, ffaw, order=1):
     fref : filename of reference volume e.g. (FMRIB58_FA_1mm.nii.gz)
     ffaw : filename for the output warped image
     '''
-    refaff = nib.load(fref).get_affine()
+    refaff = nib.load(fref).affine
     disdata = nib.load(fdis).get_data()
     imgfa = nib.load(ffa)
     fadata = imgfa.get_data()
-    fazooms = imgfa.get_header().get_zooms()
+    fazooms = imgfa.header.get_zooms()
     # from fa index to ref index
     res = flirt2aff_files(flaff, ffa, fref)
     # from ref index to fa index
@@ -264,12 +264,12 @@ def warp_displacements_tracks(fdpy, ffa, fmat, finv, fdis, fdisa, fref, fdpyw):
 
     # load the reference img
     imgref = nib.load(fref)
-    refaff = imgref.get_affine()
+    refaff = imgref.affine
 
     # load the invwarp displacements
     imginvw = nib.load(finv)
     invwdata = imginvw.get_data()
-    invwaff = imginvw.get_affine()
+    invwaff = imginvw.affine
 
     # load the forward displacements
     imgdis = nib.load(fdis)

--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -5,11 +5,11 @@ import nibabel as nib
 
 def load_nifti(fname, return_img=False, return_voxsize=False):
     img = nib.load(fname)
-    hdr = img.get_header()
+    hdr = img.header
     data = img.get_data()
     vox_size = hdr.get_zooms()[:3]
 
-    ret_val = [data, img.get_affine()]
+    ret_val = [data, img.affine]
     if return_voxsize:
         ret_val.append(vox_size)
     if return_img:

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -29,7 +29,7 @@ def nifti1_symmat(image_data, *args, **kwargs):
         raise ValueError("input_data does not seem to have matrix elements")
 
     image = Nifti1Image(image_data, *args, **kwargs)
-    hdr = image.get_header()
+    hdr = image.header
     hdr.set_intent('symmetric matrix', (n,))
     return image
 

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -63,7 +63,7 @@ def assert_image_shape_affine(filename, shape, affine):
     assert_true(os.path.isfile(filename))
     image = nib.load(filename)
     assert_equal(image.shape, shape)
-    nt.assert_array_almost_equal(image.get_affine(), affine)
+    nt.assert_array_almost_equal(image.affine, affine)
 
 
 def test_dipy_fit_tensor_again():
@@ -79,7 +79,7 @@ def test_dipy_fit_tensor_again():
         assert_equal(out[0], 0)
         # Get expected values
         img = nib.load("small_25.nii.gz")
-        affine = img.get_affine()
+        affine = img.affine
         shape = img.shape[:-1]
         # Check expected outputs
         assert_image_shape_affine("small_25_fa.nii.gz", shape, affine)
@@ -102,7 +102,7 @@ def test_dipy_fit_tensor_again():
         assert_equal(out[0], 0)
         # Get expected values
         img = nib.load("small_25.nii.gz")
-        affine = img.get_affine()
+        affine = img.affine
         shape = img.shape[:-1]
         # Check expected outputs
         assert_image_shape_affine("small_25_fa.nii.gz", shape, affine)

--- a/dipy/tracking/eudx.py
+++ b/dipy/tracking/eudx.py
@@ -115,7 +115,7 @@ class EuDX(object):
         >>> from dipy.core.gradients import gradient_table
         >>> fimg,fbvals,fbvecs = get_data('small_101D')
         >>> img = nib.load(fimg)
-        >>> affine = img.get_affine()
+        >>> affine = img.affine
         >>> data = img.get_data()
         >>> gtab = gradient_table(fbvals, fbvecs)
         >>> model = TensorModel(gtab)

--- a/dipy/tracking/tests/test_life.py
+++ b/dipy/tracking/tests/test_life.py
@@ -106,7 +106,7 @@ def test_FiberModel_init():
     data_file, bval_file, bvec_file = dpd.get_data('small_64D')
     data_ni = nib.load(data_file)
     data = data_ni.get_data()
-    data_aff = data_ni.get_affine()
+    data_aff = data_ni.affine
     bvals, bvecs = (np.load(f) for f in (bval_file, bvec_file))
     gtab = dpg.gradient_table(bvals, bvecs)
     FM = life.FiberModel(gtab)
@@ -130,7 +130,7 @@ def test_FiberFit():
     data_file, bval_file, bvec_file = dpd.get_data('small_64D')
     data_ni = nib.load(data_file)
     data = data_ni.get_data()
-    data_aff = data_ni.get_affine()
+    data_aff = data_ni.affine
     bvals, bvecs = (np.load(f) for f in (bval_file, bvec_file))
     gtab = dpg.gradient_table(bvals, bvecs)
     FM = life.FiberModel(gtab)

--- a/dipy/tracking/tests/test_propagation.py
+++ b/dipy/tracking/tests/test_propagation.py
@@ -71,7 +71,7 @@ def test_eudx_further():
     fimg, fbvals, fbvecs = get_data('small_101D')
 
     img = ni.load(fimg)
-    affine = img.get_affine()
+    affine = img.affine
     data = img.get_data()
     gtab = gradient_table(fbvals, fbvecs)
     tensor_model = TensorModel(gtab)
@@ -127,7 +127,7 @@ def test_eudx_bad_seed():
     fimg, fbvals, fbvecs = get_data('small_101D')
 
     img = ni.load(fimg)
-    affine = img.get_affine()
+    affine = img.affine
     data = img.get_data()
     gtab = gradient_table(fbvals, fbvecs)
     tensor_model = TensorModel(gtab)

--- a/dipy/workflows/denoise.py
+++ b/dipy/workflows/denoise.py
@@ -53,7 +53,7 @@ class NLMeansFlow(Workflow):
 
                 denoised_data = nlmeans(data, sigma)
                 denoised_image = nib.Nifti1Image(
-                    denoised_data, image.get_affine(), image.get_header())
+                    denoised_data, image.affine, image.header)
 
                 denoised_image.to_filename(odenoised)
                 logging.info('Denoised volume saved as {0}'.format(odenoised))

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -90,7 +90,7 @@ class ReconstDtiFlow(Workflow):
 
             img = nib.load(dwi)
             data = img.get_data()
-            affine = img.get_affine()
+            affine = img.affine
 
             if mask is None:
                 mask = None

--- a/dipy/workflows/segment.py
+++ b/dipy/workflows/segment.py
@@ -71,7 +71,7 @@ class MedianOtsuFlow(Workflow):
 
             if save_masked:
                 save_nifti(masked_out_path, masked_volume, affine,
-                           img.get_header())
+                           img.header)
 
                 logging.info('Masked volume saved as {0}'.
                              format(masked_out_path))

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -25,7 +25,7 @@ def reconst_flow_core(flow, extra_args=[]):
         vol_img = nib.load(data_path)
         volume = vol_img.get_data()
         mask = np.ones_like(volume[:, :, :, 0])
-        mask_img = nib.Nifti1Image(mask.astype(np.uint8), vol_img.get_affine())
+        mask_img = nib.Nifti1Image(mask.astype(np.uint8), vol_img.affine)
         mask_path = join(out_dir, 'tmp_mask.nii.gz')
         nib.save(mask_img, mask_path)
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -95,10 +95,10 @@ transform instead of a voxel sizes array. Please update all code using
 ``target`` in a way similar to this ::
 
     img = nib.load(anat)
-    voxel_dim = img.get_header()['pixdim'][1:4]
+    voxel_dim = img.header['pixdim'][1:4]
     streamlines = utils.target(streamlines, img.get_data(), voxel_dim)
 
 to something similar to ::
 
     img = nib.load(anat)
-    streamlines = utils.target(streamlines, img.get_data(), img.get_affine())
+    streamlines = utils.target(streamlines, img.get_data(), img.affine)

--- a/doc/dependencies.rst
+++ b/doc/dependencies.rst
@@ -6,9 +6,9 @@ Dependencies
 
 Depends on a few standard libraries: python_ (the core language), numpy_ (for
 numerical computation), scipy_ (for more specific mathematical operations),
-cython_ (for extra speed) and nibabel_ (for file formats). Optionally, it can
-use python-vtk_ (for visualisation), pytables_ (for handling large datasets),
-matplotlib_ (for scientific plotting), and ipython_ (for interaction with the
-code and its results).
+cython_ (for extra speed) and nibabel_ (for file formats; we require version 2.1
+or higher). Optionally, it can use python-vtk_ (for visualisation), pytables_
+(for handling large datasets), matplotlib_ (for scientific plotting), and
+ipython_ (for interaction with the code and its results).
 
 .. include:: links_names.inc

--- a/doc/examples/denoise_ascm.py
+++ b/doc/examples/denoise_ascm.py
@@ -43,7 +43,7 @@ fetch_sherbrooke_3shell()
 img, gtab = read_sherbrooke_3shell()
 
 data = img.get_data()
-affine = img.get_affine()
+affine = img.affine
 
 mask = data[..., 0] > 80
 data = data[..., 1]

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -14,13 +14,13 @@ poorly aligned with their neighbors, see Fig. 1.
    :scale: 60 %
    :align: center
 
-   On the left this figure illustrates (in 2D) the contribution of two fiber 
-   points to the kernel density estimator. The kernel density estimator is the 
-   sum over all such locally aligned kernels. The local fiber to bundle 
-   coherence shown on the right color-coded for each fiber, is obtained by 
-   evaluating the kernel density estimator along the fibers. One spurious 
-   fiber is present which is isolated and badly aligned with the other fibers, 
-   and can be identified by a low LFBC value in the region where it deviates 
+   On the left this figure illustrates (in 2D) the contribution of two fiber
+   points to the kernel density estimator. The kernel density estimator is the
+   sum over all such locally aligned kernels. The local fiber to bundle
+   coherence shown on the right color-coded for each fiber, is obtained by
+   evaluating the kernel density estimator along the fibers. One spurious
+   fiber is present which is isolated and badly aligned with the other fibers,
+   and can be identified by a low LFBC value in the region where it deviates
    from the bundle. Figure adapted from [Portegies2015_PLoSOne]_.
 
 Here we implement FBC measures based on kernel density estimation in the
@@ -50,7 +50,7 @@ np.random.seed(1)
 hardi_img, gtab, labels_img = read_stanford_labels()
 data = hardi_img.get_data()
 labels = labels_img.get_data()
-affine = hardi_img.get_affine()
+affine = hardi_img.affine
 fetch_stanford_t1()
 t1 = read_stanford_t1()
 t1_data = t1.get_data()
@@ -247,13 +247,13 @@ fvtk.record(ren, n_frames=1, out_path='OR_after.png', size=(900, 900))
 .. figure:: OR_before.png
    :align: center
 
-   The optic radiation obtained through probabilistic tractography colored by 
+   The optic radiation obtained through probabilistic tractography colored by
    local fiber to bundle coherence.
 
 .. figure:: OR_after.png
    :align: center
 
-   The tractography result is cleaned (shown in bottom) by removing fibers 
+   The tractography result is cleaned (shown in bottom) by removing fibers
    with a relative FBC (RFBC) lower than the threshold tau=0.2.
 
 Acknowledgments

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 numpy>=1.7.1
 scipy>=0.9
 cython>=0.18
-nibabel>=1.2
+nibabel>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 numpy>=1.7.1
 scipy>=0.9
 cython>=0.18
-nibabel>=2.0.1
+nibabel>=2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 numpy>=1.7.1
 scipy>=0.9
 cython>=0.18
-nibabel>=2.0
+nibabel>=2.0.1

--- a/scratch/very_scratch/registration_example.py
+++ b/scratch/very_scratch/registration_example.py
@@ -37,7 +37,7 @@ def eddy_current_correction(data,affine,target=None,target_affine=None):
         T=dp.volume_register(source,target,similarity,\
                                  interp,subsampling,search,optimizer)
         sourceT=dp.volume_transform(source, T.inv(), reference=target)
-        print i, sourceT.get_data().shape, sourceT.get_affine().shape
+        print i, sourceT.get_data().shape, sourceT.affine.shape
         result.append(sourceT)
 
     result.insert(0,target)

--- a/scratch/very_scratch/warptalk.py
+++ b/scratch/very_scratch/warptalk.py
@@ -22,13 +22,13 @@ def flirt2aff(mat, in_img, ref_img):
         Transform from voxel coordinates in ``in_img`` to voxel coordinates in
         ``ref_img``
     """
-    in_hdr = in_img.get_header()
-    ref_hdr = ref_img.get_header()
+    in_hdr = in_img.header
+    ref_hdr = ref_img.header
     # get_zooms gets the positive voxel sizes as returned in the header
     in_zoomer = np.diag(in_hdr.get_zooms() + (1,))
     ref_zoomer = np.diag(ref_hdr.get_zooms() + (1,))
     # The in_img voxels to ref_img voxels as recorded in the current affines
-    current_in2ref = np.dot(ref_img.get_affine(), in_img.get_affine())
+    current_in2ref = np.dot(ref_img.affine, in_img.affine)
     if npl.det(current_in2ref) < 0:
         raise ValueError('Negative determinant to current affine mapping - bailing out')
     return np.dot(npl.inv(ref_zoomer), np.dot(mat, in_zoomer))
@@ -95,7 +95,7 @@ print length(ntrack)/length(track)
 #print npl.det(im2im)**(1/3.)
 disimg=nib.load(fdis)
 ddata=disimg.get_data()
-daff=disimg.get_affine()
+daff=disimg.affine
 
 from scipy.ndimage.interpolation import map_coordinates as mc
 di=ddata[:,:,:,0]
@@ -112,7 +112,7 @@ print length(wtrack),length(ntrack),length(track)
 
 imgroi=nib.load(froi)    
 roidata=imgroi.get_data()
-roiaff=imgroi.get_affine()
+roiaff=imgroi.affine
 roiaff=daff
 I=np.array(np.where(roidata>0)).T    
 wI=np.dot(roiaff[:3,:3],I.T).T+roiaff[:3,3]
@@ -121,7 +121,7 @@ wI=wI.astype('f4')
 
 imgroi2=nib.load(froi2)    
 roidata2=imgroi2.get_data()
-roiaff2=imgroi2.get_affine()
+roiaff2=imgroi2.affine
 roiaff2=daff
 I2=np.array(np.where(roidata2>0)).T    
 wI2=np.dot(roiaff2[:3,:3],I2.T).T+roiaff2[:3,3]
@@ -130,7 +130,7 @@ wI2=wI2.astype('f4')
 
 imgroi3=nib.load(froi3)    
 roidata3=imgroi3.get_data()
-roiaff3=imgroi3.get_affine()
+roiaff3=imgroi3.affine
 roiaff3=daff
 I3=np.array(np.where(roidata3>0)).T    
 wI3=np.dot(roiaff3[:3,:3],I3.T).T+roiaff3[:3,3]
@@ -186,7 +186,7 @@ for i in range(len(offsets)-1):
 ref_fname = '/usr/share/fsl/data/standard/FMRIB58_FA-skeleton_1mm.nii.gz'
 imgref=nib.load(ref_fname)
 refdata=imgref.get_data()
-refaff=imgref.get_affine()
+refaff=imgref.affine
 
 '''
 refI=np.array(np.where(refdata>5000)).T    
@@ -203,7 +203,7 @@ froi='/home/eg309/Data/ICBM_Wmpm/ICBM_WMPM.nii'
 def get_roi(froi,no):
     imgroi=nib.load(froi)    
     roidata=imgroi.get_data()
-    roiaff=imgroi.get_affine()    
+    roiaff=imgroi.affine    
     I=np.array(np.where(roidata==no)).T    
     wI=np.dot(roiaff[:3,:3],I.T).T+roiaff[:3,3]
     wI=wI.astype('f4')
@@ -238,13 +238,13 @@ print daff
 ##load roi image
 #roiimg=ni.load(froi)
 #roidata=roiimg.get_data()
-#roiaff=roiimg.get_affine()
+#roiaff=roiimg.affine
 #print 'roiaff',roiaff,roidata.shape
 #
 ##load FA image
 #faimg=ni.load(ffa)
 #data=faimg.get_data()
-#aff=faimg.get_affine()
+#aff=faimg.affine
 ##aff[0,:]=-aff[0,:]
 ##aff[0,0]=-aff[0,0]
 ##aff=np.array([[2.5,0,0,-2.5*48],[0,2.5,0,-2.5*39],[0,0,2.5,-2.5*23],[0,0,0,1]])
@@ -273,7 +273,7 @@ print daff
 #
 #dis=ni.load(fdis)
 #disdata=dis.get_data()
-#mniaff=dis.get_affine()
+#mniaff=dis.affine
 #print 'mniaff',mniaff
 #
 ##invert disaff 
@@ -413,8 +413,8 @@ def test_flirt2aff():
     ref_img = nib.load(ref_fname)
     assert_true(np.all(res == flirt2aff(mat, in_img, ref_img)))
     # mm to mm transform
-    mm_in2mm_ref =  np.dot(ref_img.get_affine(),
-                           np.dot(res, npl.inv(in_img.get_affine())))
+    mm_in2mm_ref =  np.dot(ref_img.affine,
+                           np.dot(res, npl.inv(in_img.affine)))
     # make new in image thus transformed
     in_data = in_img.get_data()
     ires = npl.inv(res)
@@ -423,7 +423,7 @@ def test_flirt2aff():
                                          ires[:3,:3],
                                          ires[:3,3],
                                          ref_img.shape)
-    resliced_img = nib.Nifti1Image(resliced_data, ref_img.get_affine())
+    resliced_img = nib.Nifti1Image(resliced_data, ref_img.affine)
     nib.save(resliced_img, 'test.nii')
 
 


### PR DESCRIPTION
This (potentially) avoids a lot of annoying deprecation warnings that have started showing up recently.