### PR TITLE
BF: closing matplotlib plots for each file while running the examples

### DIFF
--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -120,8 +120,8 @@ for script in validated_examples:
     figure_basename = os.path.join('fig', os.path.splitext(script)[0])
     print(script)
     exec(open(script).read(), namespace)
+    plt.close('all')
     del namespace
-    # plt.close('all')
 
 if use_xvfb:
     display.stop()


### PR DESCRIPTION
It seems that although I was deleting the namespaces, the matplotlib plots were not deleted. This PR should hopefully fix this problem reported in issue https://github.com/nipy/dipy/issues/1154
