### PR TITLE
Added eigh version of localpca to svd version

### DIFF
--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -21,7 +21,7 @@ def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
         are the diffusion gradient directions.
     mask : 3D boolean array
         A mask with voxels that are true inside the brain and false outside of
-        it. The function denoises within the True part and returns zeros
+        it. The function denoises within the true part and returns zeros
         outside of those voxels.
     sigma : float or 3D array
         Standard deviation of the noise estimated from the data.

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def localpca(arr, mask, sigma, pca_method='eig', patch_radius=2,
+def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
              tau_factor=2.3, out_dtype=None):
     r"""Local PCA-based denoising of diffusion datasets.
 
@@ -49,6 +49,10 @@ def localpca(arr, mask, sigma, pca_method='eig', patch_radius=2,
                   PCA. PLoS ONE 8(9): e73021.
                   https://doi.org/10.1371/journal.pone.0073021
     """
+    if mask is None:
+        # If mask is not specified, use the whole volume
+        mask = np.ones_like(arr, dtype=bool)[..., 0]
+
     if pca_method == 'svd':
         # Try to get the SVD through direct API to lapack:
         try:

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -21,7 +21,8 @@ def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
         are the diffusion gradient directions.
     mask : 3D boolean array
         A mask with voxels that are true inside the brain and false outside of
-        it.
+        it. The function denoises within the True part and returns zeros
+        outside of those voxels.
     sigma : float or 3D array
         Standard deviation of the noise estimated from the data.
     pca_method : 'eig' or 'svd'

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -69,7 +69,7 @@ def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
     if out_dtype is None:
         out_dtype = arr.dtype
 
-    # We retain float64 precision, if the input is in this precision:
+    # We retain float64 precision, iff the input is in this precision:
     if arr.dtype == np.float64:
         calc_dtype = np.float64
 

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -221,17 +221,24 @@ def test_phantom():
 
     # Try this with a sigma volume, instead of a scalar
     sigma_vol = sigma * np.ones(DWI.shape[:-1])
-    mask = np.ones_like(DWI, dtype=bool)[..., 0]
-    mask[0, ...] = False
+    mask = np.zeros_like(DWI, dtype=bool)[..., 0]
+    mask[2:-2, 2:-2, 2:-2] = True
     DWI_den = localpca(DWI, sigma_vol, mask, patch_radius=3)
-    rmse_den = np.sum(np.abs(DWI_clean - DWI_den)) / np.sum(np.abs(DWI_clean))
-    rmse_noisy = np.sum(np.abs(DWI_clean - DWI)) / np.sum(np.abs(DWI_clean))
+    DWI_clean_masked = DWI_clean.copy()
+    DWI_clean_masked[~mask] = 0
+    DWI_masked = DWI.copy()
+    DWI_masked[~mask] = 0
+    rmse_den = np.sum(np.abs(DWI_clean_masked - DWI_den)) / np.sum(np.abs(
+            DWI_clean_masked))
+    rmse_noisy = np.sum(np.abs(DWI_clean_masked - DWI_masked)) / np.sum(np.abs(
+            DWI_clean_masked))
 
-    rmse_den_wrc = np.sum(np.abs(DWI_clean_wrc - DWI_den)
-                          ) / np.sum(np.abs(DWI_clean_wrc))
-    rmse_noisy_wrc = np.sum(np.abs(DWI_clean_wrc - DWI)) / \
-        np.sum(np.abs(DWI_clean_wrc))
-
+    DWI_clean_wrc_masked = DWI_clean_wrc.copy()
+    DWI_clean_wrc_masked[~mask] = 0
+    rmse_den_wrc = np.sum(np.abs(DWI_clean_wrc_masked - DWI_den)
+                          ) / np.sum(np.abs(DWI_clean_wrc_masked))
+    rmse_noisy_wrc = np.sum(np.abs(DWI_clean_wrc_masked - DWI_masked)) / \
+        np.sum(np.abs(DWI_clean_wrc_masked))
 
     assert_(np.max(DWI_clean) / sigma < np.max(DWI_den) / sigma)
     assert_(np.max(DWI_den) / sigma < np.max(DWI) / sigma)

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -170,7 +170,8 @@ def test_lpca_dtype():
 
     # If we set out_dtype, we get what we asked for:
     S0 = 200 * np.ones((20, 20, 20, 20), dtype=np.uint16)
-    S0ns = localpca(S0, sigma=np.ones((20, 20, 20)), out_dtype=np.float32)
+    S0ns = localpca(S0, sigma=np.ones((20, 20, 20)),
+                    out_dtype=np.float32)
     assert_equal(np.float32, S0ns.dtype)
 
     # If we set a few entries to zero, this induces negative entries in the
@@ -212,6 +213,10 @@ def test_phantom():
     assert_(rmse_den < rmse_noisy)
     assert_(rmse_den_wrc < rmse_noisy_wrc)
 
