### PR TITLE
DOC: Add missing label to reciprocal space eq.

### DIFF
--- a/doc/theory/b_and_q.rst
+++ b/doc/theory/b_and_q.rst
@@ -125,6 +125,7 @@ named the reciprocal space ``q-space`` with units of
 $\mathrm{seconds}.\mathrm{mm}^{-1}$. 
 
 .. math::
+   :label: fourier
 
    q = \gamma \delta G /{2\pi}
 


### PR DESCRIPTION
Add missing label to reciprocal space equation in b_and_q.rst file in
the doc/theory folder.

Although according to
http://www.sphinx-doc.org/en/stable/ext/math.html
cross-referencing equations via their label will not work across
different documents.

The equation at issue is referenced from doc/faq.rst.