### PR TITLE
BF: Use np.npy_intp instead of assuming long for ArraySequence attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - python: 2.7
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.18 numpy==1.7.1 scipy==0.9.0 nibabel==2.1.0"
+        - DEPENDS="cython==0.25.1 numpy==1.7.1 scipy==0.9.0 nibabel==2.1.0"
     - python: 2.7
       env:
         - DEPENDS="$DEPENDS scikit_learn tables"

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -79,7 +79,7 @@ under the GPL license.
 
 # versions for dependencies
 # Check these versions against .travis.yml and requirements.txt
-CYTHON_MIN_VERSION='0.18'
+CYTHON_MIN_VERSION='0.25.1'
 NUMPY_MIN_VERSION='1.7.1'
 SCIPY_MIN_VERSION='0.9'
 NIBABEL_MIN_VERSION='2.1.0'

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -37,7 +37,8 @@ cdef double c_length(Streamline streamline) nogil:
 
 
 cdef void c_arclengths_from_arraysequence(Streamline points,
-                                          long[:] offsets, long[:] lengths,
+                                          np.npy_intp[:] offsets,
+                                          np.npy_intp[:] lengths,
                                           double[:] arclengths) nogil:
     cdef:
         np.npy_intp i, j, k

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Check against .travis.yml file and dipy/info.py
-cython>=0.18
+cython>=0.25.1
 numpy>=1.7.1
 scipy>=0.9
 nibabel>=2.1.0


### PR DESCRIPTION
A small patch addressing the issue @arokem raised in comment https://github.com/nipy/dipy/pull/1076#issuecomment-274866713 