### PR TITLE
New hdf5 file format for saving PeaksAndMetrics objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 env:
     global:
-        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt tables"
+        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt"
         - VENV_ARGS="--python=python"
         - INSTALL_TYPE="setup"
         - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -42,6 +42,7 @@ matrix:
         - DEPENDS="$DEPENDS scikit_learn tables"
     - python: 3.5
       env:
+        - COVERAGE=1
         - DEPENDS="$DEPENDS scikit_learn tables"
     # To test vtk functionality
     - python: 2.7
@@ -53,6 +54,8 @@ matrix:
         - LIBGL_ALWAYS_INDIRECT=y
         - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
         - TEST_WITH_XVFB=true
+        - DEPENDS="$DEPENDS scikit_learn tables"
+
     - python: 2.7
       env:
         - INSTALL_TYPE=sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
         - LIBGL_ALWAYS_INDIRECT=y
         - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
         - TEST_WITH_XVFB=true
+        - DEPENDS="$DEPENDS tables"
     - python: 2.7
       env:
         - INSTALL_TYPE=sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 env:
     global:
-        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt"
+        - DEPENDS="cython numpy scipy matplotlib h5py nibabel cvxopt tables"
         - VENV_ARGS="--python=python"
         - INSTALL_TYPE="setup"
         - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -53,7 +53,6 @@ matrix:
         - LIBGL_ALWAYS_INDIRECT=y
         - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
         - TEST_WITH_XVFB=true
-        - DEPENDS="$DEPENDS tables"
     - python: 2.7
       env:
         - INSTALL_TYPE=sdist

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -217,16 +217,16 @@ def save_peaks(fname, pam, affine=None, verbose=False):
         print('PAM5 version')
         print(version_string)
         print('Affine')
-        print(pam.affine)
+        print(affine)
         print('Dirs shape')
         print(pam.peak_dirs.shape)
         print('SH shape')
-        if pam.shm_coeff is not None:
-            print(pam.shm_coeff.shape)
+        if shm_coeff is not None:
+            print(shm_coeff.shape)
         else:
             print('None')
         print('ODF shape')
-        if pam.odf is not None:
+        if odf is not None:
             print(pam.odf.shape)
         else:
             print('None')

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -44,7 +44,7 @@ def _safe_save(f, group, array, name):
 
 
 def load_peaks(fname, verbose=False):
-    """ Load PeaksAndMetrics PAM5 file (HDF5)
+    """ Load a PeaksAndMetrics HDF5 file (PAM5)
 
     Parameters
     ----------
@@ -118,9 +118,15 @@ def load_peaks(fname, verbose=False):
         print('Dirs shape')
         print(pam.peak_dirs.shape)
         print('SH shape')
-        print(pam.shm_coeff.shape)
+        if pam.shm_coeff is not None:
+            print(pam.shm_coeff.shape)
+        else:
+            print('None')
         print('ODF shape')
-        print(pam.odf.shape)
+        if pam.odf is not None:
+            print(pam.odf.shape)
+        else:
+            print('None')
         print('Total weight')
         print(pam.total_weight)
         print('Angular threshold')
@@ -132,9 +138,8 @@ def load_peaks(fname, verbose=False):
 
 
 def save_peaks(fname, pam, affine=None, verbose=False):
-    """ Save PAM5 file (HDF5) with all important attributes of object
-
-    PeaksAndMetrics
+    """ Save all important attributes of object PeaksAndMetrics in a PAM5 file
+    (HDF5).
 
     Parameters
     ----------
@@ -176,42 +181,58 @@ def save_peaks(fname, pam, affine=None, verbose=False):
     group = func_create_group(f.root, 'pam')
     version = func_create_array(f.root, 'version',
                                 [b"0.0.1"], 'PAM5 version number')
+    version_string = f.root.version[0].decode()
 
     try:
         affine = pam.affine
     except AttributeError:
         pass
 
+    try:
+        shm_coeff = pam.shm_coeff
+    except AttributeError:
+        shm_coeff = None
+
+    try:
+        odf = pam.odf
+    except AttributeError:
+        odf = None
+
     _safe_save(f, group, affine, 'affine')
     _safe_save(f, group, pam.peak_dirs, 'peak_dirs')
     _safe_save(f, group, pam.peak_values, 'peak_values')
     _safe_save(f, group, pam.peak_indices, 'peak_indices')
-    _safe_save(f, group, pam.shm_coeff, 'shm_coeff')
+    _safe_save(f, group, shm_coeff, 'shm_coeff')
     _safe_save(f, group, pam.sphere.vertices, 'sphere_vertices')
     _safe_save(f, group, pam.B, 'B')
     _safe_save(f, group, np.array([pam.total_weight]), 'total_weight')
     _safe_save(f, group, np.array([pam.ang_thr]), 'ang_thr')
     _safe_save(f, group, pam.gfa, 'gfa')
     _safe_save(f, group, pam.qa, 'qa')
-    _safe_save(f, group, pam.odf, 'odf')
+    _safe_save(f, group, odf, 'odf')
 
     f.close()
 
     if verbose:
         print('PAM5 version')
-        print(version)
+        print(version_string)
         print('Affine')
         print(pam.affine)
         print('Dirs shape')
         print(pam.peak_dirs.shape)
         print('SH shape')
-        print(pam.shm_coeff.shape)
+        if pam.shm_coeff is not None:
+            print(pam.shm_coeff.shape)
+        else:
+            print('None')
         print('ODF shape')
