### PR TITLE
RF: Replaces 1997 definitions of tensor geometric params with 1999 definitions.

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -517,17 +517,19 @@ def linearity(evals, axis=-1):
 
     .. math::
 
-        Linearity = \frac{\lambda_1-\lambda_2}{\lambda_1+\lambda_2+\lambda_3}
+        Linearity = \frac{\lambda_1-\lambda_2}{\lambda_1}
 
     Notes
     -----
-    [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.,
-        "Geometrical diffusion measures for MRI from tensor basis analysis" in
-        Proc. 5th Annual ISMRM, 1997.
+    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
+           (1999). Image Processing for Diffusion Tensor Magnetic Resonance
+           Imaging. In Proceedings of Second Int. Conf. on Medical Image
+           Computing and Computer-assisted Interventions (MICCAI’99),
+           pp.441-452, 1999.
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
-    return (ev1 - ev2) / evals.sum(0)
+    return (ev1 - ev2) / ev1
 
 
 def planarity(evals, axis=-1):
@@ -553,17 +555,19 @@ def planarity(evals, axis=-1):
     .. math::
 
         Planarity =
-        \frac{2 (\lambda_2-\lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
+        \frac{2 (\lambda_2-\lambda_3)}{\lambda_1}
 
     Notes
     -----
-    [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.,
-        "Geometrical diffusion measures for MRI from tensor basis analysis" in
-        Proc. 5th Annual ISMRM, 1997.
+    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
+          (1999). Image Processing for Diffusion Tensor Magnetic Resonance
+          Imaging. In Proceedings of Second Int. Conf. on Medical Image
+          Computing and Computer-assisted Interventions (MICCAI’99),
+          pp.441-452, 1999.
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
-    return (2 * (ev2 - ev3) / evals.sum(0))
+    return (ev2 - ev3) / ev1
 
 
 def sphericity(evals, axis=-1):
@@ -592,13 +596,15 @@ def sphericity(evals, axis=-1):
 
     Notes
     -----
-    [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.,
-        "Geometrical diffusion measures for MRI from tensor basis analysis" in
-        Proc. 5th Annual ISMRM, 1997.
+    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
+           (1999). Image Processing for Diffusion Tensor Magnetic Resonance
+           Imaging. In Proceedings of Second Int. Conf. on Medical Image
+           Computing and Computer-assisted Interventions (MICCAI’99),
+           pp.441-452, 1999.
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
-    return (3 * ev3) / evals.sum(0)
+    return ev3 / ev1
 
 
 def apparent_diffusion_coef(q_form, sphere):
@@ -1010,14 +1016,17 @@ class TensorFit(object):
         .. math::
 
             Sphericity =
-            \frac{2 (\lambda2 - \lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
+            \frac{(\lambda_3)}{\lambda_1}
 
         Notes
         -----
-        [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz
-            F., "Geometrical diffusion measures for MRI from tensor basis
-            analysis" in Proc. 5th Annual ISMRM, 1997.
 
+
+        .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
+            (1999). Image Processing for Diffusion Tensor Magnetic Resonance
+            Imaging. In Proceedings of Second Int. Conf. on Medical Image
+            Computing and Computer-assisted Interventions (MICCAI’99),
+            pp.441-452, 1999.
         """
         return planarity(self.evals)
 
@@ -1036,11 +1045,13 @@ class TensorFit(object):
         .. math::
 
             Linearity =
-            \frac{\lambda_1-\lambda_2}{\lambda_1+\lambda_2+\lambda_3}
+            \frac{\lambda_1-\lambda_2}{\lambda_1}
 
-        [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz
-            F., "Geometrical diffusion measures for MRI from tensor basis
-            analysis" in Proc. 5th Annual ISMRM, 1997.
+    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
+           (1999). Image Processing for Diffusion Tensor Magnetic Resonance
+           Imaging. In Proceedings of Second Int. Conf. on Medical Image
+           Computing and Computer-assisted Interventions (MICCAI’99),
+           pp.441-452, 1999.
 
         """
         return linearity(self.evals)
@@ -1059,13 +1070,15 @@ class TensorFit(object):
 
         .. math::
 
-            Sphericity = \frac{3 \lambda_3}{\lambda_1+\lambda_2+\lambda_3}
+            Sphericity = \frac{\lambda_3}{\lambda_1}
 
         Notes
         -----
-        [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz
-            F., "Geometrical diffusion measures for MRI from tensor basis
-            analysis" in Proc. 5th Annual ISMRM, 1997.
+        .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
+               (1999). Image Processing for Diffusion Tensor Magnetic Resonance
+               Imaging. In Proceedings of Second Int. Conf. on Medical Image
+               Computing and Computer-assisted Interventions (MICCAI’99),
+               pp.441-452, 1999.
 
         """
         return sphericity(self.evals)

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -495,9 +495,9 @@ def mode(q_form):
     return 3 * np.sqrt(6) * determinant((A_squiggle / A_s_norm))
 
 
-def linearity(evals, axis=-1):
+def linearity(evals, axis=-1, version="1997"):
     r"""
-    The linearity of the tensor [1]_
+    The linearity of the tensor [1]_, [2]_.
 
     Parameters
     ----------
@@ -505,6 +505,9 @@ def linearity(evals, axis=-1):
         Eigenvalues of a diffusion tensor.
     axis : int
         Axis of `evals` which contains 3 eigenvalues.
+    version : str
+        One of {"1997" | "1999"} to select which of the definitions in the two
+        papers describing this method ([1]_, [2]_) to use. Default: "1997"
 
     Returns
     -------
@@ -513,7 +516,13 @@ def linearity(evals, axis=-1):
 
     Notes
     --------
-    Linearity is calculated with the following equation:
+    Linearity is calculated with the following equation (version="1997")[1]_:
+
+    .. math::
+
+        Linearity = \frac{\lambda_1-\lambda_2}{\lambda_1+\lambda_2+\lambda_3}
+
+    Or (version="1999") [2]_:
 
     .. math::
 
@@ -521,20 +530,27 @@ def linearity(evals, axis=-1):
 
     Notes
     -----
-    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
-           (1999). Image Processing for Diffusion Tensor Magnetic Resonance
-           Imaging. In Proceedings of Second Int. Conf. on Medical Image
-           Computing and Computer-assisted Interventions (MICCAI’99),
+    .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.
+           (1997). "Geometrical diffusion measures for MRI from tensor basis
+           analysis" in Proc. 5th Annual ISMRM, 1997.
+
+    .. [2] Westin C.-F., Maier S.E., Khidhir B., Everett P., Jolesz F.A.,
+           Kikinis R. (1999). "Image Processing for Diffusion Tensor Magnetic
+           Resonance Imaging" In Proceedings of Second Int. Conf. on Medical
+           Image Computing and Computer-assisted Interventions (MICCAI’99),
            pp.441-452, 1999.
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
-    return (ev1 - ev2) / ev1
+    if version == "1999":
+        return (ev1 - ev2) / ev1
+    elif version == "1997":
+        return (ev1 - ev2) / evals.sum(0)
 
 
-def planarity(evals, axis=-1):
+def planarity(evals, axis=-1, version="1997"):
     r"""
-    The planarity of the tensor [1]_
+    The planarity of the tensor [1]_, [2]_
 
     Parameters
     ----------
@@ -542,6 +558,9 @@ def planarity(evals, axis=-1):
         Eigenvalues of a diffusion tensor.
     axis : int
         Axis of `evals` which contains 3 eigenvalues.
+    version : str
+        One of {"1997" | "1999"} to select which of the definitions in the two
+        papers describing this method ([1]_, [2]_) to use. Default: "1997"
 
     Returns
     -------
@@ -550,29 +569,42 @@ def planarity(evals, axis=-1):
 
     Notes
     --------
-    Planarity is calculated with the following equation:
+    Planarity is calculated with the following equation (version="1997") [1]_:
 
     .. math::
 
         Planarity =
-        \frac{2 (\lambda_2-\lambda_3)}{\lambda_1}
+        \frac{2 (\lambda_2-\lambda_3)}{\lambda_1 + \lambda_2 + \lambda_3}
+
+    Or (version="1999") [2]_:
+
+    .. math::
+
+        Planarity = \frac{\lambda_2-\lambda_3}{\lambda_1}
 
     Notes
     -----
-    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
-          (1999). Image Processing for Diffusion Tensor Magnetic Resonance
-          Imaging. In Proceedings of Second Int. Conf. on Medical Image
-          Computing and Computer-assisted Interventions (MICCAI’99),
-          pp.441-452, 1999.
+    .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.
+           (1997). "Geometrical diffusion measures for MRI from tensor basis
+           analysis" in Proc. 5th Annual ISMRM, 1997.
+
+    .. [2] Westin C.-F., Maier S.E., Khidhir B., Everett P., Jolesz F.A.,
+           Kikinis R. (1999). "Image Processing for Diffusion Tensor Magnetic
+           Resonance Imaging" In Proceedings of Second Int. Conf. on Medical
+           Image Computing and Computer-assisted Interventions (MICCAI’99),
+           pp.441-452, 1999.
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
-    return (ev2 - ev3) / ev1
+    if version == "1999":
+        return (ev2 - ev3) / ev1
+    elif version == "1997":
+        return (2 * (ev2 - ev3) / evals.sum(0))
 
 
-def sphericity(evals, axis=-1):
+def sphericity(evals, axis=-1, version="1997"):
     r"""
-    The sphericity of the tensor [1]_
+    The sphericity of the tensor [1]_, [2]_.
 
     Parameters
     ----------
@@ -580,6 +612,9 @@ def sphericity(evals, axis=-1):
         Eigenvalues of a diffusion tensor.
     axis : int
         Axis of `evals` which contains 3 eigenvalues.
+    version : str
+        One of {"1997" | "1999"} to select which of the definitions in the two
+        papers describing this method ([1]_, [2]_) to use. Default: "1997"
 
     Returns
     -------
@@ -588,23 +623,36 @@ def sphericity(evals, axis=-1):
 
     Notes
     --------
-    Sphericity is calculated with the following equation:
+    Sphericity is calculated with the following equation (version="1997") [1]_:
 
     .. math::
 
         Sphericity = \frac{3 \lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
 
+    Or with the following equation (version="1997") [2]_:
+
+    .. math::
+
+        Sphericity = \frac{\lambda_3}{\lambda_1}
+
     Notes
     -----
-    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
-           (1999). Image Processing for Diffusion Tensor Magnetic Resonance
-           Imaging. In Proceedings of Second Int. Conf. on Medical Image
-           Computing and Computer-assisted Interventions (MICCAI’99),
+    .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.
+           (1997). "Geometrical diffusion measures for MRI from tensor basis
+           analysis" in Proc. 5th Annual ISMRM, 1997.
+
+    .. [2] Westin C.-F., Maier S.E., Khidhir B., Everett P., Jolesz F.A.,
+           Kikinis R. (1999). "Image Processing for Diffusion Tensor Magnetic
+           Resonance Imaging" In Proceedings of Second Int. Conf. on Medical
+           Image Computing and Computer-assisted Interventions (MICCAI’99),
            pp.441-452, 1999.
     """
     evals = _roll_evals(evals, axis)
     ev1, ev2, ev3 = evals
-    return ev3 / ev1
+    if version == "1999":
+        return ev3 / ev1
+    elif version == "1997":
+        return (3 * ev3) / evals.sum(0)
 
 
 def apparent_diffusion_coef(q_form, sphere):
@@ -1002,35 +1050,6 @@ class TensorFit(object):
         return trace(self.evals)
 
     @auto_attr
-    def planarity(self):
-        r"""
-        Returns
-        -------
-        sphericity : array
-            Calculated sphericity of the diffusion tensor [1]_.
-
-        Notes
-        --------
-        Sphericity is calculated with the following equation:
-
-        .. math::
-
-            Sphericity =
-            \frac{(\lambda_3)}{\lambda_1}
-
-        Notes
-        -----
-
-
-        .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
-            (1999). Image Processing for Diffusion Tensor Magnetic Resonance
-            Imaging. In Proceedings of Second Int. Conf. on Medical Image
-            Computing and Computer-assisted Interventions (MICCAI’99),
-            pp.441-452, 1999.
-        """
-        return planarity(self.evals)
-
-    @auto_attr
     def linearity(self):
         r"""
         Returns
@@ -1045,16 +1064,37 @@ class TensorFit(object):
         .. math::
 
             Linearity =
-            \frac{\lambda_1-\lambda_2}{\lambda_1}
+            \frac{2 (\lambda_1-\lambda_2)}{\lambda_1+\lambda_2+\lambda_3}
 
-    .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
-           (1999). Image Processing for Diffusion Tensor Magnetic Resonance
-           Imaging. In Proceedings of Second Int. Conf. on Medical Image
-           Computing and Computer-assisted Interventions (MICCAI’99),
-           pp.441-452, 1999.
+        .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.
+               (1997). "Geometrical diffusion measures for MRI from tensor
+               basis analysis" in Proc. 5th Annual ISMRM, 1997.
 
         """
         return linearity(self.evals)
+
+    @auto_attr
+    def planarity(self):
+        r"""
+        Returns
+        -------
+        planarity : array
+            Calculated sphericity of the diffusion tensor [1]_.
+
+        Notes
+        --------
+        Planarity is calculated with the following equation:
+
+        .. math::
+
+            Planarity =
+            \frac{2 (\lambda_2-\lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
+
+        .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.
+               (1997). "Geometrical diffusion measures for MRI from tensor
+               basis analysis" in Proc. 5th Annual ISMRM, 1997.
+        """
+        return planarity(self.evals)
 
     @auto_attr
     def sphericity(self):
@@ -1070,16 +1110,11 @@ class TensorFit(object):
 
         .. math::
 
-            Sphericity = \frac{\lambda_3}{\lambda_1}
+            Sphericity = \frac{3 \lambda_3}{\lambda_1+\lambda_2+\lambda_3}
 
-        Notes
-        -----
-        .. [1] Westin CF, Maier SE, Khidhir B, Everett P, Jolesz FA, Kikinis R
-               (1999). Image Processing for Diffusion Tensor Magnetic Resonance
-               Imaging. In Proceedings of Second Int. Conf. on Medical Image
-               Computing and Computer-assisted Interventions (MICCAI’99),
-               pp.441-452, 1999.
-
+        .. [1] Westin C.-F., Peled S., Gubjartsson H., Kikinis R., Jolesz F.
+               (1997). "Geometrical diffusion measures for MRI from tensor
+               basis analysis" in Proc. 5th Annual ISMRM, 1997.
         """
         return sphericity(self.evals)
 

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -270,9 +270,10 @@ def test_diffusivities():
     assert_almost_equal(Trace, (0.0015 + 0.0003 + 0.0001))
     assert_almost_equal(ad, 0.0015)
     assert_almost_equal(rd, (0.0003 + 0.0001) / 2)
-    assert_almost_equal(lin, (0.0015 - 0.0003)/Trace)
-    assert_almost_equal(plan, 2 * (0.0003 - 0.0001)/Trace)
-    assert_almost_equal(spher, (3 * 0.0001)/Trace)
+    assert_almost_equal(lin, (0.0015 - 0.0003) / 0.0015)
+    assert_almost_equal(plan, (0.0003 - 0.0001) / 0.0015)
+    assert_almost_equal(spher, 0.0001 / 0.0015)
+    assert_almost_equal(lin + plan + spher, 1)
 
 
 def test_color_fa():
@@ -791,7 +792,7 @@ def test_decompose_tensor_nan():
                                          from_lower_triangular(D_alter))
     assert_array_almost_equal(lfine, np.array([1.7e-3, 0.3e-3, 0.2e-3]))
     assert_array_almost_equal(vfine, vref)
-    
+
     lref, vref = decompose_tensor(from_lower_triangular(D_alter))
     lalter, valter = _decompose_tensor_nan(from_lower_triangular(D_nan),
                                            from_lower_triangular(D_alter))

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -262,18 +262,32 @@ def test_diffusivities():
     Trace = trace(dmfit.evals)
     rd = radial_diffusivity(dmfit.evals)
     ad = axial_diffusivity(dmfit.evals)
-    lin = linearity(dmfit.evals)
-    plan = planarity(dmfit.evals)
-    spher = sphericity(dmfit.evals)
+    lin97 = linearity(dmfit.evals)
+    plan97 = planarity(dmfit.evals)
+    spher97 = sphericity(dmfit.evals)
+    lin99 = linearity(dmfit.evals, version="1999")
+    plan99 = planarity(dmfit.evals, version="1999")
+    spher99 = sphericity(dmfit.evals, version="1999")
 
     assert_almost_equal(md, (0.0015 + 0.0003 + 0.0001) / 3)
     assert_almost_equal(Trace, (0.0015 + 0.0003 + 0.0001))
     assert_almost_equal(ad, 0.0015)
     assert_almost_equal(rd, (0.0003 + 0.0001) / 2)
-    assert_almost_equal(lin, (0.0015 - 0.0003) / 0.0015)
-    assert_almost_equal(plan, (0.0003 - 0.0001) / 0.0015)
-    assert_almost_equal(spher, 0.0001 / 0.0015)
-    assert_almost_equal(lin + plan + spher, 1)
+    assert_almost_equal(lin97, (0.0015 - 0.0003) / (0.0015 + 0.0003 + 0.0001))
+    assert_almost_equal(plan97,
+                        2 * (0.0003 - 0.0001) / (0.0015 + 0.0003 + 0.0001))
+    assert_almost_equal(spher97, 3 * 0.0001 / (0.0015 + 0.0003 + 0.0001))
+    assert_almost_equal(lin99, (0.0015 - 0.0003) / 0.0015)
+    assert_almost_equal(plan99, (0.0003 - 0.0001) / 0.0015)
+    assert_almost_equal(spher99, 0.0001 / 0.0015)
+    assert_almost_equal(lin99 + plan99 + spher99, 1)
+
+    assert_almost_equal(dmfit.linearity,
+                        (0.0015 - 0.0003) / (0.0015 + 0.0003 + 0.0001))
+    assert_almost_equal(dmfit.planarity,
+                        (2 * (0.0003 - 0.0001) / (0.0015 + 0.0003 + 0.0001)))
+    assert_almost_equal(dmfit.sphericity,
+                        3 * 0.0001 / (0.0015 + 0.0003 + 0.0001))
 
 
 def test_color_fa():


### PR DESCRIPTION
@RafaelNH just pointed out to me that Westin et al. changed their definition of planarity, linearity and sphericity in a paper that came out in MICCAI in 1999, and that some of the subsequent literature used these definitions, rather than the ones we have been using. 

Compare this paper:

http://lmi.bwh.harvard.edu/papers/pdfs/1999/westinMICCAI99.pdf

Instead of this paper:

http://lmi.bwh.harvard.edu/papers/papers/westinISMRM97.html

The main feature of the new definitions is that the three measures sum to 1 in every voxel. 

It seems that this is the version that people should use, but this is a change from the previous definitions in our software, and users will get *different results* with this change. I am not sure how to handle that. Any thoughts?