### PR TITLE
MRG: Suppress a divide-by-zero warning.

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -559,7 +559,10 @@ def gfa(samples):
     n = samples.shape[-1]
     numer = n * (diff * diff).sum(-1)
     denom = (n - 1) * (samples * samples).sum(-1)
-    return np.sqrt(numer / denom)
+    if denom > 0:
+        return np.sqrt(numer / denom)
+    else:
+        return np.nan
 
 
 def reshape_peaks_for_visualization(peaks):

--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -12,9 +12,10 @@ from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
 import scipy.optimize as opt
 
+from dipy.reconst.odf import gfa
 from dipy.reconst.recspeed import (local_maxima, remove_similar_vertices,
                                    search_descending)
-from dipy.core.sphere import HemiSphere, Sphere
+from dipy.core.sphere import Sphere
 from dipy.data import default_sphere
 from dipy.core.ndindex import ndindex
 from dipy.reconst.shm import sh_to_sf_matrix
@@ -24,7 +25,7 @@ from dipy.reconst.peak_direction_getter import PeaksAndMetricsDirectionGetter
 def peak_directions_nl(sphere_eval, relative_peak_threshold=.25,
                        min_separation_angle=25, sphere=default_sphere,
                        xtol=1e-7):
-    """Non Linear Direction Finder
+    """Non Linear Direction Finder.
 
     Parameters
     ----------
@@ -91,7 +92,7 @@ def peak_directions_nl(sphere_eval, relative_peak_threshold=.25,
 
 def peak_directions(odf, sphere, relative_peak_threshold=.5,
                     min_separation_angle=25, minmax_norm=True):
-    """Get the directions of odf peaks
+    """Get the directions of odf peaks.
 
     Peaks are defined as points on the odf that are greater than at least one
     neighbor and greater than or equal to all neighbors. Peaks are sorted in
@@ -160,8 +161,7 @@ def peak_directions(odf, sphere, relative_peak_threshold=.5,
 def _pam_from_attrs(klass, sphere, peak_indices, peak_values, peak_dirs,
                     gfa, qa, shm_coeff, B, odf):
     """
-    Construct a PeaksAndMetrics object (or object of a subclass) from its
-    attributes.
+    Construct PeaksAndMetrics object (or subclass) from its attributes.
 
     This is also useful for pickling/unpickling of these objects (see also
     :func:`__reduce__` below).
@@ -397,7 +397,7 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
                      return_sh=True, gfa_thr=0, normalize_peaks=False,
                      sh_order=8, sh_basis_type=None, npeaks=5, B=None,
                      invB=None, parallel=False, nbr_processes=None):
-    """Fits the model to data and computes peaks and metrics
+    """Fit the model to data and computes peaks and metrics
 
     Parameters
     ----------
@@ -453,7 +453,6 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
         An object with ``gfa``, ``peak_directions``, ``peak_values``,
         ``peak_indices``, ``odf``, ``shm_coeffs`` as attributes
     """
-
     if return_sh and (B is None or invB is None):
         B, invB = sh_to_sf_matrix(
             sphere, sh_order, sh_basis_type, return_inv=True)
@@ -552,18 +551,6 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
                            odf_array if return_odf else None)
 
 
-def gfa(samples):
-    """The general fractional anisotropy of a function evaluated
-    on the unit sphere"""
-    diff = samples - samples.mean(-1)[..., None]
-    n = samples.shape[-1]
-    numer = n * (diff * diff).sum(-1)
-    denom = (n - 1) * (samples * samples).sum(-1)
-    if denom > 0:
-        return np.sqrt(numer / denom)
-    else:
-        return np.nan
-
 
 def reshape_peaks_for_visualization(peaks):
     """Reshape peaks for visualization.
@@ -580,7 +567,6 @@ def reshape_peaks_for_visualization(peaks):
     --------
     peaks : nd array (..., 3*N)
     """
-
     if isinstance(peaks, PeaksAndMetrics):
         peaks = peaks.peak_dirs
 

--- a/dipy/direction/tests/test_peaks.py
+++ b/dipy/direction/tests/test_peaks.py
@@ -12,9 +12,10 @@ from dipy.direction.peaks import (peaks_from_model,
                                   peak_directions,
                                   peak_directions_nl,
                                   reshape_peaks_for_visualization)
+
 from dipy.core.subdivide_octahedron import create_unit_hemisphere
 from dipy.core.sphere import unit_icosahedron
-from dipy.sims.voxel import multi_tensor, all_tensor_evecs, multi_tensor_odf
+from dipy.sims.voxel import multi_tensor, multi_tensor_odf
 from dipy.data import get_data, get_sphere
 from dipy.core.gradients import gradient_table, GradientTable
 from dipy.core.sphere_stats import angular_similarity

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -320,6 +320,7 @@ class ConstrainedSDTModel(SphHarmModel):
         Z = np.linalg.norm(qball_odf)
         # normalize ODF
         odf_sh /= Z
+
         shm_coeff, num_it = odf_deconv(odf_sh, self.R, self.B_reg,
                                        self.lambda_, self.tau)
         # print 'SDT CSD converged after %d iterations' % num_it

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -10,17 +10,15 @@ from dipy.reconst import dti, mapmri
 from dipy.sims.voxel import (MultiTensor,
                              multi_tensor_pdf,
                              single_tensor,
-                             cylinders_and_ball_soderman,
-                             callaghan_perpendicular)
+                             cylinders_and_ball_soderman)
 from scipy.special import gamma
 from scipy.misc import factorial
 from dipy.data import get_sphere
 from dipy.sims.voxel import add_noise
 import scipy.integrate as integrate
