### PR TITLE
Fix nlmeans indexing

### DIFF
--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -181,7 +181,6 @@ cdef void _value_block(double[:, :, :] estimate, double[:, :, :] Label, int x, i
 
 
 @cython.boundscheck(False)
-@cython.wraparound(False)
 @cython.cdivision(True)
 cdef double _distance(double[:, :, :] image, int x, int y, int z,
                       int nx, int ny, int nz, int block_radius) nogil:
@@ -210,11 +209,11 @@ cdef double _distance(double[:, :, :] image, int x, int y, int z,
         block radius for which the distince is computed for
     """
 
-    cdef double acu, distancetotal
+    cdef int acu = 0
+    cdef double distancetotal = 0.0
     cdef int i, j, k, ni1, nj1, ni2, nj2, nk1, nk2
-    cdef int sx = image.shape[1], sy = image.shape[0], sz = image.shape[2]
-    acu = 0
-    distancetotal = 0
+    cdef int sx = image.shape[0], sy = image.shape[1], sz = image.shape[2]
+
     for i in range(-block_radius, block_radius + 1):
         for j in range(-block_radius, block_radius + 1):
             for k in range(-block_radius, block_radius + 1):
@@ -248,14 +247,13 @@ cdef double _distance(double[:, :, :] image, int x, int y, int z,
                     nj2 = 2 * sy - nj2 - 1
                 if(nk2 >= sz):
                     nk2 = 2 * sz - nk2 - 1
-                distancetotal += (image[nj1, ni1, nk1] -
-                                  image[nj2, ni2, nk2])**2
-                acu = acu + 1
+                distancetotal += (image[ni1, nj1, nk1] -
+                                  image[ni2, nj2, nk2])**2
+                acu += 1
     return distancetotal / acu
 
 
 @cython.boundscheck(False)
-@cython.wraparound(False)
 @cython.cdivision(True)
 cdef double _local_mean(double[:, :, :]ima, int x, int y, int z) nogil:
     """
@@ -412,19 +410,19 @@ def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, 
 
     with nogil:
         for k in range(dims[2]):
-            for i in range(dims[1]):
-                for j in range(dims[0]):
-                    means[j, i, k] = _local_mean(image, j, i, k)
-                    variances[j, i, k] = _local_variance(
-                        image, means[j, i, k], j, i, k)
+            for j in range(dims[1]):
+                for i in range(dims[0]):
+                    means[i, j, k] = _local_mean(image, i, j, k)
+                    variances[i, j, k] = _local_variance(
+                        image, means[i, j, k], i, j, k)
         for k in range(0, dims[2], 2):
-            for i in range(0, dims[1], 2):
-                for j in range(0, dims[0], 2):
+            for j in range(0, dims[1], 2):
+                for i in range(0, dims[0], 2):
                     with gil:
                         average[...] = 0
                     totalWeight = 0
-                    if (means[j, i, k] <= epsilon) or (
-                            variances[j, i, k] <= epsilon):
+                    if (means[i, j, k] <= epsilon) or (
+                            variances[i, j, k] <= epsilon):
                         wmax = 1.0
                         _average_block(image, i, j, k, average, wmax)
                         totalWeight += wmax
@@ -433,19 +431,19 @@ def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, 
                     else:
                         wmax = 0
                         for nk in range(k - patch_radius, k + patch_radius + 1):
-                            for ni in range(i - patch_radius, i + patch_radius + 1):
-                                for nj in range(j - patch_radius, j + patch_radius + 1):
+                            for nj in range(j - patch_radius, j + patch_radius + 1):
+                                for ni in range(i - patch_radius, i + patch_radius + 1):
                                     if((ni == i)and(nj == j)and(nk == k)):
                                         continue
                                     if ((ni < 0) or (nj < 0) or (nk < 0) or (
                                             nj >= dims[0]) or (ni >= dims[1]) or (nk >= dims[2])):
                                         continue
-                                    if ((means[nj, ni, nk] <= epsilon) or (
-                                            variances[nj, ni, nk] <= epsilon)):
+                                    if ((means[ni, nj, nk] <= epsilon) or (
+                                            variances[ni, nj, nk] <= epsilon)):
                                         continue
-                                    t1 = (means[j, i, k]) / (means[nj, ni, nk])
-                                    t2 = (variances[j, i, k]) / \
-                                        (variances[nj, ni, nk])
+                                    t1 = (means[i, j, k]) / (means[ni, nj, nk])
+                                    t2 = (variances[i, j, k]) / \
+                                        (variances[ni, nj, nk])
                                     if ((t1 > mu1) and (t1 < (1 / mu1)) and
                                             (t2 > var1) and (t2 < (1 / var1))):
                                         d = _distance(
@@ -462,16 +460,16 @@ def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, 
                                          average, totalWeight, hh, rician)
 
         for k in range(0, dims[2]):
-            for i in range(0, dims[1]):
-                for j in range(0, dims[0]):
+            for j in range(0, dims[1]):
+                for i in range(0, dims[0]):
 
-                    if mask[j, i, k] == 0:
-                        fima[j, i, k] = 0
+                    if mask[i, j, k] == 0:
+                        fima[i, j, k] = 0
 
                     else:
-                        if(Label[j, i, k] == 0.0):
-                            fima[j, i, k] = image[j, i, k]
+                        if(Label[i, j, k] == 0.0):
+                            fima[i, j, k] = image[i, j, k]
                         else:
-                            fima[j, i, k] = Estimate[j, i, k] / Label[j, i, k]
+                            fima[i, j, k] = Estimate[i, j, k] / Label[i, j, k]
 
     return fima

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -457,11 +457,8 @@ def nlmeans_block(double[:, :, :]image, int[:, :, :] mask, int patch_radius, int
         for k in range(0, dims[2]):
             for j in range(0, dims[1]):
                 for i in range(0, dims[0]):
-
-                    if mask[i, j, k] == 0:
-                        fima[i, j, k] = 0
-
-                    else:
+                    # fima is initialized to zero, so we only put stuff where the mask is
+                    if mask[i, j, k]:
                         if(Label[i, j, k] == 0.0):
                             fima[i, j, k] = image[i, j, k]
                         else:

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -380,11 +380,6 @@ def nlmeans_block(double[:, :, :]image, int[:, :, :] mask, int patch_radius, int
         "An Optimized Blockwise Non Local Means Denoising Filter for 3D Magnetic
         Resonance Images"
         IEEE Transactions on Medical Imaging, 27(4):425-441, 2008
-
-    [2] Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins.
-        "Multiresolution Non-Local Means Filter for 3D MR Image Denoising"
-        IET Image Processing, Institution of Engineering and Technology, 2011
-
     """
 
     cdef int[:] dims = cvarray((3,), itemsize=sizeof(int), format="i")

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -351,7 +351,7 @@ def nlmeans_block(double[:, :, :]image, int[:, :, :] mask, int patch_radius, int
     ----------
     image : 3D array of doubles
         the input image, corrupted with rician noise
-    mask : 3D array of doubles
+    mask : 3D array of int
         the input mask
     patch_radius :  int
         similar patches in the non-local means are searched for locally,

--- a/dipy/denoise/nlmeans_block.pyx
+++ b/dipy/denoise/nlmeans_block.pyx
@@ -344,7 +344,7 @@ cpdef upfir(double[:, :] image, double[:] h):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def nlmeans_block(double[:, :, :]image, double[:, :, :] mask, int patch_radius, int block_radius, double h, int rician):
+def nlmeans_block(double[:, :, :]image, int[:, :, :] mask, int patch_radius, int block_radius, double h, int rician):
     """Non-Local Means Denoising Using Blockwise Averaging
 
     Parameters

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -14,7 +14,7 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
     arr : 3D or 4D ndarray
         The array to be denoised
     mask : 3D ndarray
-    sigma : float
+    sigma : double
         standard deviation of the noise estimated from the data
     patch_radius : int
         patch size is ``2 x patch_radius + 1``. Default is 1.
@@ -38,32 +38,38 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                  Medical Imaging, 27(4):425-441, 2008
     """
     if not np.isscalar(sigma) and not sigma.shape == (1, ):
-        raise ValueError("Sigma input needs to be of type float", sigma)
+        raise ValueError("Sigma input needs to be of type double", sigma)
     if mask is None and arr.ndim > 2:
-        mask = np.ones((arr.shape[0], arr.shape[1], arr.shape[2]), dtype=np.bool)
+        mask = np.ones((arr.shape[0], arr.shape[1], arr.shape[2]), dtype=np.int32)
+    else:
+        mask = mask.astype(np.int32)
 
     if mask.ndim != 3:
         raise ValueError('mask needs to be a 3D ndarray', mask.shape)
 
+    denoised_arr = np.zeros_like(arr, dtype=np.float32)
+
     # the cython part expects an array of double
     arr = arr.astype(np.float64)
+    # it also does not recognize bool dtype
+    rician = int(rician)
 
     if arr.ndim == 3:
-        return nlmeans_block(arr,
-                             mask,
-                             patch_radius,
-                             block_radius,
-                             sigma,
-                             rician)
+        denoised_arr[:] = nlmeans_block(arr,
+                                        mask,
+                                        patch_radius,
+                                        block_radius,
+                                        sigma,
+                                        rician)
     elif arr.ndim == 4:
-        denoised_arr = np.zeros_like(arr, dtype=np.float32)
-        for i in range(arr.shape[-1]):
-            denoised_arr[..., i] = nlmeans_block(arr[..., i],
-                                                 mask,
-                                                 patch_radius,
-                                                 block_radius,
-                                                 sigma,
-                                                 rician)
-        return denoised_arr
+            for i in range(arr.shape[-1]):
+                denoised_arr[..., i] = nlmeans_block(arr[..., i],
+                                                     mask,
+                                                     patch_radius,
+                                                     block_radius,
+                                                     sigma,
+                                                     rician)
     else:
         raise ValueError("Only 3D or 4D array are supported!", arr.shape)
+
+    return np.asarray(denoised_arr)

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -45,6 +45,9 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
     if mask.ndim != 3:
         raise ValueError('mask needs to be a 3D ndarray', mask.shape)
 
+    # the cython part expects an array of double
+    arr = arr.astype(np.float64)
+
     if arr.ndim == 3:
         return nlmeans_block(arr,
                              mask,
@@ -62,6 +65,5 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                                                  sigma,
                                                  rician)
         return denoised_arr
-
     else:
         raise ValueError("Only 3D or 4D array are supported!", arr.shape)

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -40,28 +40,27 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
     if not np.isscalar(sigma) and not sigma.shape == (1, ):
         raise ValueError("Sigma input needs to be of type float", sigma)
     if mask is None and arr.ndim > 2:
-        mask = np.ones((arr.shape[0], arr.shape[1], arr.shape[2]), dtype='f8')
-    else:
-        mask = np.ascontiguousarray(mask, dtype='f8')
+        mask = np.ones((arr.shape[0], arr.shape[1], arr.shape[2]), dtype=np.bool)
 
     if mask.ndim != 3:
         raise ValueError('mask needs to be a 3D ndarray', mask.shape)
 
     if arr.ndim == 3:
-        return np.array(nlmeans_block(
-            np.double(arr),
-            mask,
-            patch_radius,
-            block_radius,
-            sigma,
-            np.int(rician))).astype(arr.dtype)
+        return nlmeans_block(arr,
+                             mask,
+                             patch_radius,
+                             block_radius,
+                             sigma,
+                             rician)
     elif arr.ndim == 4:
-        denoised_arr = np.zeros_like(arr)
+        denoised_arr = np.zeros_like(arr, dtype=np.float32)
         for i in range(arr.shape[-1]):
-            denoised_arr[..., i] = np.array(nlmeans_block(np.double(
-                arr[..., i]), mask, patch_radius, block_radius, sigma,
-                np.int(rician))).astype(arr.dtype)
-
+            denoised_arr[..., i] = nlmeans_block(arr[..., i],
+                                                 mask,
+                                                 patch_radius,
+                                                 block_radius,
+                                                 sigma,
+                                                 rician)
         return denoised_arr
 
     else:

--- a/dipy/denoise/non_local_means.py
+++ b/dipy/denoise/non_local_means.py
@@ -36,12 +36,6 @@ def non_local_means(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                  Barillot, An Optimized Blockwise Non Local Means Denoising
                  Filter for 3D Magnetic Resonance Images, IEEE Transactions on
                  Medical Imaging, 27(4):425-441, 2008
-
-    .. [Coupe11] Pierrick Coupe, Jose Manjon, Montserrat Robles, Louis Collins.
-                Adaptive Multiresolution Non-Local Means Filter for 3D MR Image
-                Denoising IET Image Processing, Institution of Engineering and
-                Technology, 2011
-
     """
     if not np.isscalar(sigma) and not sigma.shape == (1, ):
         raise ValueError("Sigma input needs to be of type float", sigma)

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -56,6 +56,8 @@ def test_nlmeans_boundary():
     S0n = non_local_means(S0, sigma=np.std(noise), rician=False)
     assert_(S0[9, 9, 9] > 290)
     assert_(S0[10, 10, 10] < 110)
+    assert_(S0n[9, 9, 9] > 290)
+    assert_(S0n[10, 10, 10] < 110)
 
 
 def test_nlmeans_wrong():

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -16,20 +16,25 @@ def test_nlmeans_static():
 def test_nlmeans_random_noise():
     S0 = 100 + 2 * np.random.standard_normal((22, 23, 30))
 
-    masker = np.zeros(S0.shape[:3]).astype(bool)
+    masker = np.zeros(S0.shape[:3]).astype(np.bool)
     masker[8:15, 8:15, 8:15] = 1
     for mask in [None, masker]:
+        # if mask is None, then we have to create a blank one for the comparisons
+        if mask is None:
+            m = np.ones_like(S0, dtype=np.bool)
+        else:
+            m = masker.copy()
+
+        S0nb = non_local_means(S0, sigma=np.std(S0), rician=False, mask=mask)
+        assert_(S0nb[m].min() > S0[m].min())
+        assert_(S0nb[m].max() < S0[m].max())
+        assert_equal(np.round(S0nb[m].mean()), 100)
+
         S0nb = non_local_means(S0, sigma=np.std(S0), rician=False, mask=mask)
 
-        assert_(S0nb[mask].min() > S0[mask].min())
-        assert_(S0nb[mask].max() < S0[mask].max())
-        assert_equal(np.round(S0nb[mask].mean()), 100)
-
-        S0nb = non_local_means(S0, sigma=np.std(S0), rician=False, mask=mask)
-
-        assert_(S0nb[mask].min() > S0[mask].min())
-        assert_(S0nb[mask].max() < S0[mask].max())
-        assert_equal(np.round(S0nb[mask].mean()), 100)
+        assert_(S0nb[m].min() > S0[m].min())
+        assert_(S0nb[m].max() < S0[m].max())
+        assert_equal(np.round(S0nb[m].mean()), 100)
 
 
 def test_scalar_sigma():

--- a/dipy/denoise/tests/test_non_local_means.py
+++ b/dipy/denoise/tests/test_non_local_means.py
@@ -78,11 +78,6 @@ def test_nlmeans_dtype():
     mask[10:14, 10:14, 10:14] = 1
     S0n = non_local_means(S0, sigma=1, mask=mask, rician=True)
     assert_equal(S0.dtype, S0n.dtype)
-    S0 = 200 * np.ones((20, 20, 20), dtype=np.uint16)
-    mask = np.zeros((20, 20, 20))
-    mask[10:14, 10:14, 10:14] = 1
-    S0n = non_local_means(S0, sigma=1, mask=mask, rician=True)
-    assert_equal(S0.dtype, S0n.dtype)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I though I had made an issue about it, must have been a mental note.

Anyway, the cython part of nlmeans had a few indexing error which inverted along the way the first and second dimension, so hopefully I fixed them here. That's why not all the code is changed, the main loop was using j,i,k, but passing i,j,k down, so now they should match.

I also revamped the calling file to remove parts I personally deemed unnecessary at the same time. From memory, the example also had some statements which were not truc, so I'll have a look afterwards if this here is fine.