### PR TITLE
Fix inversion in the dti mode doc

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -468,7 +468,7 @@ def mode(q_form):
 
     Notes
     -----
-    Mode ranges between -1 (linear anisotropy) and +1 (planar anisotropy)
+    Mode ranges between -1 (planar anisotropy) and +1 (linear anisotropy)
     with 0 representing orthotropy. Mode is calculated with the
     following equation (equation 9 in [1]_):
 


### PR DESCRIPTION
According to the article referenced in the docstring and some quick tests **-1=planar anisotropy** and **1=linear anisotropy**

