### PR TITLE
non_local_means : patch size argument for local mean and variance

### DIFF
--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -118,8 +118,9 @@ cdef void _average_block(double[:, :, :] ima, int x, int y, int z,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef void _value_block(double[:, :, :] estimate, double[:, :, :] Label, int x, int y,
-                       int z, double[:, :, :] average, double global_sum, double hh, int rician_int) nogil:
+cdef void _value_block(double[:, :, :] estimate, double[:, :, :] Label, int x,
+    int y, int z, double[:, :, :] average, double global_sum, double hh,
+    int rician_int) nogil:
 
     """
     Computes the final estimate of the denoised image
@@ -284,7 +285,8 @@ cdef double _local_mean(double[:, :, :]ima, int x, int y, int z, int p) nogil:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef double _local_variance(double[:, :, :] ima, double mean, int x, int y, int z, int p) nogil:
+cdef double _local_variance(double[:, :, :] ima, double mean, int x, int y,
+    int z, int p) nogil:
     """
     local variance of a patch with patch radius = p centered at x,y,z
     """
@@ -347,7 +349,8 @@ cpdef upfir(double[:, :] image, double[:] h):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, int block_radius, double h, int lmean_radius, int rician):
+def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius,
+int block_radius, double h, int lmean_radius, int rician):
     """Non-Local Means Denoising Using Blockwise Averaging
 
     Parameters
@@ -401,7 +404,8 @@ def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, 
     cdef double hh = 2 * h * h
     cdef int Ndims = (2 * block_radius + 1)**3
     cdef int nvox = dims[0] * dims[1] * dims[2]
-    cdef double[:, :, :] average = np.zeros((2 * block_radius + 1, 2 * block_radius + 1, 2 * block_radius + 1), dtype=np.float64)
+    cdef double[:, :, :] average = np.zeros((2 * block_radius + 1,
+    2 * block_radius + 1, 2 * block_radius + 1), dtype=np.float64)
     cdef double[:, :, :] fima = np.zeros_like(image)
     cdef double[:, :, :] means = np.zeros_like(image)
     cdef double[:, :, :] variances = np.zeros_like(image)
@@ -443,7 +447,8 @@ def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, 
                                     if((ni == i)and(nj == j)and(nk == k)):
                                         continue
                                     if ((ni < 0) or (nj < 0) or (nk < 0) or (
-                                            nj >= dims[0]) or (ni >= dims[1]) or (nk >= dims[2])):
+                                            nj >= dims[0]) or (ni >= dims[1]) 
+                                            or (nk >= dims[2])):
                                         continue
                                     if ((means[nj, ni, nk] <= epsilon) or (
                                             variances[nj, ni, nk] <= epsilon)):

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -5,7 +5,7 @@ from dipy.denoise.nlmeans_block import nlmeans_block
 
 
 def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
-                    rician=True):
+                    lmean_radius=1, rician=True):
     r""" Non-local means for denoising 3D and 4D images, using
         blockwise averaging approach
 
@@ -20,6 +20,10 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
         patch size is ``2 x patch_radius + 1``. Default is 1.
     block_radius : int
         block size is ``2 x block_radius + 1``. Default is 5.
+    lmean_radius : int
+        patch radius for finding local mean and variances,
+        the patch size (local mean) is ``2 x lmean_radius + 1``.
+        The default (recommended value) is 1.
     rician : boolean
         If True the noise is estimated as Rician, otherwise Gaussian noise
         is assumed.
@@ -60,13 +64,14 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
             patch_radius,
             block_radius,
             sigma,
+            lmean_radius,
             np.int(rician))).astype(arr.dtype)
     elif arr.ndim == 4:
         denoised_arr = np.zeros_like(arr)
         for i in range(arr.shape[-1]):
             denoised_arr[..., i] = np.array(nlmeans_block(np.double(
                 arr[..., i]), mask, patch_radius, block_radius, sigma,
-                np.int(rician))).astype(arr.dtype)
+                lmean_radius, np.int(rician))).astype(arr.dtype)
 
         return denoised_arr
 

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -72,7 +72,6 @@ def test_nlmeans_4D_and_mask():
 
 
 def test_nlmeans_dtype():
-
     S0 = 200 * np.ones((20, 20, 20, 3), dtype='f4')
     mask = np.zeros((20, 20, 20))
     mask[10:14, 10:14, 10:14] = 1
@@ -84,6 +83,15 @@ def test_nlmeans_dtype():
     S0n = non_local_means(S0, sigma=1, mask=mask, rician=True)
     assert_equal(S0.dtype, S0n.dtype)
 
+def test_lmean_patch_variation():
+    S0 = 100 + np.zeros((22, 23, 30))
+    S0n = 100 + 2 * np.random.standard_normal((22, 23, 30))
+    S0n1 = non_local_means(S0n, sigma=np.std(S0n), lmean_radius=1, rician=False)
+    S0n2 = non_local_means(S0n, sigma=np.std(S0n), lmean_radius=2, rician=False)
+    assert_(np.sum(np.abs(S0 - S0n1)) / np.sum(S0) <
+            np.sum(np.abs(S0 - S0n)) / np.sum(S0))
+    assert_(np.sum(np.abs(S0 - S0n2)) / np.sum(S0) <
+            np.sum(np.abs(S0 - S0n)) / np.sum(S0))
 
 if __name__ == '__main__':
     run_module_suite()

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -60,7 +60,7 @@ print("total time (non_local_means)", time() - t)
 t = time()
 
 den_old = nlmeans(data, sigma=sigma, mask=mask, patch_radius= 1,
-  block_radius = 1, rician= True)
+block_radius = 1, rician= True)
 
 print("total time (nlmeans)", time() - t)
 """

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -59,7 +59,8 @@ print("total time (non_local_means)", time() - t)
 
 t = time()
 
-den_old = nlmeans(data, sigma=sigma, mask=mask, patch_radius= 1, block_radius = 1, rician= True)
+den_old = nlmeans(data, sigma=sigma, mask=mask, patch_radius= 1,
+  block_radius = 1, rician= True)
 
 print("total time (nlmeans)", time() - t)
 """

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -55,15 +55,15 @@ den = non_local_means(
     patch_radius=1,
     block_radius=1,
     rician=True)
-print("total time", time() - t)
+print("total time (non_local_means)", time() - t)
 
 t = time()
 
-den = nlmeans(data, sigma=sigma, mask=mask, patch_radius= 1, block_radius = 1, rician= True)
+den_old = nlmeans(data, sigma=sigma, mask=mask, patch_radius= 1, block_radius = 1, rician= True)
 
-print("total time", time() - t)
+print("total time (nlmeans)", time() - t)
 """
-Let us plot the axial slice of the denoised output
+Let us plot the axial slice of the denoised (non_local_means) output
 """
 
 axial_middle = data.shape[2] // 2


### PR DESCRIPTION
Added the argument which allows user to change the patch size used for computation of local mean and local variance in the non_local_means.
Addresses the issue brought up in #1178 