### PR TITLE
Follow PEP8 in reconst (part 2)

### DIFF
--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -208,7 +208,7 @@ class DiffusionSpectrumFit(OdfFit):
         ----------
         normalized : boolean
             default true, normalize the propagator by its sum in order
-            to obtain a pdf
+            to obtain a pdf. Default: True.
 
         Returns
         -------
@@ -252,7 +252,7 @@ class DiffusionSpectrumFit(OdfFit):
         ----------
         normalized : boolean
             default true, normalize the propagator by its sum in order
-            to obtain a pdf
+            to obtain a pdf. Default: True.
 
         Returns
         -------

--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -200,13 +200,15 @@ class DiffusionSpectrumFit(OdfFit):
 
     def rtop_pdf(self, normalized=True):
         r""" Calculates the return to origin probability from the propagator, which is
-        the propagator evaluated at zero (see Descoteaux et Al. [1]_, Tuch [2]_, Wu et al. [3]_)
+        the propagator evaluated at zero (see Descoteaux et Al. [1]_,
+        Tuch [2]_, Wu et al. [3]_)
         rtop = P(0)
 
         Parameters
         ----------
         normalized : boolean
-            default true, normalize the propagator by its sum in order to obtain a pdf
+            default true, normalize the propagator by its sum in order
+            to obtain a pdf
 
         Returns
         -------
@@ -243,12 +245,14 @@ class DiffusionSpectrumFit(OdfFit):
                     MSD:{DSI}=\int_{-\infty}^{\infty}\int_{-\infty}^{\infty}\int_{-\infty}^{\infty} P(\hat{\mathbf{r}}) \cdot \hat{\mathbf{r}}^{2} \ dr_x \ dr_y \ dr_z
                 \end{equation}
 
-        where $\hat{\mathbf{r}}$ is a point in the 3D Propagator space (see Wu et. al [1]_).
+        where $\hat{\mathbf{r}}$ is a point in the 3D Propagator space
+        (see Wu et. al [1]_).
 
         Parameters
         ----------
         normalized : boolean
-            default true, normalize the propagator by its sum in order to obtain a pdf
+            default true, normalize the propagator by its sum in order
+            to obtain a pdf
 
         Returns
         -------
@@ -573,7 +577,7 @@ class DiffusionSpectrumDeconvFit(DiffusionSpectrumFit):
         self.model.cache_set('deconv_psf', self.model.gtab, DSID_PSF)
         # apply fourier transform
         Pr = fftshift(np.abs(np.real(fftn(ifftshift(Sq),
-                      3 * (self.qgrid_sz, )))))
+                                          3 * (self.qgrid_sz, )))))
         # threshold propagator
         Pr = threshold_propagator(Pr)
         # apply LR deconvolution
@@ -645,8 +649,9 @@ def LR_deconv(prop, psf, numit=5, acc_factor=1):
         reBlurred = np.real(np.fft.ifftn(otf * np.fft.fftn(prop_deconv)))
         reBlurred[reBlurred < eps] = eps
         # Update the estimate
-        prop_deconv = prop_deconv * (np.real(np.fft.ifftn(otf *
-                                                          np.fft.fftn((prop / reBlurred) + eps)))) ** acc_factor
+        prop_deconv = prop_deconv * (
+            np.real(np.fft.ifftn(
+                otf * np.fft.fftn((prop / reBlurred) + eps)))) ** acc_factor
         # Enforce positivity
         prop_deconv = np.clip(prop_deconv, 0, np.inf)
     return prop_deconv / prop_deconv.sum()

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -1373,12 +1373,12 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
     log_s = np.log(data)
     w = np.exp(np.einsum('...ij,...j', ols_fit, log_s))
     fit_result = np.einsum('...ij,...j',
-                  pinv(design_matrix * w[..., None]),
-                  w * log_s)
+                           pinv(design_matrix * w[..., None]),
+                           w * log_s)
     if return_S0_hat:
         return (eig_from_lo_tri(fit_result,
                                 min_diffusivity=tol / -design_matrix.min()),
-                                np.exp(-fit_result[:, -1]))
+                np.exp(-fit_result[:, -1]))
     else:
         return eig_from_lo_tri(fit_result,
                                min_diffusivity=tol / -design_matrix.min())
@@ -1437,7 +1437,7 @@ def ols_fit_tensor(design_matrix, data, return_S0_hat=False):
     if return_S0_hat:
         return (eig_from_lo_tri(fit_result,
                                 min_diffusivity=tol / -design_matrix.min()),
-                                np.exp(-fit_result[:, -1]))
+                np.exp(-fit_result[:, -1]))
     else:
         return eig_from_lo_tri(fit_result,
                                min_diffusivity=tol / -design_matrix.min())

--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -638,8 +638,8 @@ def nls_iter(design_matrix, sig, S0, Diso=3e-3, mdreg=2.7e-3,
         # Process water volume fraction f
         f = this_tensor[7]
         if f_transform:
-            f = 0.5 * (1 + np.sin(f - np.pi/2))        
-        
+            f = 0.5 * (1 + np.sin(f - np.pi/2))
+
         params = np.concatenate((evals, evecs[0], evecs[1], evecs[2],
                                  np.array([f])), axis=0)
     return params

--- a/dipy/reconst/gqi.py
+++ b/dipy/reconst/gqi.py
@@ -37,13 +37,13 @@ class GeneralizedQSamplingModel(OdfModel, Cache):
 
         .. [2] Garyfallidis E, "Towards an accurate brain tractography", PhD
         thesis, University of Cambridge, 2012.
-        
+
         Notes
         -----
         As of version 0.9, range of the sampling length in GQI2 has changed
-	to match the same scale used in the 'standard' method [1]_. This 
-        means that the value of `sampling_length` should be approximately 
-        1 - 1.3 (see [1]_, pg. 1628). 
+        to match the same scale used in the 'standard' method [1]_. This
+        means that the value of `sampling_length` should be approximately
+        1 - 1.3 (see [1]_, pg. 1628).
 
         Examples
         --------
@@ -53,7 +53,7 @@ class GeneralizedQSamplingModel(OdfModel, Cache):
 
         >>> from dipy.data import dsi_voxels
         >>> data, gtab = dsi_voxels()
-        >>> from dipy.core.subdivide_octahedron import create_unit_sphere 
+        >>> from dipy.core.subdivide_octahedron import create_unit_sphere
         >>> sphere = create_unit_sphere(5)
         >>> from dipy.reconst.gqi import GeneralizedQSamplingModel
         >>> gq = GeneralizedQSamplingModel(gtab, 'gqi2', 1.1)
@@ -75,7 +75,7 @@ class GeneralizedQSamplingModel(OdfModel, Cache):
         scaling = np.sqrt(self.gtab.bvals * 0.01506)
         tmp = np.tile(scaling, (3, 1))
         gradsT = self.gtab.bvecs.T
-        b_vector = gradsT * tmp # element-wise product
+        b_vector = gradsT * tmp  # element-wise product
         self.b_vector = b_vector.T
 
     @multi_voxel_fit
@@ -109,18 +109,22 @@ class GeneralizedQSamplingFit(OdfFit):
         self.gqi_vector = self.model.cache_get('gqi_vector', key=sphere)
         if self.gqi_vector is None:
             if self.model.method == 'gqi2':
-                H=squared_radial_component
-                #print self.gqi_vector.shape
-                self.gqi_vector = np.real(H(np.dot(self.model.b_vector,                                         sphere.vertices.T) * self.model.Lambda))
+                H = squared_radial_component
+                # print self.gqi_vector.shape
+                self.gqi_vector = np.real(H(np.dot(
+                    self.model.b_vector, sphere.vertices.T) *
+                    self.model.Lambda))
             if self.model.method == 'standard':
-                self.gqi_vector = np.real(np.sinc(np.dot(self.model.b_vector,                                   sphere.vertices.T) * self.model.Lambda / np.pi))
+                self.gqi_vector = np.real(np.sinc(np.dot(
+                    self.model.b_vector, sphere.vertices.T) *
+                    self.model.Lambda / np.pi))
             self.model.cache_set('gqi_vector', sphere, self.gqi_vector)
 
         return np.dot(self.data, self.gqi_vector)
 
 
 def normalize_qa(qa, max_qa=None):
-    """ Normalize quantitative anisotropy. 
+    """ Normalize quantitative anisotropy.
 
     Used mostly with GQI rather than GQI2.
 
@@ -139,8 +143,8 @@ def normalize_qa(qa, max_qa=None):
     Notes
     -----
     Normalized quantitative anisotropy has the very useful property
-    to be very small near gray matter and background areas. Therefore, 
-    it can be used to mask out white matter areas. 
+    to be very small near gray matter and background areas. Therefore,
+    it can be used to mask out white matter areas.
 
     """
     if max_qa is None:
