### PR TITLE
Suppress warnings regarding one-dimensional arrays changes in scipy 0.18

### DIFF
--- a/dipy/align/reslice.py
+++ b/dipy/align/reslice.py
@@ -68,7 +68,7 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
     """
     new_zooms = np.array(new_zooms, dtype='f8')
     zooms = np.array(zooms, dtype='f8')
-    R = new_zooms / zooms
+    R = np.diag(new_zooms / zooms)
     new_shape = zooms / new_zooms * np.array(data.shape[:3])
     new_shape = tuple(np.round(new_shape).astype('i8'))
     kwargs = {'matrix': R, 'output_shape': new_shape, 'order': order,
@@ -95,6 +95,6 @@ def reslice(data, affine, zooms, new_zooms, order=1, mode='constant', cval=0,
             pool.close()
 
     Rx = np.eye(4)
-    Rx[:3, :3] = np.diag(R)
+    Rx[:3, :3] = R
     affine2 = np.dot(affine, Rx)
     return data2, affine2


### PR DESCRIPTION
undoes changes introduced in: https://github.com/nipy/dipy/pull/757/commits/b6fc887d4309f7bbd76ff10c20b86953de708bde

Should resolve https://github.com/nipy/dipy/issues/1107