+    # Check if the results of different PCA methods (eig, svd) are similar
+    DWI_den_svd = localpca(DWI, sigma, pca_method='svd', patch_radius=3)
+    assert_array_almost_equal(DWI_den, DWI_den_svd)
+
     # Try this with a sigma volume, instead of a scalar
     sigma_vol = sigma * np.ones(DWI.shape[:-1])
     DWI_den = localpca(DWI, sigma_vol, patch_radius=3)
@@ -223,11 +228,11 @@ def test_phantom():
     rmse_noisy_wrc = np.sum(np.abs(DWI_clean_wrc - DWI)) / \
         np.sum(np.abs(DWI_clean_wrc))
 
+
     assert_(np.max(DWI_clean) / sigma < np.max(DWI_den) / sigma)
     assert_(np.max(DWI_den) / sigma < np.max(DWI) / sigma)
     assert_(rmse_den < rmse_noisy)
     assert_(rmse_den_wrc < rmse_noisy_wrc)
-
 
 
 def test_lpca_ill_conditioned():

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -231,6 +231,7 @@ def test_phantom():
     rmse_noisy_wrc = np.sum(np.abs(DWI_clean_wrc - DWI)) / \
         np.sum(np.abs(DWI_clean_wrc))
 
+
     assert_(np.max(DWI_clean) / sigma < np.max(DWI_den) / sigma)
     assert_(np.max(DWI_den) / sigma < np.max(DWI) / sigma)
     assert_(rmse_den < rmse_noisy)

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -220,8 +220,6 @@ def test_phantom():
     # Try this with a sigma volume, instead of a scalar
     sigma_vol = sigma * np.ones(DWI.shape[:-1])
     mask = np.ones_like(DWI, dtype=bool)[..., 0]
-    mask[0, ...] = False
-    mask[:, -1, :] = False
     DWI_den = localpca(DWI, sigma_vol, mask, patch_radius=3)
     rmse_den = np.sum(np.abs(DWI_clean - DWI_den)) / np.sum(np.abs(DWI_clean))
     rmse_noisy = np.sum(np.abs(DWI_clean - DWI)) / np.sum(np.abs(DWI_clean))

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -219,7 +219,10 @@ def test_phantom():
 
     # Try this with a sigma volume, instead of a scalar
     sigma_vol = sigma * np.ones(DWI.shape[:-1])
-    DWI_den = localpca(DWI, sigma_vol, patch_radius=3)
+    mask = np.ones_like(DWI, dtype=bool)[..., 0]
+    mask[0, ...] = False
+    mask[:, -1, :] = False
+    DWI_den = localpca(DWI, sigma_vol, mask, patch_radius=3)
     rmse_den = np.sum(np.abs(DWI_clean - DWI_den)) / np.sum(np.abs(DWI_clean))
     rmse_noisy = np.sum(np.abs(DWI_clean - DWI)) / np.sum(np.abs(DWI_clean))
 
@@ -227,7 +230,6 @@ def test_phantom():
                           ) / np.sum(np.abs(DWI_clean_wrc))
     rmse_noisy_wrc = np.sum(np.abs(DWI_clean_wrc - DWI)) / \
         np.sum(np.abs(DWI_clean_wrc))
-
 
     assert_(np.max(DWI_clean) / sigma < np.max(DWI_den) / sigma)
     assert_(np.max(DWI_den) / sigma < np.max(DWI) / sigma)

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -217,9 +217,12 @@ def test_phantom():
     DWI_den_svd = localpca(DWI, sigma, pca_method='svd', patch_radius=3)
     assert_array_almost_equal(DWI_den, DWI_den_svd)
 
+    assert_raises(ValueError, localpca, DWI, sigma, pca_method='empty')
+
     # Try this with a sigma volume, instead of a scalar
     sigma_vol = sigma * np.ones(DWI.shape[:-1])
     mask = np.ones_like(DWI, dtype=bool)[..., 0]
+    mask[0, ...] = False
     DWI_den = localpca(DWI, sigma_vol, mask, patch_radius=3)
     rmse_den = np.sum(np.abs(DWI_clean - DWI_den)) / np.sum(np.abs(DWI_clean))
     rmse_noisy = np.sum(np.abs(DWI_clean - DWI)) / np.sum(np.abs(DWI_clean))

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -910,7 +910,7 @@ class TensorFit(object):
     @auto_attr
     def md(self):
         r"""
-        Mean diffusitivity (MD) calculated from cached eigenvalues.
+        Mean diffusivity (MD) calculated from cached eigenvalues.
 
         Returns
         ---------
@@ -931,7 +931,7 @@ class TensorFit(object):
     @auto_attr
     def rd(self):
         r"""
-        Radial diffusitivity (RD) calculated from cached eigenvalues.
+        Radial diffusivity (RD) calculated from cached eigenvalues.
 
         Returns
         ---------
@@ -1007,7 +1007,7 @@ class TensorFit(object):
         .. math::
 
             Sphericity =
