### PR TITLE
NF Add the parameter fa_operator in auto_response function

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -809,9 +809,10 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
         radius of cubic ROI
     fa_thr : float
         FA threshold
-    fa_operator : function
-        Function that defines operator used to compare the FA with the fa_thr.
-        Must be defined as `def function_name(FA, fa_thr)` and return a bool array.
+    fa_operator : callable
+        A callable that defines an operation that compares FA with the fa_thr. The operator
+        should have two positional arguments (e.g., `fa_operator(FA, fa_thr)`) and it should
+        return a bool array.
     return_number_of_voxels : bool
         If True, returns the number of voxels used for estimating the response
         function.

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -794,7 +794,7 @@ def fa_inferior(FA, fa_thr):
 
 
 def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
-                  fa_operator=fa_superior, return_number_of_voxels=False):
+                  fa_callable=fa_superior, return_number_of_voxels=False):
     """ Automatic estimation of response function using FA.
 
     Parameters
@@ -809,7 +809,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
         radius of cubic ROI
     fa_thr : float
         FA threshold
-    fa_operator : callable
+    fa_callable : callable
         A callable that defines an operation that compares FA with the fa_thr. The operator
         should have two positional arguments (e.g., `fa_operator(FA, fa_thr)`) and it should
         return a bool array.
@@ -869,7 +869,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
     tenfit = ten.fit(roi)
     FA = fractional_anisotropy(tenfit.evals)
     FA[np.isnan(FA)] = 0
-    indices = np.where(fa_operator(FA, fa_thr))
+    indices = np.where(fa_callable(FA, fa_thr))
 
     if indices[0].size == 0:
         msg = "No voxel with a FA higher than " + str(fa_thr) + " were found."

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -759,8 +759,42 @@ def odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15., sh_order=8,
     return fodf_sh
 
 
+def fa_superior(FA, fa_thr):
+    """ Check that the FA is greater than the FA threshold
+
+        Parameters
+        ----------
+        FA : array
+            Fractional Anisotropy
+        fa_thr : int
+            FA threshold
+
+        Returns
+        -------
+        True when the FA value is greater than the FA threshold, otherwise False.
+    """
+    return FA > fa_thr
+
+
+def fa_inferior(FA, fa_thr):
+    """ Check that the FA is lower than the FA threshold
+
+        Parameters
+        ----------
+        FA : array
+            Fractional Anisotropy
+        fa_thr : int
+            FA threshold
+
+        Returns
+        -------
+        True when the FA value is lower than the FA threshold, otherwise False.
+    """
+    return FA < fa_thr
+
+
 def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
-                  fa_operator=lambda FA, fa_thr: FA > fa_thr, return_number_of_voxels=False):
+                  fa_operator=fa_superior, return_number_of_voxels=False):
     """ Automatic estimation of response function using FA.
 
     Parameters
@@ -775,8 +809,8 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
         radius of cubic ROI
     fa_thr : float
         FA threshold
-    fa_operator : lambda
-        operator used to compare the FA with the fa_thr.
+    fa_operator : function
+        Function that defines operator used to compare the FA with the fa_thr.
     return_number_of_voxels : bool
         If True, returns the number of voxels used for estimating the response
         function.

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -760,7 +760,7 @@ def odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15., sh_order=8,
 
 
 def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
-                  return_number_of_voxels=False):
+                  fa_operator=lambda FA, fa_thr: FA > fa_thr, return_number_of_voxels=False):
     """ Automatic estimation of response function using FA.
 
     Parameters
@@ -775,6 +775,8 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
         radius of cubic ROI
     fa_thr : float
         FA threshold
+    fa_operator : lambda
+        operator used to compare the FA with the fa_thr.
     return_number_of_voxels : bool
         If True, returns the number of voxels used for estimating the response
         function.
@@ -831,7 +833,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
     tenfit = ten.fit(roi)
     FA = fractional_anisotropy(tenfit.evals)
     FA[np.isnan(FA)] = 0
-    indices = np.where(FA > fa_thr)
+    indices = np.where(fa_operator(FA, fa_thr))
 
     if indices[0].size == 0:
         msg = "No voxel with a FA higher than " + str(fa_thr) + " were found."

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -811,6 +811,7 @@ def auto_response(gtab, data, roi_center=None, roi_radius=10, fa_thr=0.7,
         FA threshold
     fa_operator : function
         Function that defines operator used to compare the FA with the fa_thr.
+        Must be defined as `def function_name(FA, fa_thr)` and return a bool array.
     return_number_of_voxels : bool
         If True, returns the number of voxels used for estimating the response
         function.

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -134,7 +134,7 @@ def test_auto_response():
                 data,
                 roi_center=None,
                 roi_radius=radius,
-                fa_operator=predefined,
+                fa_callable=predefined,
                 fa_thr=fa_thr,
                 return_number_of_voxels=True)
 
@@ -143,7 +143,7 @@ def test_auto_response():
                 data,
                 roi_center=None,
                 roi_radius=radius,
-                fa_operator=defined,
+                fa_callable=defined,
                 fa_thr=fa_thr,
                 return_number_of_voxels=True)
 


### PR DESCRIPTION
Add a new parameter (fa_operator) in auto_response to give an operator for the comparison with the FA threshold.

@jchoude, @arokem, @MrBago Can you review ? This PR will be useful when the MSMT PR will be merged.