### PR TITLE
Feature: Added environment override for dipy_home variable

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -23,7 +23,10 @@ else:
 
 
 # Set a user-writeable file-system location to put files:
-dipy_home = pjoin(os.path.expanduser('~'), '.dipy')
+if 'DIPY_HOME' in os.environ:
+    dipy_home = os.environ['DIPY_HOME']
+else:
+    dipy_home = pjoin(os.path.expanduser('~'), '.dipy')
 
 # The URL to the University of Washington Researchworks repository:
 UW_RW_URL = \

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -120,3 +120,7 @@ def test_fetch_data():
         os.environ['DIPY_HOME'] = test_path
         reload(fetcher)
         npt.assert_string_equal(fetcher.dipy_home, test_path)
+
+        # return to previous state
+        if old_home:
+            os.environ['DIPY_HOME'] = old_home

--- a/dipy/data/tests/test_fetcher.py
+++ b/dipy/data/tests/test_fetcher.py
@@ -104,3 +104,19 @@ def test_fetch_data():
         server.shutdown()
         # change to original working directory
         os.chdir(current_dir)
+
+    def test_dipy_home():
+        test_path = 'TEST_PATH'
+        if 'DIPY_HOME' in os.environ:
+            old_home = os.environ['DIPY_HOME']
+            del os.environ['DIPY_HOME']
+        else:
+            old_home = None
+
+        reload(fetcher)
+
+        npt.assert_string_equal(fetcher.dipy_home,
+                                op.join(os.path.expanduser('~'), '.dipy'))
+        os.environ['DIPY_HOME'] = test_path
+        reload(fetcher)
+        npt.assert_string_equal(fetcher.dipy_home, test_path)


### PR DESCRIPTION
The fetcher module defines a path based from the users home directory. This can cause a problem when running in a cluster environment where the home directory can be machine specific.

This PR enables an environment variable DIPY_HOME to override the default setting.