### PR TITLE
BF: fix interpolation call with Numpy 1.12

### DIFF
--- a/dipy/tracking/local/interpolation.pyx
+++ b/dipy/tracking/local/interpolation.pyx
@@ -112,6 +112,6 @@ cpdef trilinear_interpolate4d(double[:, :, :, :] data, double[:] point,
 
 
 def nearestneighbor_interpolate(data, point):
-    index = tuple(np.round(point))
+    index = tuple(np.round(point).astype(np.int))
     return data[index]
 


### PR DESCRIPTION
This fixed the issue described in https://github.com/nipy/dipy/issues/1176

Numpy 1.12 now Raises when indexing an with a double instead of an int. We cast to int.