### PR TITLE
Enable memory profiling of the examples.

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -551,7 +551,6 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
                            odf_array if return_odf else None)
 
 
-
 def reshape_peaks_for_visualization(peaks):
     """Reshape peaks for visualization.
 

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -447,6 +447,12 @@ def test_degenerative_cases():
     assert_equal(len(values), 1)
 
 
+def test_gfa_nan():
+    all_zeros = np.zeros(_odf.shape)
+    assert_(np.isnan(gfa(all_zeros)))
+    one_is_a_zero = np.copy(_odf)
+
+
 def test_peaksFromModel():
     data = np.zeros((10, 2))
 

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -447,11 +447,6 @@ def test_degenerative_cases():
     assert_equal(len(values), 1)
 
 
-def test_gfa_nan():
-    all_zeros = np.zeros(_odf.shape)
-    assert_(np.isnan(gfa(all_zeros)))
-    one_is_a_zero = np.copy(_odf)
-
 
 def test_peaksFromModel():
     data = np.zeros((10, 2))

--- a/dipy/reconst/sfm.py
+++ b/dipy/reconst/sfm.py
@@ -422,8 +422,10 @@ class SparseFascicleModel(ReconstModel, Cache):
             # parameters at all-zeros, and avoid nasty sklearn errors:
             if not (np.any(~np.isfinite(vox_data)) or np.all(vox_data == 0)):
                 fit_it = vox_data - isopredict[vox]
-                flat_params[vox] = self.solver.fit(self.design_matrix,
-                                                   fit_it).coef_
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    flat_params[vox] = self.solver.fit(self.design_matrix,
+                                                       fit_it).coef_
 
         if mask is None:
             out_shape = data.shape[:-1] + (-1, )

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -121,7 +121,7 @@ doctest:
 
 rstexamples: rstexamples-stamp
 rstexamples-stamp:
-	../tools/make_examples.py
+	cd examples_built && ../../tools/make_examples.py
 	touch $@
 
 pdf: pdf-stamp

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -131,3 +131,9 @@ pdf-stamp: latex
 
 upload: html
 	./upload-gh-pages.sh _build/html/ dipy nipy
+
+xvfb:
+	export TEST_WITH_XVFB=true && make html
+
+memory_profile:
+	export TEST_WITH_MEMPROF=true && make html

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -211,5 +211,5 @@ window.record(show_manager.ren, size=current_size, out_path="viz_ui.png")
 .. figure:: viz_ui.png
    :align: center
 
-   User interface example.
+   **User interface example**.
 """

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -119,9 +119,11 @@ if use_xvfb:
     display = Xvfb(width=1920, height=1080)
     display.start()
 
+if use_memprof:
+    import memory_profiler
+
 
 name = ''
-
 
 def run_script(script_name=name):
     namespace = {}
@@ -129,18 +131,13 @@ def run_script(script_name=name):
     plt.close('all')
     del namespace
 
-if use_memprof:
-    import memory_profiler
-
-    def memprof():
-        run_script(name)
 
 for script in validated_examples:
     figure_basename = op.join('fig', op.splitext(script)[0])
     if use_memprof:
         print("memory profiling ", script)
         name = script
-        memory_profiler.profile(memprof)()
+        memory_profiler.profile(run_script)()
     else:
         print(script)
         run_script(script)

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -54,12 +54,12 @@ plt.show = show
 # -----------------------------------------------------------------------------
 
 # Where things are
-DOC_PATH = op.abspath(op.join('..', 'doc'))
+DOC_PATH = op.abspath('..')
 EG_INDEX_FNAME = op.join(DOC_PATH, 'examples_index.rst')
 EG_SRC_DIR = op.join(DOC_PATH, 'examples')
 
 # Work in examples directory
-os.chdir(op.join(DOC_PATH, 'examples_built'))
+#os.chdir(op.join(DOC_PATH, 'examples_built'))
 
 if not os.getcwd().endswith(op.join('doc', 'examples_built')):
     raise OSError('This must be run from the doc directory')
@@ -107,7 +107,6 @@ check_call('python ../../tools/ex2rst --project dipy --outdir . .', shell=True)
 # added the path so that scripts can import other scripts on the same directory
 sys.path.insert(0, os.getcwd())
 
-# Execute each python script in the directory.
 if not op.isdir('fig'):
     os.mkdir('fig')
 
