### PR TITLE
Adding a decorator for skipping test if openmp is not available

### DIFF
--- a/dipy/denoise/tests/test_nlmeans.py
+++ b/dipy/denoise/tests/test_nlmeans.py
@@ -6,7 +6,7 @@ from numpy.testing import (run_module_suite,
                            assert_raises)
 from dipy.denoise.nlmeans import nlmeans
 from dipy.denoise.denspeed import (add_padding_reflection, remove_padding)
-from dipy.utils.omp import cpu_count
+from dipy.utils.omp import cpu_count, have_openmp
 from time import time
 
 
@@ -89,7 +89,7 @@ def test_nlmeans_dtype():
     S0n = nlmeans(S0, sigma=np.ones((20, 20, 20)), mask=mask, rician=True)
     assert_equal(S0.dtype, S0n.dtype)
 
-
+@np.testing.dec.skipif(not have_openmp)
 def test_nlmeans_4d_3dsigma_and_threads():
     # Input is 4D data and 3D sigma
     data = np.ones((50, 50, 50, 5))


### PR DESCRIPTION
The goal of this PR is to avoid test failure on mac when openmp is not avalaible. is it ok for you @matthew-brett @Garyfallidis  ?