@@ -165,15 +169,19 @@ def npa(self, odf, width=5):
 
     Nimmo-Smith et. al  ISMRM 2011
     """
-    #odf = self.odf(s)
+    # odf = self.odf(s)
     t0, t1, t2 = triple_odf_maxima(self.odf_vertices, odf, width)
     psi0 = t0[1] ** 2
     psi1 = t1[1] ** 2
     psi2 = t2[1] ** 2
-    npa = np.sqrt((psi0 - psi1) ** 2 + (psi1 - psi2) ** 2 + (psi2 - psi0) ** 2) / np.sqrt(2 * (psi0 ** 2 + psi1 ** 2 + psi2 ** 2))
-    #print 'tom >>>> ',t0,t1,t2,npa
+    npa = (np.sqrt(
+        (psi0 - psi1) ** 2 +
+        (psi1 - psi2) ** 2 +
+        (psi2 - psi0) ** 2) /
+        np.sqrt(2 * (psi0 ** 2 + psi1 ** 2 + psi2 ** 2)))
+    # print 'tom >>>> ',t0,t1,t2,npa
 
-    return t0,t1,t2,npa
+    return t0, t1, t2, npa
 
 
 def equatorial_zone_vertices(vertices, pole, width=5):
@@ -181,7 +189,9 @@ def equatorial_zone_vertices(vertices, pole, width=5):
     finds the 'vertices' in the equatorial zone conjugate
     to 'pole' with width half 'width' degrees
     """