-        print(pam.odf.shape)
+        if pam.odf is not None:
+            print(pam.odf.shape)
+        else:
+            print('None)
         print('Total weight')
         print(pam.total_weight)
         print('Angular threshold')
         print(pam.ang_thr)
         print('Sphere vertices shape')
         print(pam.sphere.vertices.shape)
-

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -69,7 +69,6 @@ def load_peaks(fname, verbose=False):
     pamh = f.root.pam
 
     version = f.root.version[0].decode()
-    print(version[0].decode())
 
     try:
         affine = pamh.affine[:]

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -47,8 +47,15 @@ def _safe_save(f, group, array, name):
         ds[:] = array
 
 
-def load_peaks(fname, verbose=True):
-    """ Load PeaksAndMetrics PAM file (HDF5)
+def load_peaks(fname, verbose=False):
+    """ Load PeaksAndMetrics PAM5 file (HDF5)
+
+    Parameters
+    ----------
+    fname : string
+        Filename of PAM5 file.
+    verbose : bool
+        Print summary information about the loaded file.
     """
 
     if TABLES_LESS_3_0:
@@ -133,7 +140,15 @@ def load_peaks(fname, verbose=True):
 
 
 def save_peaks(fname, pam):
-    """ Save NPZ file with all important attributes of object PeaksAndMetrics
+    """ Save PAM5 file (HDF5) with all important attributes of object
+    PeaksAndMetrics
+
+    Parameters
+    ----------
+    fname : string
+        Filenam of PAM5 file
+    pam : PeakAndMetrics
+        Object holding peak_dirs, shm_coeffs and other attributes
     """
 
     if TABLES_LESS_3_0:

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -229,7 +229,7 @@ def save_peaks(fname, pam, affine=None, verbose=False):
         if pam.odf is not None:
             print(pam.odf.shape)
         else:
-            print('None)
+            print('None')
         print('Total weight')
         print(pam.total_weight)
         print('Angular threshold')

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -25,21 +25,6 @@ from dipy.data import get_sphere
 from dipy.core.sphere import Sphere
 
 
-def _safe_load(arr):
-    """ Safe loading of values from HDF5 file
-
-    Parameters
-    ----------
-    arr : array or scalar
-    """
-
-    try:
-        return arr[:]
-    except: #tables.exceptions.NoSuchNodeError:
-        print('Honolulu')
-        return None
-
-
 def _safe_save(f, group, array, name):
     """ Safe saving of arrays with specific names
 
@@ -82,29 +67,60 @@ def load_peaks(fname, verbose=True):
     except tables.NoSuchNodeError:
         affine = None
 
+    try:
+        peak_dirs = pamh.peak_dirs[:]
+    except tables.NoSuchNodeError:
+        peak_dirs = None
+
+    try:
+        peak_values = pamh.peak_values[:]
+    except tables.NoSuchNodeError:
+        peak_values = None
+
+    try:
+        peak_indices = pamh.peak_indices[:]
+    except tables.NoSuchNodeError:
+        peak_indices = None
+
+    try:
+        shm_coeff = pamh.shm_coeff[:]
+    except tables.NoSuchNodeError:
+        shm_coeff = None
+
+    try:
+        sphere_vertices = pamh.sphere_vertices[:]
+    except tables.NoSuchNodeError:
+        sphere_vertices = None
+
+    try:
+        odf = pamh.odf[:]
+    except tables.NoSuchNodeError:
+        odf = None
+
+
     pam.affine = affine
-    pam.peak_dirs = _safe_load(pamh.peak_dirs)
-    pam.peak_values = _safe_load(pamh.peak_values)
-    pam.peak_indices = _safe_load(pamh.peak_indices)
-    pam.shm_coeff = _safe_load(pamh.shm_coeff)
-    pam.sphere = Sphere(xyz=_safe_load(pamh.sphere_vertices))
-    pam.B = _safe_load(pamh.B)
-    pam.total_weight = _safe_load(pamh.total_weight)[0]
-    pam.ang_thr = _safe_load(pamh.ang_thr)[0]
-    pam.gfa = _safe_load(pamh.gfa)
-    pam.qa = _safe_load(pamh.qa)
-    pam.odf = _safe_load(pamh.odf)
+    pam.peak_dirs = peak_dirs
+    pam.peak_values = peak_values
+    pam.peak_indices = peak_indices
+    pam.shm_coeff = shm_coeff
+    pam.sphere = Sphere(xyz=pamh.sphere_vertices)
+    pam.B = pamh.B[:]
+    pam.total_weight = pamh.total_weight[:][0]
+    pam.ang_thr = pamh.ang_thr[:][0]
+    pam.gfa = pamh.gfa[:]
+    pam.qa = pamh.qa[:]
+    pam.odf = odf
 
     f.close()
 
     if verbose:
         print('Affine')
         print(pam.affine)
-        print('Dirs Shape')
+        print('Dirs shape')
         print(pam.peak_dirs.shape)
-        print('SH Shape')
+        print('SH shape')
         print(pam.shm_coeff.shape)
-        print('ODF')
+        print('ODF shape')
         print(pam.odf.shape)
         print('Total weight')
         print(pam.total_weight)

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -147,7 +147,7 @@ def save_peaks(fname, pam, affine=None, verbose=False):
     Parameters
     ----------
     fname : string
-        Filenam of PAM5 file
+        Filename of PAM5 file
     pam : PeaksAndMetrics
         Object holding peak_dirs, shm_coeffs and other attributes
     affine : array
@@ -164,7 +164,9 @@ def save_peaks(fname, pam, affine=None, verbose=False):
     if not (hasattr(pam, 'peak_dirs') and hasattr(pam, 'peak_values') and
             hasattr(pam, 'peak_indices')):
 
-        raise ValueError('Cannot save object without peak_dirs/values/indices')
+        msg = 'Cannot save object without peak_dirs, peak_values'
+        msg += ' and peak_indices'
+        raise ValueError(msg)
 
     if TABLES_LESS_3_0:
         func_open_file = tables.openFile

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -1,0 +1,151 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+
+from dipy.core.sphere import Sphere
+from dipy.direction.peaks import (PeaksAndMetrics,
+                                  reshape_peaks_for_visualization)
+from distutils.version import LooseVersion
+from dipy.reconst.peaks import PeaksAndMetrics
+
+# Conditional testing machinery for pytables
+from dipy.testing import doctest_skip_parser
+
+# Conditional import machinery for pytables
+from dipy.utils.optpkg import optional_package
+
+# Allow import, but disable doctests, if we don't have pytables
+tables, have_tables, _ = optional_package('tables')
+
+# Useful variable for backward compatibility.
+if have_tables:
+    TABLES_LESS_3_0 = LooseVersion(tables.__version__) < "3.0"
+
+from dipy.data import get_sphere
+from dipy.core.sphere import Sphere
+
+
+def _safe_load(arr):
+    """ Safe loading of values from HDF5 file
+
+    Parameters
+    ----------
+    arr : array or scalar
+    """
+
+    try:
+        return arr[:]
+    except: #tables.exceptions.NoSuchNodeError:
+        print('Honolulu')
+        return None
+
+
+def _safe_save(f, group, array, name):
+    """ Safe saving of arrays with specific names
+
+    Parameters
+    ----------
+    f : HDF5 file handle
+    group : HDF5 group
+    array : array
+    name : string
+    """
+
+    if TABLES_LESS_3_0:
+        func_create_carray = f.createCArray
+    else:
+        func_create_carray = f.create_carray
+
+    if array is not None:
+        atom = tables.Atom.from_dtype(array.dtype)
+        ds = func_create_carray(group, name, atom, array.shape)
+        ds[:] = array
+
+
+def load_peaks(fname, verbose=True):
+    """ Load PeaksAndMetrics PAM file (HDF5)
+    """
+
+    if TABLES_LESS_3_0:
+        func_open_file = tables.openFile
+    else:
+        func_open_file = tables.open_file
+
+    f = func_open_file(fname, 'r')
+
+    pam = PeaksAndMetrics()
+
+    pamh = f.root.pam
+
+    try:
+        affine = pamh.affine[:]
+    except tables.NoSuchNodeError:
+        affine = None
+
+    pam.affine = affine
+    pam.peak_dirs = _safe_load(pamh.peak_dirs)
+    pam.peak_values = _safe_load(pamh.peak_values)
+    pam.peak_indices = _safe_load(pamh.peak_indices)
+    pam.shm_coeff = _safe_load(pamh.shm_coeff)
+    pam.sphere = Sphere(xyz=_safe_load(pamh.sphere_vertices))
+    pam.B = _safe_load(pamh.B)
+    pam.total_weight = _safe_load(pamh.total_weight)[0]
+    pam.ang_thr = _safe_load(pamh.ang_thr)[0]
+    pam.gfa = _safe_load(pamh.gfa)
+    pam.qa = _safe_load(pamh.qa)
+    pam.odf = _safe_load(pamh.odf)
+
+    f.close()
+
+    if verbose:
+        print('Affine')
+        print(pam.affine)
+        print('Dirs Shape')
+        print(pam.peak_dirs.shape)
+        print('SH Shape')
+        print(pam.shm_coeff.shape)
+        print('ODF')
+        print(pam.odf.shape)
+        print('Total weight')
+        print(pam.total_weight)
+        print('Angular threshold')
+        print(pam.ang_thr)
+        print('Sphere vertices shape')
+        print(pam.sphere.vertices.shape)
+
+    return pam
+
+
+def save_peaks(fname, pam):
+    """ Save NPZ file with all important attributes of object PeaksAndMetrics
+    """
+
+    if TABLES_LESS_3_0:
+        func_open_file = tables.openFile
+    else:
+        func_open_file = tables.open_file
+
+    f = func_open_file(fname, 'w')
+
+    if TABLES_LESS_3_0:
+        func_create_group = f.createGroup
+    else:
+        func_create_group = f.create_group
+
+    group = func_create_group(f.root, 'pam')
+
+    _safe_save(f, group, pam.affine, 'affine')
+    _safe_save(f, group, pam.peak_dirs, 'peak_dirs')
+    _safe_save(f, group, pam.peak_values, 'peak_values')
+    _safe_save(f, group, pam.peak_indices, 'peak_indices')
+    _safe_save(f, group, pam.shm_coeff, 'shm_coeff')
+    _safe_save(f, group, pam.sphere.vertices, 'sphere_vertices')
+    _safe_save(f, group, pam.B, 'B')
+    _safe_save(f, group, np.array([pam.total_weight]), 'total_weight')
+    _safe_save(f, group, np.array([pam.ang_thr]), 'ang_thr')
+    _safe_save(f, group, pam.B, 'gfa')
+    _safe_save(f, group, pam.B, 'qa')
+    _safe_save(f, group, pam.B, 'odf')
+
+    f.close()
+

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -162,7 +162,6 @@ def save_peaks(fname, pam, affine=None, verbose=False):
             hasattr(pam, 'peak_indices')):
 
         raise ValueError('Cannot save object without peak_dirs/values/indices')
-        return
 
     if TABLES_LESS_3_0:
         func_open_file = tables.openFile

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -74,6 +74,9 @@ def load_peaks(fname, verbose=False):
 
     version = f.root.version[0].decode()
 
+    if version != '0.0.1':
+        raise IOError('Incorrect PAM5 file version')
+
     try:
         affine = pamh.affine[:]
     except tables.NoSuchNodeError:

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
+import os
 import numpy as np
 
 from dipy.core.sphere import Sphere
@@ -56,6 +57,9 @@ def load_peaks(fname, verbose=False):
     -------
     pam : PeaksAndMetrics object
     """
+
+    if os.path.splitext(fname)[1] != '.pam5':
+        raise IOError('This function supports only PAM5 (HDF5) files')
 
     if TABLES_LESS_3_0:
         func_open_file = tables.openFile
@@ -142,7 +146,7 @@ def load_peaks(fname, verbose=False):
     return pam
 
 
-def save_peaks(fname, pam, affine=None):
+def save_peaks(fname, pam, affine=None, verbose=False):
     """ Save PAM5 file (HDF5) with all important attributes of object
 
     PeaksAndMetrics
@@ -157,15 +161,18 @@ def save_peaks(fname, pam, affine=None):
         The 4x4 matrix transforming the date from native to world coordinates.
         PeaksAndMetrics should have that attribute but if not it can be
         provided here. Default None.
+    verbose : bool
+        Print summary information about the saved file.
     """
 
-    if not (hasattr(pam, 'peak_dirs') \
-        and hasattr(pam, 'peak_values') \
-        and hasattr(pam, 'peak_indices')):
+    if os.path.splitext(fname)[1] != '.pam5':
+        raise IOError('This function saves only PAM5 (HDF5) files')
+
+    if not (hasattr(pam, 'peak_dirs') and hasattr(pam, 'peak_values') and
+            hasattr(pam, 'peak_indices')):
 
         raise ValueError('Cannot save object without peak_dirs/values/indices')
         return
-
 
     if TABLES_LESS_3_0:
         func_open_file = tables.openFile
@@ -190,7 +197,6 @@ def save_peaks(fname, pam, affine=None):
     except AttributeError:
         pass
 
-
     _safe_save(f, group, affine, 'affine')
     _safe_save(f, group, pam.peak_dirs, 'peak_dirs')
     _safe_save(f, group, pam.peak_values, 'peak_values')
@@ -205,4 +211,22 @@ def save_peaks(fname, pam, affine=None):
     _safe_save(f, group, pam.odf, 'odf')
 
     f.close()
+
+    if verbose:
+        print('PAM5 version')
+        print(pam.version)
+        print('Affine')
+        print(pam.affine)
+        print('Dirs shape')
+        print(pam.peak_dirs.shape)
+        print('SH shape')
+        print(pam.shm_coeff.shape)
+        print('ODF shape')
+        print(pam.odf.shape)
+        print('Total weight')
+        print(pam.total_weight)
+        print('Angular threshold')
+        print(pam.ang_thr)
+        print('Sphere vertices shape')
+        print(pam.sphere.vertices.shape)
 

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -79,37 +79,22 @@ def load_peaks(fname, verbose=False):
     except tables.NoSuchNodeError:
         affine = None
 
-    try:
-        peak_dirs = pamh.peak_dirs[:]
-    except tables.NoSuchNodeError:
-        peak_dirs = None
-
-    try:
-        peak_values = pamh.peak_values[:]
-    except tables.NoSuchNodeError:
-        peak_values = None
-
-    try:
-        peak_indices = pamh.peak_indices[:]
-    except tables.NoSuchNodeError:
-        peak_indices = None
+    peak_dirs = pamh.peak_dirs[:]
+    peak_values = pamh.peak_values[:]
+    peak_indices = pamh.peak_indices[:]
 
     try:
         shm_coeff = pamh.shm_coeff[:]
     except tables.NoSuchNodeError:
         shm_coeff = None
 
-    try:
-        sphere_vertices = pamh.sphere_vertices[:]
-    except tables.NoSuchNodeError:
-        sphere_vertices = None
+    sphere_vertices = pamh.sphere_vertices[:]
 
     try:
         odf = pamh.odf[:]
     except tables.NoSuchNodeError:
         odf = None
 
-    pam.version = version
     pam.affine = affine
     pam.peak_dirs = peak_dirs
     pam.peak_values = peak_values
@@ -127,7 +112,7 @@ def load_peaks(fname, verbose=False):
 
     if verbose:
         print('PAM5 version')
-        print(pam.version)
+        print(version)
         print('Affine')
         print(pam.affine)
         print('Dirs shape')
@@ -214,7 +199,7 @@ def save_peaks(fname, pam, affine=None, verbose=False):
 
     if verbose:
         print('PAM5 version')
-        print(pam.version)
+        print(version)
         print('Affine')
         print(pam.affine)
         print('Dirs shape')

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -39,7 +39,7 @@ def test_io_peaks():
     verbose = True
 
     pam = PeaksAndMetrics()
-    pam.affine = np.eye(4)
+    pam.affine = None
     pam.peak_dirs = np.zeros((10, 10, 10, 5, 3))
     pam.peak_values = np.zeros((10, 10, 10, 5))
     pam.peak_indices = np.zeros((10, 10, 10, 5))
@@ -64,10 +64,30 @@ def test_io_peaks():
         func_create_earray = f.create_earray
 
     group = func_create_group(f.root, 'pam')
-    x = pam.affine
-    atom = tables.Atom.from_dtype(x.dtype)
-    ds = func_create_carray(group, 'affine', atom, x.shape)
-    ds[:] = x
+
+    def save_array(group, x, name):
+
+        if x is None:
+            atom = tables.Atom.from_dtype(np.int)
+            ds = func_create_carray(group, name, atom)
+        else:
+            atom = tables.Atom.from_dtype(x.dtype)
+            ds = func_create_carray(group, name, atom, x.shape)
+            ds[:] = x
+
+    save_array(group, pam.affine, 'affine')
+    save_array(group, pam.peak_dirs, 'peak_dirs')
+    save_array(group, pam.peak_values, 'peak_values')
+    save_array(group, pam.peak_indices, 'peak_indices')
+    save_array(group, pam.shm_coeff, 'shm_coeff')
+    save_array(group, pam.sphere.vertices, 'sphere')
+    save_array(group, pam.B, 'B')
+    save_array(group, np.array([pam.total_weight]), 'total_weight')
+    save_array(group, np.array([pam.ang_thr]), 'ang_thr')
+    save_array(group, pam.B, 'gfa')
+    save_array(group, pam.B, 'qa')
+    save_array(group, pam.B, 'odf')
+
     f.close()
 
     f2 = func_open_file(fname, 'r')

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -1,0 +1,95 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+import numpy.testing as npt
+
+from distutils.version import LooseVersion
+from dipy.reconst.peaks import PeaksAndMetrics
+
+# Conditional testing machinery for pytables
+from dipy.testing import doctest_skip_parser
+
+# Conditional import machinery for pytables
+from dipy.utils.optpkg import optional_package
+
+# Allow import, but disable doctests, if we don't have pytables
+tables, have_tables, _ = optional_package('tables')
+
+# Useful variable for backward compatibility.
+if have_tables:
+    TABLES_LESS_3_0 = LooseVersion(tables.__version__) < "3.0"
+
+from dipy.data import get_sphere
+from dipy.core.sphere import Sphere
+
+# Make sure not to carry across setup module from * import
+# __all__ = ['']
+
+
+def test_io_peaks():
+
+    fname = 'test.pam'
+
+    if TABLES_LESS_3_0:
+        func_open_file = tables.openFile
+    else:
+        func_open_file = tables.open_file
+
+    sphere = get_sphere('repulsion724')
+    verbose = True
+
+    pam = PeaksAndMetrics()
+    pam.affine = np.eye(4)
+    pam.peak_dirs = np.zeros((10, 10, 10, 5, 3))
+    pam.peak_values = np.zeros((10, 10, 10, 5))
+    pam.peak_indices = np.zeros((10, 10, 10, 5))
+    pam.shm_coeff = np.zeros((10, 10, 10, 45))
+    pam.sphere = Sphere(xyz=sphere.vertices)
+    pam.B = np.zeros((45, sphere.vertices.shape[0]))
+    pam.total_weight = 0.5
+    pam.ang_thr = 60
+    pam.gfa = np.zeros((10, 10, 10))
+    pam.qa = np.zeros((10, 10, 10, 5))
+    pam.odf = np.zeros((10, 10, 10, sphere.vertices.shape[0]))
+
+    f = func_open_file(fname, 'w')
+
+    if TABLES_LESS_3_0:
+        func_create_group = f.createGroup
+        func_create_carray = f.createCArray
+        func_create_earray = f.createEArray
+    else:
+        func_create_group = f.create_group
+        func_create_carray = f.create_carray
+        func_create_earray = f.create_earray
+
+    group = func_create_group(f.root, 'pam')
+    x = pam.affine
+    atom = tables.Atom.from_dtype(x.dtype)
+    ds = func_create_carray(group, 'affine', atom, x.shape)
+    ds[:] = x
+    f.close()
+
+    f2 = func_open_file(fname, 'r')
+
+    print(f2.root.pam.affine)
+    f2.close()
+
+
+    if verbose:
+        print('Affine')
+        print(pam.affine)
+        print('Dirs Shape')
+        print(pam.peak_dirs.shape)
+        print('SH Shape')
+        print(pam.shm_coeff.shape)
+        print('ODF')
+        print(pam.odf.shape)
+        print('Total weight')
+        print(pam.total_weight)
+        print('Angular threshold')
+        print(pam.ang_thr)
+        print('Sphere vertices shape')
+        print(pam.sphere.vertices.shape)
+
+test_io_peaks()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -54,10 +54,16 @@ def test_io_peaks():
 
         fname2 = 'test2.pam'
         save_peaks(fname2, pam2)
+
         pam3 = load_peaks(fname2, verbose=True)
         npt.assert_equal(pam3.total_weight, pam.total_weight)
+
+        fname3 = 'test3.pam'
+        #pam4 = PeaksAndMetrics()
+        #save_peaks(fname3, pam4)
 
 
 if __name__ == '__main__':
 
-    npt.run_module_suite()
+    #npt.run_module_suite()
+    test_io_peaks()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -7,25 +7,23 @@ from distutils.version import LooseVersion
 from dipy.reconst.peaks import PeaksAndMetrics
 from nibabel.tmpdirs import InTemporaryDirectory
 
-# Conditional testing machinery for pytables
-from dipy.testing import doctest_skip_parser
-
 # Conditional import machinery for pytables
 from dipy.utils.optpkg import optional_package
 
 # Allow import, but disable doctests, if we don't have pytables
 tables, have_tables, _ = optional_package('tables')
 
-# Useful variable for backward compatibility.
-if have_tables:
-    TABLES_LESS_3_0 = LooseVersion(tables.__version__) < "3.0"
-
 from dipy.data import get_sphere
 from dipy.core.sphere import Sphere
 
 from dipy.io.peaks import load_peaks, save_peaks
 
+# Decorator to protect tests from being run without pytables present
+iftables = npt.dec.skipif(not have_tables,
+                          'Pytables does not appear to be installed')
 
+
+@iftables
 def test_io_peaks():
 
     with InTemporaryDirectory():
@@ -50,16 +48,13 @@ def test_io_peaks():
 
         save_peaks(fname, pam)
         pam2 = load_peaks(fname, verbose=True)
-        npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
+        #npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
 
-        pam2.affine = None
+        #pam2.affine = None
 
-        fname2 = 'test2.pam'
-        save_peaks(fname2, pam2)
-        pam3 = load_peaks(fname2, verbose=True)
-
-
-
+        #fname2 = 'test2.pam'
+        #save_peaks(fname2, pam2)
+        #pam3 = load_peaks(fname2, verbose=True)
 
 
 

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -83,6 +83,8 @@ def test_io_peaks():
         pam.shm_coeff = np.zeros((10, 10, 10, 45))
         del pam.odf
         save_peaks(fname6, pam)
+        pam_tmp = load_peaks(fname6, True)
+        npt.assert_equal(pam_tmp.odf, None)
 
 
 if __name__ == '__main__':

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -56,11 +56,16 @@ def test_io_peaks():
         save_peaks(fname2, pam2)
 
         pam3 = load_peaks(fname2, verbose=False)
+
+        for attr in ['peak_dirs', 'peak_values', 'peak_indices',
+                     'gfa', 'qa', 'shm_coeff', 'B', 'odf']:
+            npt.assert_array_equal(getattr(pam3, attr),
+                                   getattr(pam, attr))
+
         npt.assert_equal(pam3.total_weight, pam.total_weight)
         npt.assert_equal(pam3.ang_thr, pam.ang_thr)
-        npt.assert_equal(pam3.gfa, pam.gfa)
-        npt.assert_equal(pam3.qa, pam.qa)
-        npt.assert_equal(pam3.odf, pam.odf)
+        npt.assert_array_almost_equal(pam3.sphere.vertices,
+                                      pam.sphere.vertices)
 
         fname3 = 'test3.pam5'
         pam4 = PeaksAndMetrics()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -48,14 +48,16 @@ def test_io_peaks():
 
         save_peaks(fname, pam)
         pam2 = load_peaks(fname, verbose=True)
-        #npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
+        npt.assert_array_equal(pam.peak_dirs, pam2.peak_dirs)
 
-        #pam2.affine = None
+        pam2.affine = None
 
-        #fname2 = 'test2.pam'
-        #save_peaks(fname2, pam2)
-        #pam3 = load_peaks(fname2, verbose=True)
+        fname2 = 'test2.pam'
+        save_peaks(fname2, pam2)
+        pam3 = load_peaks(fname2, verbose=True)
+        npt.assert_equal(pam2.total_weight, pam.total_weight)
 
 
+if __name__ == '__main__':
 
-test_io_peaks()
+    npt.run_module_suite()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -5,6 +5,7 @@ import numpy.testing as npt
 
 from distutils.version import LooseVersion
 from dipy.reconst.peaks import PeaksAndMetrics
+from nibabel.tmpdirs import InTemporaryDirectory
 
 # Conditional testing machinery for pytables
 from dipy.testing import doctest_skip_parser
@@ -28,88 +29,88 @@ from dipy.core.sphere import Sphere
 
 def test_io_peaks():
 
-    fname = 'test.pam'
+    with InTemporaryDirectory():
 
-    if TABLES_LESS_3_0:
-        func_open_file = tables.openFile
-    else:
-        func_open_file = tables.open_file
+        fname = 'test.pam'
 
-    sphere = get_sphere('repulsion724')
-    verbose = True
-
-    pam = PeaksAndMetrics()
-    pam.affine = None
-    pam.peak_dirs = np.zeros((10, 10, 10, 5, 3))
-    pam.peak_values = np.zeros((10, 10, 10, 5))
-    pam.peak_indices = np.zeros((10, 10, 10, 5))
-    pam.shm_coeff = np.zeros((10, 10, 10, 45))
-    pam.sphere = Sphere(xyz=sphere.vertices)
-    pam.B = np.zeros((45, sphere.vertices.shape[0]))
-    pam.total_weight = 0.5
-    pam.ang_thr = 60
-    pam.gfa = np.zeros((10, 10, 10))
-    pam.qa = np.zeros((10, 10, 10, 5))
-    pam.odf = np.zeros((10, 10, 10, sphere.vertices.shape[0]))
-
-    f = func_open_file(fname, 'w')
-
-    if TABLES_LESS_3_0:
-        func_create_group = f.createGroup
-        func_create_carray = f.createCArray
-        func_create_earray = f.createEArray
-    else:
-        func_create_group = f.create_group
-        func_create_carray = f.create_carray
-        func_create_earray = f.create_earray
-
-    group = func_create_group(f.root, 'pam')
-
-    def save_array(group, x, name):
-
-        if x is None:
-            atom = tables.Atom.from_dtype(np.int)
-            ds = func_create_carray(group, name, atom)
+        if TABLES_LESS_3_0:
+            func_open_file = tables.openFile
         else:
-            atom = tables.Atom.from_dtype(x.dtype)
-            ds = func_create_carray(group, name, atom, x.shape)
-            ds[:] = x
+            func_open_file = tables.open_file
 
-    save_array(group, pam.affine, 'affine')
-    save_array(group, pam.peak_dirs, 'peak_dirs')
-    save_array(group, pam.peak_values, 'peak_values')
-    save_array(group, pam.peak_indices, 'peak_indices')
-    save_array(group, pam.shm_coeff, 'shm_coeff')
-    save_array(group, pam.sphere.vertices, 'sphere')
-    save_array(group, pam.B, 'B')
-    save_array(group, np.array([pam.total_weight]), 'total_weight')
-    save_array(group, np.array([pam.ang_thr]), 'ang_thr')
-    save_array(group, pam.B, 'gfa')
-    save_array(group, pam.B, 'qa')
-    save_array(group, pam.B, 'odf')
+        sphere = get_sphere('repulsion724')
+        verbose = True
 
-    f.close()
+        pam = PeaksAndMetrics()
+        pam.affine = np.eye(4)
+        pam.peak_dirs = np.zeros((10, 10, 10, 5, 3))
+        pam.peak_values = np.zeros((10, 10, 10, 5))
+        pam.peak_indices = np.zeros((10, 10, 10, 5))
+        pam.shm_coeff = np.zeros((10, 10, 10, 45))
+        pam.sphere = Sphere(xyz=sphere.vertices)
+        pam.B = np.zeros((45, sphere.vertices.shape[0]))
+        pam.total_weight = 0.5
+        pam.ang_thr = 60
+        pam.gfa = np.zeros((10, 10, 10))
+        pam.qa = np.zeros((10, 10, 10, 5))
+        pam.odf = np.zeros((10, 10, 10, sphere.vertices.shape[0]))
 
-    f2 = func_open_file(fname, 'r')
+        f = func_open_file(fname, 'w')
 
-    print(f2.root.pam.affine)
-    f2.close()
+        if TABLES_LESS_3_0:
+            func_create_group = f.createGroup
+            func_create_array = f.createArray
+            func_create_carray = f.createCArray
+            func_create_earray = f.createEArray
+        else:
+            func_create_group = f.create_group
+            func_create_array = f.create_array
+            func_create_carray = f.create_carray
+            func_create_earray = f.create_earray
 
+        group = func_create_group(f.root, 'pam')
 
-    if verbose:
-        print('Affine')
-        print(pam.affine)
-        print('Dirs Shape')
-        print(pam.peak_dirs.shape)
-        print('SH Shape')
-        print(pam.shm_coeff.shape)
-        print('ODF')
-        print(pam.odf.shape)
-        print('Total weight')
-        print(pam.total_weight)
-        print('Angular threshold')
-        print(pam.ang_thr)
-        print('Sphere vertices shape')
-        print(pam.sphere.vertices.shape)
+        def save_array(group, x, name):
+
+            if x is not None:
+                atom = tables.Atom.from_dtype(x.dtype)
+                ds = func_create_carray(group, name, atom, x.shape)
+                ds[:] = x
+
+        save_array(group, pam.affine, 'affine')
+        save_array(group, pam.peak_dirs, 'peak_dirs')
+        save_array(group, pam.peak_values, 'peak_values')
+        save_array(group, pam.peak_indices, 'peak_indices')
+        save_array(group, pam.shm_coeff, 'shm_coeff')
+        save_array(group, pam.sphere.vertices, 'sphere_vertices')
+        save_array(group, pam.B, 'B')
+        save_array(group, np.array([pam.total_weight]), 'total_weight')
+        save_array(group, np.array([pam.ang_thr]), 'ang_thr')
+        save_array(group, pam.B, 'gfa')
+        save_array(group, pam.B, 'qa')
+        save_array(group, pam.B, 'odf')
+
+        f.close()
+
+        f2 = func_open_file(fname, 'r')
+
+        print(f2.root.pam.affine)
+        f2.close()
+
+        if verbose:
+            print('Affine')
+            print(pam.affine)
+            print('Dirs Shape')
+            print(pam.peak_dirs.shape)
+            print('SH Shape')
+            print(pam.shm_coeff.shape)
+            print('ODF')
+            print(pam.odf.shape)
+            print('Total weight')
+            print(pam.total_weight)
+            print('Angular threshold')
+            print(pam.ang_thr)
+            print('Sphere vertices shape')
+            print(pam.sphere.vertices.shape)
 
 test_io_peaks()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -28,7 +28,7 @@ def test_io_peaks():
 
     with InTemporaryDirectory():
 
-        fname = 'test.pam'
+        fname = 'test.pam5'
 
         sphere = get_sphere('repulsion724')
 
@@ -52,7 +52,7 @@ def test_io_peaks():
 
         pam2.affine = None
 
-        fname2 = 'test2.pam'
+        fname2 = 'test2.pam5'
         save_peaks(fname2, pam2)
 
         pam3 = load_peaks(fname2, verbose=False)
@@ -62,13 +62,27 @@ def test_io_peaks():
         npt.assert_equal(pam3.qa, pam.qa)
         npt.assert_equal(pam3.odf, pam.odf)
 
-        fname3 = 'test3.pam'
+        fname3 = 'test3.pam5'
         pam4 = PeaksAndMetrics()
         npt.assert_raises(ValueError, save_peaks, fname3, pam4)
 
-        fname4 = 'test4.pam'
+        fname4 = 'test4.pam5'
         del pam.affine
         save_peaks(fname4, pam, affine=None)
+
+        fname5 = 'test5.pkm'
+        npt.assert_raises(IOError, save_peaks, fname5, pam)
+
+        pam.affine = np.eye(4)
+        fname6 = 'test6.pam5'
+        save_peaks(fname6, pam, verbose=True)
+
+        del pam.shm_coeff
+        save_peaks(fname6, pam, verbose=False)
+
+        pam.shm_coeff = np.zeros((10, 10, 10, 45))
+        del pam.odf
+        save_peaks(fname6, pam)
 
 
 if __name__ == '__main__':

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -38,7 +38,7 @@ def test_io_peaks():
         pam.peak_values = np.zeros((10, 10, 10, 5))
         pam.peak_indices = np.zeros((10, 10, 10, 5))
         pam.shm_coeff = np.zeros((10, 10, 10, 45))
-        pam.sphere = Sphere(xyz=sphere.vertices)
+        pam.sphere = sphere
         pam.B = np.zeros((45, sphere.vertices.shape[0]))
         pam.total_weight = 0.5
         pam.ang_thr = 60
@@ -55,12 +55,21 @@ def test_io_peaks():
         fname2 = 'test2.pam'
         save_peaks(fname2, pam2)
 
-        pam3 = load_peaks(fname2, verbose=True)
+        pam3 = load_peaks(fname2, verbose=False)
         npt.assert_equal(pam3.total_weight, pam.total_weight)
+        npt.assert_equal(pam3.ang_thr, pam.ang_thr)
+        npt.assert_equal(pam3.gfa, pam.gfa)
+        npt.assert_equal(pam3.qa, pam.qa)
+        npt.assert_equal(pam3.odf, pam.odf)
 
         fname3 = 'test3.pam'
-        #pam4 = PeaksAndMetrics()
-        #save_peaks(fname3, pam4)
+        pam4 = PeaksAndMetrics()
+        npt.assert_raises(ValueError, save_peaks, fname3, pam4)
+
+        fname4 = 'test4.pam'
+        del pam.affine
+        save_peaks(fname4, pam, affine=None)
+
 
 
 if __name__ == '__main__':

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -55,7 +55,7 @@ def test_io_peaks():
         fname2 = 'test2.pam'
         save_peaks(fname2, pam2)
         pam3 = load_peaks(fname2, verbose=True)
-        npt.assert_equal(pam2.total_weight, pam.total_weight)
+        npt.assert_equal(pam3.total_weight, pam.total_weight)
 
 
 if __name__ == '__main__':

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -86,6 +86,13 @@ def test_io_peaks():
         pam_tmp = load_peaks(fname6, True)
         npt.assert_equal(pam_tmp.odf, None)
 
+        fname7 = 'test7.paw'
+        npt.assert_raises(IOError, load_peaks, fname7)
+
+        del pam.shm_coeff
+        save_peaks(fname6, pam, verbose=True)
+        pam_tmp = load_peaks(fname6, True)
+
 
 if __name__ == '__main__':
 

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -71,8 +71,6 @@ def test_io_peaks():
         save_peaks(fname4, pam, affine=None)
 
 
-
 if __name__ == '__main__':
 
-    #npt.run_module_suite()
-    test_io_peaks()
+    npt.run_module_suite()

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -66,6 +66,7 @@ but we can go a step further and restrict fiber tracking to those areas where
 the ODF shows significant restricted diffusion by thresholding on
 the general fractional anisotropy (GFA).
 """
+1/0
 
 from dipy.tracking.local import ThresholdTissueClassifier
 

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -66,7 +66,6 @@ but we can go a step further and restrict fiber tracking to those areas where
 the ODF shows significant restricted diffusion by thresholding on
 the general fractional anisotropy (GFA).
 """
-1/0
 
 from dipy.tracking.local import ThresholdTissueClassifier
 

--- a/doc/examples/viz_widgets.py
+++ b/doc/examples/viz_widgets.py
@@ -121,9 +121,9 @@ renderer.reset_clipping_range()
 Uncomment the following lines to start the interaction.
 """
 
-# show_manager.initialize()
-# show_manager.render()
-# show_manager.start()
+show_manager.initialize()
+show_manager.render()
+show_manager.start()
 
 
 window.record(renderer, out_path='mini_ui.png', size=(800, 800),

--- a/doc/examples/viz_widgets.py
+++ b/doc/examples/viz_widgets.py
@@ -118,12 +118,12 @@ renderer.roll(10.)
 renderer.reset_clipping_range()
 
 """
-Uncomment the following lines to start the interaction.
+Uncomment the line with method start() to begin the interaction.
 """
 
 show_manager.initialize()
 show_manager.render()
-show_manager.start()
+# show_manager.start()
 
 
 window.record(renderer, out_path='mini_ui.png', size=(800, 800),

--- a/doc/examples/viz_widgets.py
+++ b/doc/examples/viz_widgets.py
@@ -118,13 +118,12 @@ renderer.roll(10.)
 renderer.reset_clipping_range()
 
 """
-Uncomment the line with method start() to begin the interaction.
+Uncomment the lines below to begin the interaction.
 """
 
-show_manager.initialize()
-show_manager.render()
+# show_manager.initialize()
+# show_manager.render()
 # show_manager.start()
-
 
 window.record(renderer, out_path='mini_ui.png', size=(800, 800),
               reset_camera=False)


### PR DESCRIPTION
Hi @matthieudumont and all this PR is resolving the issue with saving the peaks object. Making it an HDF5 file allows to be read by other languages etc.

Mr. Dumont you will need to update your workflow PRs to use this one and then we can move to merging them asap.

Do you agree with the file extension .pam or .pam5 (as in hdf5)?

Also have in mind that the helper peaks_to_niftis is not in this PR so you will have to use it from your other PR. Let me know how it goes.