-import scipy.special as special
-from scipy.special import jn
 from dipy.core.sphere_stats import angular_similarity
-from dipy.direction.peaks import gfa, peak_directions
+from dipy.direction.peaks import peak_directions
+from dipy.reconst.odf import gfa
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.reconst.shm import sh_to_sf

--- a/dipy/reconst/tests/test_odf.py
+++ b/dipy/reconst/tests/test_odf.py
@@ -1,6 +1,7 @@
 import numpy as np
-from numpy.testing import run_module_suite, assert_equal
-from dipy.reconst.odf import (OdfFit, OdfModel, minmax_normalize)
+from numpy.testing import (run_module_suite, assert_equal, assert_almost_equal,
+                           assert_)
+from dipy.reconst.odf import (OdfFit, OdfModel, minmax_normalize, gfa)
 
 from dipy.core.subdivide_octahedron import create_unit_hemisphere
 from dipy.sims.voxel import multi_tensor, multi_tensor_odf
@@ -65,6 +66,24 @@ def test_minmax_normalize():
     odf3 = minmax_normalize(odf, odf3)
     assert_equal(odf3.max(), 1)
     assert_equal(odf3.min(), 0)
+
+
+def test_gfa():
+    g = gfa(np.ones(100))
+    assert_equal(g, 0)
+
+    g = gfa(np.ones((2, 100)))
+    assert_equal(g, np.array([0, 0]))
+
+    # The following series follows the rule (sqrt(n-1)/((n-1)^2))
+    g = gfa(np.hstack([np.ones((9)), [0]]))
+    assert_almost_equal(g, np.sqrt(9/81))
+    g = gfa(np.hstack([np.ones((99)), [0]]))
+    assert_almost_equal(g, np.sqrt(99/(99**2)))
+
+    # All-zeros returns a nan with no warning:
+    g = gfa(np.zeros(10))
+    assert_(np.isnan(g))
 
 
 if __name__ == '__main__':

--- a/dipy/reconst/tests/test_odf.py
+++ b/dipy/reconst/tests/test_odf.py
@@ -77,9 +77,9 @@ def test_gfa():
 
     # The following series follows the rule (sqrt(n-1)/((n-1)^2))
     g = gfa(np.hstack([np.ones((9)), [0]]))
-    assert_almost_equal(g, np.sqrt(9/81))
+    assert_almost_equal(g, np.sqrt(9./81))
     g = gfa(np.hstack([np.ones((99)), [0]]))
-    assert_almost_equal(g, np.sqrt(99/(99**2)))
+    assert_almost_equal(g, np.sqrt(99./(99.**2)))
 
     # All-zeros returns a nan with no warning:
     g = gfa(np.zeros(10))

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -1,13 +1,12 @@
 import numpy as np
 from dipy.data import get_sphere, get_3shell_gtab, get_isbi2013_2shell_gtab
 from dipy.reconst.shore import ShoreModel
-from dipy.reconst.shm import QballModel, sh_to_sf
-from dipy.direction.peaks import gfa, peak_directions
+from dipy.reconst.shm import sh_to_sf
+from dipy.direction.peaks import peak_directions
+from dipy.reconst.odf import gfa
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
-                           run_module_suite,
-                           assert_array_equal,
-                           assert_raises)
+                           run_module_suite)
 from dipy.sims.voxel import SticksAndBall
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity


### PR DESCRIPTION
Suppress the warning described in #1181? Still needs testing.