### PR TITLE
Cast Streamline attrs to numpy ints, to avoid buffer mismatch.

### DIFF
--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -104,14 +104,14 @@ def length(streamlines):
         if streamlines.data.dtype == np.float32:
             c_arclengths_from_arraysequence[float2d](
                                     streamlines.data,
-                                    streamlines._offsets.astype(np.int),
-                                    streamlines._lengths.astype(np.int),
+                                    streamlines._offsets.astype(np.intp),
+                                    streamlines._lengths.astype(np.intp),
                                     arclengths)
         else:
             c_arclengths_from_arraysequence[double2d](
                                       streamlines.data,
-                                      streamlines._offsets.astype(np.int),
-                                      streamlines._lengths.astype(np.int),
+                                      streamlines._offsets.astype(np.intp),
+                                      streamlines._lengths.astype(np.intp),
                                       arclengths)
 
 

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -102,15 +102,18 @@ def length(streamlines):
         arclengths = np.zeros(len(streamlines), dtype=np.float64)
 
         if streamlines.data.dtype == np.float32:
-            c_arclengths_from_arraysequence[float2d](streamlines.data,
-                                                     streamlines._offsets,
-                                                     streamlines._lengths,
-                                                     arclengths)
+            c_arclengths_from_arraysequence[float2d](
+                                    streamlines.data,
+                                    streamlines._offsets.astype(np.int),
+                                    streamlines._lengths.astype(np.int),
+                                    arclengths)
         else:
-            c_arclengths_from_arraysequence[double2d](streamlines.data,
-                                                      streamlines._offsets,
-                                                      streamlines._lengths,
-                                                      arclengths)
+            c_arclengths_from_arraysequence[double2d](
+                                      streamlines.data,
+                                      streamlines._offsets.astype(np.int),
+                                      streamlines._lengths.astype(np.int),
+                                      arclengths)
+
 
         return arclengths
 


### PR DESCRIPTION
See: https://nipy.bic.berkeley.edu/builders/dipy-bdist64-27/builds/122/steps/shell_12/logs/stdio