### PR TITLE
Fix missing documentation content

### DIFF
--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -21,7 +21,7 @@ As an example, lets take a 2d image where the affine is::
      [0., 2., 0.],
      [0., 0., 1.]]
 
-The pixels of an image with this affine would look something like:
+The pixels of an image with this affine would look something like::
 
     A------------
     |   |   |   |

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -276,7 +276,7 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
 
     See Also
     --------
-    :func:``dipy.viz.actor.line``
+    :func:`dipy.viz.actor.line`
     """
     # Poly data with lines and colors
     poly_data, is_colormap = lines_to_vtk_polydata(lines, colors)

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -9,9 +9,11 @@
  reconst_dsi_metrics.py
  reconst_dsi.py
  reconst_dti.py
+ reconst_fwdti.py
  reconst_gqi.py
  reconst_dsid.py
  reconst_ivim.py
+ reconst_mapmri.py
  kfold_xval.py
  reslice_datasets.py
  segment_quickbundles.py
@@ -40,6 +42,7 @@
  affine_registration_3d.py
  syn_registration_2d.py
  syn_registration_3d.py
+ tissue_classification.py
  bundle_registration.py
  tracking_tissue_classifier.py
  piesno.py

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -166,5 +166,16 @@ show_manager.ren.add(text)
 show_manager.ren.add(line_slider)
 show_manager.ren.add(disk_slider)
 
+show_manager.ren.azimuth(30)
+
 # Uncomment this to start the visualisation
-show_manager.start()
+# show_manager.start()
+
+window.record(show_manager.ren, size=current_size, out_path="viz_ui.png")
+
+"""
+.. figure:: viz_ui.png
+   :align: center
+
+   **User interface example**.
+"""

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
                                         r'\.tracking\.interfaces.*$',
                                         r'\.tracking\.gui_tools.*$',
                                         r'.*test.*$',
-                                        r'\.utils\.',
+                                        r'^\.utils.*',
                                         r'\.boots\.resampling.*$',
                                         r'\.fixes.*$',
                                         r'\.info.*$',

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                                         r'\.tracking\.interfaces.*$',
                                         r'\.tracking\.gui_tools.*$',
                                         r'.*test.*$',
-                                        r'\.utils.*$',
+                                        r'\.utils\.',
                                         r'\.viz.*$',
                                         r'\.boots\.resampling.*$',
                                         r'\.fixes.*$',

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -64,12 +64,10 @@ if __name__ == '__main__':
                              other_defines=other_defines)
     docwriter.package_skip_patterns += [r'\.fixes$',
                                         r'\.externals$',
-                                        r'\.reconst.eit$',
                                         r'\.tracking\.interfaces.*$',
                                         r'\.tracking\.gui_tools.*$',
                                         r'.*test.*$',
                                         r'\.utils\.',
-                                        r'\.viz.*$',
                                         r'\.boots\.resampling.*$',
                                         r'\.fixes.*$',
                                         r'\.info.*$',


### PR DESCRIPTION
All dipy.*.utils (ex: dipy.tracking.utils) are missing on the documentation so this PR change the regular expression to make this files available on api reference. (see #322)