-    return [i for i,v in enumerate(vertices) if np.abs(np.dot(v,pole)) < np.abs(np.sin(np.pi*width/180))]
+    return [i
+            for i, v in enumerate(vertices)
+            if np.abs(np.dot(v, pole)) < np.abs(np.sin(np.pi * width / 180))]
 
 
 def polar_zone_vertices(vertices, pole, width=5):
@@ -189,7 +199,9 @@ def polar_zone_vertices(vertices, pole, width=5):
     finds the 'vertices' in the equatorial band around
     the 'pole' of radius 'width' degrees
     """
-    return [i for i,v in enumerate(vertices) if np.abs(np.dot(v,pole)) > np.abs(np.cos(np.pi*width/180))]
+    return [i
+            for i, v in enumerate(vertices)
+            if np.abs(np.dot(v, pole)) > np.abs(np.cos(np.pi * width / 180))]
 
 
 def upper_hemi_map(v):
@@ -201,9 +213,10 @@ def upper_hemi_map(v):
 
 def equatorial_maximum(vertices, odf, pole, width):
     eqvert = equatorial_zone_vertices(vertices, pole, width)
-    #need to test for whether eqvert is empty or not
+    # need to test for whether eqvert is empty or not
     if len(eqvert) == 0:
-        print('empty equatorial band at %s  pole with width %f' % (np.array_str(pole), width))
+        print('empty equatorial band at %s  pole with width %f' %
+              (np.array_str(pole), width))
         return None, None
     eqvals = [odf[i] for i in eqvert]
     eqargmax = np.argmax(eqvals)
@@ -213,18 +226,21 @@ def equatorial_maximum(vertices, odf, pole, width):
     return eqvertmax, eqvalmax
 
 
-def patch_vertices(vertices,pole, width):
+def patch_vertices(vertices, pole, width):
     """
     find 'vertices' within the cone of 'width' degrees around 'pole'
     """
-    return [i for i,v in enumerate(vertices) if np.abs(np.dot(v,pole)) > np.abs(np.cos(np.pi*width/180))]
+    return [i
+            for i, v in enumerate(vertices)
+            if np.abs(np.dot(v, pole)) > np.abs(np.cos(np.pi * width / 180))]
 
 
 def patch_maximum(vertices, odf, pole, width):
     eqvert = patch_vertices(vertices, pole, width)
-    #need to test for whether eqvert is empty or not
+    # need to test for whether eqvert is empty or not
     if len(eqvert) == 0:
-        print('empty cone around pole %s with with width %f' % (np.array_str(pole), width))
+        print('empty cone around pole %s with with width %f' %
+              (np.array_str(pole), width))
         return np.Null, np.Null
     eqvals = [odf[i] for i in eqvert]
     eqargmax = np.argmax(eqvals)
@@ -239,26 +255,27 @@ def odf_sum(odf):
 
 def patch_sum(vertices, odf, pole, width):
     eqvert = patch_vertices(vertices, pole, width)
-    #need to test for whether eqvert is empty or not
+    # need to test for whether eqvert is empty or not
     if len(eqvert) == 0:
-        print('empty cone around pole %s with with width %f' % (np.array_str(pole), width))
+        print('empty cone around pole %s with with width %f' %
+              (np.array_str(pole), width))
         return np.Null
     return np.sum([odf[i] for i in eqvert])
 
 
 def triple_odf_maxima(vertices, odf, width):
 
-    indmax1 = np.argmax([odf[i] for i,v in enumerate(vertices)])
+    indmax1 = np.argmax([odf[i] for i, v in enumerate(vertices)])
     odfmax1 = odf[indmax1]
     pole = vertices[indmax1]
     eqvert = equatorial_zone_vertices(vertices, pole, width)
-    indmax2, odfmax2 = equatorial_maximum(vertices,\
-                                              odf, pole, width)
-    indmax3 = eqvert[np.argmin([np.abs(np.dot(vertices[indmax2],vertices[p])) for p in eqvert])]
+    indmax2, odfmax2 = equatorial_maximum(vertices, odf, pole, width)
+    indmax3 = eqvert[np.argmin([np.abs(np.dot(vertices[indmax2], vertices[p]))
+                                for p in eqvert])]
     odfmax3 = odf[indmax3]
     """
     cross12 = np.cross(vertices[indmax1],vertices[indmax2])
     cross12 = cross12/np.sqrt(np.sum(cross12**2))
     indmax3, odfmax3 = patch_maximum(vertices, odf, cross12, 2*width)
     """
-    return [(indmax1, odfmax1),(indmax2, odfmax2),(indmax3, odfmax3)]
+    return [(indmax1, odfmax1), (indmax2, odfmax2), (indmax3, odfmax3)]

--- a/dipy/reconst/interpolate.py
+++ b/dipy/reconst/interpolate.py
@@ -1,4 +1,5 @@
-"""Interpolators wrap arrays to allow the array to be indexed in continuous coordinates
+"""Interpolators wrap arrays to allow the array to be indexed in
+continuous coordinates
 
 This module uses the trackvis coordinate system, for more information about
 this coordinate system please see dipy.tracking.utils
@@ -10,14 +11,17 @@ dipy.reconst.interpolate
 from numpy import array
 from dipy.reconst.recspeed import trilinear_interp
 
+
 class OutsideImage(Exception):
     pass
+
 
 class Interpolator(object):
     """Class to be subclassed by different interpolator types"""
     def __init__(self, data, voxel_size):
         self.data = data
         self.voxel_size = array(voxel_size, dtype=float, copy=True)
+
 
 class NearestNeighborInterpolator(Interpolator):
     """Interpolates data using nearest neighbor interpolation"""
@@ -30,6 +34,7 @@ class NearestNeighborInterpolator(Interpolator):
             return self.data[tuple(array(index).astype(int))]
         except IndexError:
             raise OutsideImage
+
 
 class TriLinearInterpolator(Interpolator):
     """Interpolates data using trilinear interpolation

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -923,7 +923,6 @@ class MapmriFit(ReconstFit):
         E = S0 * np.dot(M, self._mapmri_coef)
         return E
 
