### PR TITLE
BUG: Fix non-ASCII characters in reconst_dki.py example.

### DIFF
--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -368,7 +368,7 @@ References:
                 axonal loss and demyelination in brain white matter.
                 Proceedings of the 20th Annual Meeting of the International
                 Society for Magnetic Resonance Medicine; Melbourne, Australia.
-                May 5–11.
+                May 5-11.
 .. [Hansen2016] Hansen, B, Jespersen, SN (2016). Data for evaluation of fast
                 kurtosis strategies, b-value optimization and exploration of
                 diffusion MRI contrast. Scientific Data 3: 160072


### PR DESCRIPTION
Non-ASCII characters were introduced in the reconst_dki.py example;
since no encoding was specified in that file, a syntax error was being
reported by Python.