@@ -138,22 +137,23 @@ if use_memprof:
 name = ''
 
 
-def run_script(script_name=name):
+def run_script():
     namespace = {}
     exec(open(script).read(), namespace)
     plt.close('all')
     del namespace
 
 
+# Execute each python script in the directory:
 for script in validated_examples:
     figure_basename = op.join('fig', op.splitext(script)[0])
     if use_memprof:
         print("memory profiling ", script)
-        name = script
         memory_profiler.profile(run_script)()
+
     else:
         print(script)
-        run_script(script)
+        run_script()
 
 if use_xvfb:
     display.stop()

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -54,7 +54,7 @@ plt.show = show
 # -----------------------------------------------------------------------------
 
 # Where things are
-DOC_PATH = op.join(op.split(dipy.__path__[0])[0], 'doc')
+DOC_PATH = op.join(dipy.__path__[0], 'doc')
 EG_INDEX_FNAME = op.join(DOC_PATH, 'examples_index.rst')
 EG_SRC_DIR = op.join(DOC_PATH, 'examples')
 

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -54,7 +54,7 @@ plt.show = show
 # -----------------------------------------------------------------------------
 
 # Where things are
-DOC_PATH = op.join(dipy.__path__[0], 'doc')
+DOC_PATH = op.abspath(op.join('..', 'doc'))
 EG_INDEX_FNAME = op.join(DOC_PATH, 'examples_index.rst')
 EG_SRC_DIR = op.join(DOC_PATH, 'examples')
 
@@ -72,7 +72,7 @@ eg_index_contents = open(EG_INDEX_FNAME, 'rt').read()
 # with debugging the examples and the documentation only a few examples at
 # the time.
 flist_name = op.join(op.dirname(os.getcwd()), 'examples',
-                   'valid_examples.txt')
+                     'valid_examples.txt')
 flist = open(flist_name, "r")
 validated_examples = flist.readlines()
 flist.close()
@@ -119,7 +119,10 @@ if use_xvfb:
     display = Xvfb(width=1920, height=1080)
     display.start()
 
+
 name = ''
+
+
 def run_script(script_name=name):
     namespace = {}
     exec(open(script).read(), namespace)
@@ -128,6 +131,7 @@ def run_script(script_name=name):
 
 if use_memprof:
     import memory_profiler
+
     def memprof():
         run_script(name)
 

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -115,14 +115,28 @@ use_xvfb = os.environ.get('TEST_WITH_XVFB', False)
 use_memprof = os.environ.get('TEST_WITH_MEMPROF', False)
 
 if use_xvfb:
-    from xvfbwrapper import Xvfb
+    try:
+        from xvfbwrapper import Xvfb
+    except ImportError:
+        raise RuntimeError("You are trying to run a documentation build",
+                           "with 'TEST_WITH_XVFB' set to True, but ",
+                           "xvfbwrapper is not available. Please install",
+                           "xvfbwrapper and try again")
+
     display = Xvfb(width=1920, height=1080)
     display.start()
 
 if use_memprof:
-    import memory_profiler
+    try:
+        import memory_profiler
+    except ImportError:
+        raise RuntimeError("You are trying to run a documentation build",
+                           "with 'TEST_WITH_MEMPROF' set to True, but ",
+                           "memory_profiler is not available. Please install",
+                           "memory_profiler and try again")
 
 name = ''
+
 
 def run_script(script_name=name):
     namespace = {}

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -18,6 +18,7 @@ import sys
 import shutil
 from subprocess import check_call
 from glob import glob
+from time import time
 
 # Third-party imports
 
@@ -139,7 +140,10 @@ name = ''
 
 def run_script():
     namespace = {}
+    t1 = time()
     exec(open(script).read(), namespace)
+    t2 = time()
+    print("That took %.2f seconds to run" % (t2 - t1))
     plt.close('all')
     del namespace
 

--- a/tools/make_examples.py
+++ b/tools/make_examples.py
@@ -122,7 +122,6 @@ if use_xvfb:
 if use_memprof:
     import memory_profiler
 
-
 name = ''
 
 def run_script(script_name=name):


### PR DESCRIPTION
This seems to work when running this directly in IPython, but I am still not sure if this works generally, so needs to be switched on with some care. Shouldn't affect normal doc building, though.