### PR TITLE
RF: Remove patch for older numpy ravel_multi_index.

### DIFF
--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -11,7 +11,7 @@ from dipy.tracking.utils import (affine_for_trackvis, connectivity_matrix,
                                  ndbincount, reduce_labels,
                                  reorder_voxels_affine, seeds_from_mask,
                                  random_seeds_from_mask, target,
-                                 target_line_based, _rmi, unique_rows, near_roi,
+                                 target_line_based, unique_rows, near_roi,
                                  reduce_rois, path_length, flexi_tvis_affine,
                                  get_flexi_tvis_affine, _min_at)
 
@@ -449,34 +449,6 @@ def test_streamline_mapping():
     mapping = streamline_mapping(streamlines, affine=affine,
                                  mapping_as_streamlines=True)
     assert_equal(mapping, expected)
-
-
-def test_rmi():
-    I1 = _rmi([3, 4], [10, 10])
-    assert_equal(I1, 34)
-    I1 = _rmi([0, 0], [10, 10])
-    assert_equal(I1, 0)
-    assert_raises(ValueError, _rmi, [10, 0], [10, 10])
-
-    try:
-        from numpy import ravel_multi_index
-    except ImportError:
-        raise nose.SkipTest()
-
-    # Dtype of random integers is system dependent
-    A, B, C, D = np.random.randint(0, 1000, size=[4, 100])
-    I1 = _rmi([A, B], dims=[1000, 1000])
-    I2 = ravel_multi_index([A, B], dims=[1000, 1000])
-    assert_array_equal(I1, I2)
-    I1 = _rmi([A, B, C, D], dims=[1000] * 4)
-    I2 = ravel_multi_index([A, B, C, D], dims=[1000] * 4)
-    assert_array_equal(I1, I2)
-    # Check for overflow with small int types
-    indices = np.random.randint(0, 255, size=(2, 100))
-    dims = (1000, 1000)
-    I1 = _rmi(indices, dims=dims)
-    I2 = ravel_multi_index(indices, dims=dims)
-    assert_array_equal(I1, I2)
 
 
 def test_affine_for_trackvis():

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -53,6 +53,7 @@ from warnings import warn
 
 from nibabel.affines import apply_affine
 from scipy.spatial.distance import cdist
+from numpy import ravel_multi_index
 
 from dipy.core.geometry import dist_to_corner
 
@@ -69,30 +70,6 @@ from dipy.tracking.vox2track import _streamlines_in_mask
 from dipy.tracking._utils import (_mapping_to_voxel, _to_voxel_coordinates)
 from dipy.io.bvectxt import orientation_from_string
 import nibabel as nib
-
-
-def _rmi(index, dims):
-    """An alternate implementation of numpy.ravel_multi_index for older
-    versions of numpy.
-
-    Assumes array layout is C contiguous
-    """
-    # Upcast to integer type capable of holding largest array index
-    index = np.asarray(index, dtype=np.intp)
-    dims = np.asarray(dims)
-    if index.ndim > 2:
-        raise ValueError("Index should be 1 or 2-D")
-    elif index.ndim == 2:
-        index = index.T
-    if (index >= dims).any():
-        raise ValueError("Index exceeds dimensions")
-    strides = np.r_[dims[:0:-1].cumprod()[::-1], 1]
-    return (strides * index).sum(-1)
-
-try:
-    from numpy import ravel_multi_index
-except ImportError:
-    ravel_multi_index = _rmi
 
 
 def density_map(streamlines, vol_dims, voxel_size=None, affine=None):


### PR DESCRIPTION
Attempting to address #1299. 

It looks like the test that is failing there is related to a patch of numpy's ravel_multi_index for older versions of numpy. I am putting in this PR to see whether we can do without that patch altogether at this point.