-            \frac{2 (\lambda2 - \lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
+            \frac{2 (\lambda_2 - \lambda_3)}{\lambda_1+\lambda_2+\lambda_3}
 
         Notes
         -----
@@ -1343,7 +1343,7 @@ def wls_fit_tensor(design_matrix, data, return_S0_hat=False):
         1. calculate OLS estimates of the data
         2. apply the OLS estimates as weights to the WLS fit of the data
 
-    This ensured heteroscadasticity could be properly modeled for various
+    This ensured heteroscedasticity could be properly modeled for various
     types of bootstrap resampling (namely residual bootstrap).
 
     .. math::
@@ -1477,7 +1477,7 @@ def _nlls_err_func(tensor, design_matrix, data, weighting=None,
         The voxel signal in all gradient directions
 
     weighting : str (optional).
-         Whether to use the Geman McClure weighting criterion (see [1]_
+         Whether to use the Geman-McClure weighting criterion (see [1]_
          for details)
 
     sigma : float or float array (optional)
@@ -1490,7 +1490,7 @@ def _nlls_err_func(tensor, design_matrix, data, weighting=None,
 
     Notes
     -----
-    The GemanMcClure M-estimator is described as follows [1]_ (page 1089): "The
+    The Geman-McClure M-estimator is described as follows [1]_ (page 1089): "The
     scale factor C affects the shape of the GMM [Geman-McClure M-estimator]
     weighting function and represents the expected spread of the residuals
     (i.e., the SD of the residuals) due to Gaussian distributed noise. The
@@ -1534,7 +1534,7 @@ def _nlls_err_func(tensor, design_matrix, data, weighting=None,
         w = 1 / (sigma**2)
 
     elif weighting == 'gmm':
-        # We use the Geman McClure M-estimator to compute the weights on the
+        # We use the Geman-McClure M-estimator to compute the weights on the
         # residuals:
         C = 1.4826 * np.median(np.abs(residuals - np.median(residuals)))
         with warnings.catch_warnings():
@@ -1573,7 +1573,7 @@ def _decompose_tensor_nan(tensor, tensor_alternative, min_diffusivity=0):
 
     Computes tensor eigen decomposition to calculate eigenvalues and
     eigenvectors (Basser et al., 1994a). Some fit approaches can produce nan
-    tensor elements in background voxels (particularly non-linear approachs).
+    tensor elements in background voxels (particularly non-linear approaches).
     This function avoids the eigen decomposition errors of nan tensor elements
     by replacing tensor with nan elements by a given alternative tensor
     estimate.
@@ -1732,7 +1732,7 @@ def restore_fit_tensor(design_matrix, data, sigma=None, jac=True,
 
     jac : bool, optional
         Whether to use the Jacobian of the tensor to speed the non-linear
-        optimization procedure used to fit the tensor paramters (see also
+        optimization procedure used to fit the tensor parameters (see also
         :func:`nlls_fit_tensor`). Default: True
 
     return_S0_hat : bool
@@ -1856,8 +1856,9 @@ _lt_indices = np.array([[0, 1, 3],
 def from_lower_triangular(D):
     """ Returns a tensor given the six unique tensor elements
 
-    Given the six unique tensor elments (in the order: Dxx, Dxy, Dyy, Dxz, Dyz,
-    Dzz) returns a 3 by 3 tensor. All elements after the sixth are ignored.
+    Given the six unique tensor elements (in the order: Dxx, Dxy, Dyy, Dxz,
+    Dyz, Dzz) returns a 3 by 3 tensor. All elements after the sixth are
+    ignored.
 
     Parameters
     -----------

--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -468,7 +468,7 @@ def mode(q_form):
 
     Notes
     -----
-    Mode ranges between -1 (linear anisotropy) and +1 (planar anisotropy)
+    Mode ranges between -1 (planar anisotropy) and +1 (linear anisotropy)
     with 0 representing orthotropy. Mode is calculated with the
     following equation (equation 9 in [1]_):
 

--- a/doc/theory/b_and_q.rst
+++ b/doc/theory/b_and_q.rst
@@ -125,6 +125,7 @@ named the reciprocal space ``q-space`` with units of
 $\mathrm{seconds}.\mathrm{mm}^{-1}$. 
 
 .. math::
+   :label: fourier
 
    q = \gamma \delta G /{2\pi}
 


### PR DESCRIPTION
Denoising with LocalPCA:
The bottleneck of LocalPCA is decomposition of the data into the eigenvalues/singular values and the corresponding vectors (basis). For this purpose, Eigenvalue decomposition was used but was previously replaced with Singular Values Decomposition, for more accuracy. However, SVD is many times slower than EVD. In this pull request, the code is changed to include both of them, as an optional parameter, "pca_method".
Also for more speed up, the function accepts the brain mask as an optional parameter and the denoising will be only applied to the voxels inside the mask.