-
     def pdf(self, r_points):
         """ Diffusion propagator on a given set of real points.
         if the array r_points is non writeable, then intermediate

--- a/dipy/reconst/odf.py
+++ b/dipy/reconst/odf.py
@@ -5,6 +5,7 @@ import numpy as np
 # Classes OdfModel and OdfFit are using API ReconstModel and ReconstFit from
 # .base
 
+
 class OdfModel(ReconstModel):
 
     """An abstract class to be sub-classed by specific odf models
@@ -67,4 +68,3 @@ def minmax_normalize(samples, out=None):
     out -= sample_mins
     out /= (sample_maxes - sample_mins)
     return out
-


### PR DESCRIPTION
Using `pycodestyle` fixed every error, except for:

* `dsi.py`: The long lines are TeX docstrings. Variable name `I` is not a problem
```
dsi.py:29:80: E501 line too long (116 > 79 characters)
dsi.py:245:80: E501 line too long (167 > 79 characters)
dsi.py:482:9: E741 ambiguous variable name 'I'
dsi.py:508:80: E501 line too long (174 > 79 characters)
dsi.py:509:80: E501 line too long (163 > 79 characters)
dsi.py:510:80: E501 line too long (166 > 79 characters)
```

* `dti.py`: Line contains an FTP url
```
dti.py:1103:80: E501 line too long (94 > 79 characters)
```

* `mapmri.py`: Variable names `I` or `l` are not a problem
```
mapmri.py:502:13: E741 ambiguous variable name 'I'
mapmri.py:504:17: E741 ambiguous variable name 'I'
mapmri.py:533:9: E741 ambiguous variable name 'I'
mapmri.py:536:13: E741 ambiguous variable name 'I'
mapmri.py:573:25: E741 ambiguous variable name 'l'
mapmri.py:624:21: E741 ambiguous variable name 'l'
mapmri.py:1331:13: E741 ambiguous variable name 'l'
mapmri.py:1383:13: E741 ambiguous variable name 'l'
mapmri.py:1406:13: E741 ambiguous variable name 'l'
mapmri.py:1449:13: E741 ambiguous variable name 'l'
mapmri.py:1501:13: E741 ambiguous variable name 'l'
mapmri.py:1526:13: E741 ambiguous variable name 'l'
mapmri.py:1584:13: E741 ambiguous variable name 'l'
mapmri.py:1639:13: E741 ambiguous variable name 'l'
mapmri.py:1647:41: E741 ambiguous variable name 'l'
mapmri.py:1686:17: E741 ambiguous variable name 'l'
```

This is the second PR that replaces #1207 (See https://github.com/nipy/dipy/issues/881#issuecomment-290594264)