### PR TITLE
DOC: Fix typos and formatting in .rst files and Python examples.

### DIFF
--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -4,14 +4,14 @@
 Development workflow
 ####################
 
-You already have your own forked copy of the `dipy`_ repository, by
+You already have your own forked copy of the dipy_ repository, by
 following :ref:`forking`. You have :ref:`set-up-fork`. You have configured
 git by following :ref:`configure-git`.  Now you are ready for some real work.
 
 Workflow summary
 ================
 
-In what follows we'll refer to the upstream dipy ``master`` branch, as
+In what follows we'll refer to the upstream DIPY ``master`` branch, as
 "trunk".
 
 * Don't use your ``master`` branch for anything.  Consider deleting it.
@@ -81,7 +81,7 @@ what the changes in the branch are for.  For example ``add-ability-to-fly``, or
     git checkout my-new-feature
 
 Generally, you will want to keep your feature branches on your public github_
-fork of `dipy`_.  To do this, you `git push`_ this new branch up to your
+fork of dipy_. To do this, you `git push`_ this new branch up to your
 github repo.  Generally (if you followed the instructions in these pages, and by
 default), git will have a link to your github repo, called ``origin``.  You push
 up to your own repo on github with::

--- a/doc/devel/gitwash/following_latest.rst
+++ b/doc/devel/gitwash/following_latest.rst
@@ -5,7 +5,7 @@
 =============================
 
 These are the instructions if you just want to follow the latest
-*dipy* source, but you don't need to do any development for now.
+DIPY source, but you don't need to do any development for now.
 
 The steps are:
 

--- a/doc/devel/gitwash/forking_hell.rst
+++ b/doc/devel/gitwash/forking_hell.rst
@@ -1,12 +1,12 @@
 .. _forking:
 
 ======================================================
-Making your own copy (fork) of dipy
+Making your own copy (fork) of DIPY
 ======================================================
 
-You need to do this only once.  The instructions here are very similar
+You need to do this only once. The instructions here are very similar
 to the instructions at http://help.github.com/forking/ |emdash| please see
-that page for more detail.  We're repeating some of it here just to give the
+that page for more detail. We're repeating some of it here just to give the
 specifics for the `dipy`_ project, and to suggest some default names.
 
 Set up and configure a github account
@@ -17,7 +17,7 @@ If you don't have a github account, go to the github page, and make one.
 You then need to configure your account to allow write access |emdash| see
 the ``Generating SSH keys`` help on `github help`_.
 
-Create your own forked copy of `dipy`_
+Create your own forked copy of dipy_
 ======================================================
 
 #. Log into your github account.

--- a/doc/devel/gitwash/git_intro.rst
+++ b/doc/devel/gitwash/git_intro.rst
@@ -2,14 +2,14 @@
  Introduction
 ==============
 
-These pages describe a git_ and github_ workflow for the `dipy`_
+These pages describe a git_ and github_ workflow for the dipy_
 project.
 
 There are several different workflows here, for different ways of
-working with *dipy*.
+working with DIPY.
 
 This is not a comprehensive git reference, it's just a workflow for our
-own project.  It's tailored to the github hosting service. You may well
+own project. It's tailored to the github hosting service. You may well
 find better or quicker ways of getting stuff done with git, but these
 should get you started.
 

--- a/doc/devel/gitwash/index.rst
+++ b/doc/devel/gitwash/index.rst
@@ -1,6 +1,6 @@
 .. _using-git:
 
-Working with *dipy* source code
+Working with DIPY source code
 ================================================
 
 Contents:

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -1,6 +1,6 @@
  .. _development:
 
-DiPy development
+DIPY development
 ================
 
 Contents:

--- a/doc/devel/make_release.rst
+++ b/doc/devel/make_release.rst
@@ -1,19 +1,19 @@
 .. _release-guide:
 
 *********************************
-A guide to making a dipy release
+A guide to making a DIPY release
 *********************************
 
-A guide for developers who are doing a dipy release
+A guide for developers who are doing a DIPY release
 
 .. _release-tools:
 
 Release tools
 =============
 
-There are some release utilities that come with nibabel_.  nibabel should
+There are some release utilities that come with nibabel_. nibabel should
 install these as the ``nisext`` package, and the testing stuff is understandably
-in the ``testers`` module of that package.  Dipy has Makefile targets for their
+in the ``testers`` module of that package. DIPY has Makefile targets for their
 use.  The relevant targets are::
 
     make check-version-info
@@ -75,10 +75,10 @@ Release checklist
   ``README`` in the root directory, maybe with ``vim`` ``diffthis`` command.
   Check all the links are still valid.
 
-* Check all the dipy builds are green on the `nipy buildbot`_
+* Check all the DIPY builds are green on the `nipy buildbot`_
 
 * If you have travis-ci_ building set up you might want to push the code in its
-  current state to a branch that will build, e.g::
+current state to a branch that will build, e.g.::
 
     git branch -D pre-release-test # in case branch already exists
     git co -b pre-release-test
@@ -128,7 +128,7 @@ Release checklist
     git clean -fxd
     python setup.py build_ext --inplace
 
-* Make sure all tests pass on your local machine (from the dipy root directory)::
+* Make sure all tests pass on your local machine (from the ``<dipy root>`` directory)::
 
     cd ..
     nosetests --with-doctest dipy
@@ -144,14 +144,16 @@ Release checklist
   running the doctests in the code, where the doctests pass when run in nose -
   we should find out why this is at some point, but leave it for now.
 
-* Trigger builds of all the binary build testers for dipy, using the web
-  interface.  You may need permissions set to do this - contact Matthew or
+* Trigger builds of all the binary build testers for DIPY, using the web
+  interface. You may need permissions set to do this - contact Matthew or
   Eleftherios if you do.
 
-  At the moment, the useful dipy binary build testers are:
+  At the moment, the useful DIPY binary build testers are:
 
-      * http://nipy.bic.berkeley.edu/builders/dipy-bdist32-26
+      * http://nipy.bic.berkeley.edu/builders/dipy-bdist32-35
       * http://nipy.bic.berkeley.edu/builders/dipy-bdist32-27
+      * http://nipy.bic.berkeley.edu/builders/dipy-bdist64-27
+      * http://nipy.bic.berkeley.edu/builders/dipy-bdist64-35
       * http://nipy.bic.berkeley.edu/builders/dipy-bdist-mpkg-2.6
       * http://nipy.bic.berkeley.edu/builders/dipy-bdist-mpkg-2.7
 
@@ -263,9 +265,9 @@ tag to github, so the buildbots can find the released code and build it.
 
   Download the builds and upload to pypi.
 
-  You can upload the exe files with the *files* interface for the new dipy release.
+  You can upload the exe files with the *files* interface for the new DIPY release.
   Obviously you'll need to log in to do this, and you'll need to be an admin for
-  the dipy pypi project.
+  the DIPY pypi project.
 
   For reference, if you need to do binary exe builds by hand, use something
   like::

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -66,7 +66,7 @@ regtools.overlay_slices(static, resampled, None, 2,
 .. figure:: resampled_2.png
    :align: center
 
-   **Input images before alignment**.
+   Input images before alignment.
 """
 
 """
@@ -99,7 +99,7 @@ regtools.overlay_slices(static, transformed, None, 2,
 .. figure:: transformed_com_2.png
    :align: center
 
-   **Registration result by aligning the centers of mass of the images**.
+   Registration result by aligning the centers of mass of the images.
 """
 
 """
@@ -203,7 +203,7 @@ regtools.overlay_slices(static, transformed, None, 2,
 .. figure:: transformed_trans_2.png
    :align: center
 
-   **Registration result by translating the moving image, using MI**.
+   Registration result by translating the moving image, using Mutual Information.
 """
 
 """
@@ -238,7 +238,7 @@ regtools.overlay_slices(static, transformed, None, 2,
 .. figure:: transformed_rigid_2.png
    :align: center
 
-   **Registration result with a rigid transform, using Mutual Information**.
+   Registration result with a rigid transform, using Mutual Information.
 """
 
 """
@@ -274,7 +274,7 @@ regtools.overlay_slices(static, transformed, None, 2,
 .. figure:: transformed_affine_2.png
    :align: center
 
-   **Registration result with an affine transform, using Mutual Information**.
+   Registration result with an affine transform, using Mutual Information.
 
 .. [Mattes03] Mattes, D., Haynor, D. R., Vesselle, H., Lewellen, T. K.,
               Eubank, W. (2003). PET-CT image registration in the chest using

--- a/doc/examples/brain_extraction_dwi.py
+++ b/doc/examples/brain_extraction_dwi.py
@@ -3,8 +3,8 @@
 Brain segmentation with median_otsu
 ===================================
 
-We show how to extract brain information and mask from a b0 image using dipy's
-segment.mask module.
+We show how to extract brain information and mask from a b0 image using dipy_'s
+``segment.mask`` module.
 
 First import the necessary modules:
 """
@@ -15,8 +15,8 @@ import nibabel as nib
 """
 Download and read the data for this tutorial.
 
-The scil_b0 dataset contains different data from different companies and
-models. For this example, the data comes from a 1.5 tesla Siemens MRI.
+The ``scil_b0`` dataset contains different data from different companies and
+models. For this example, the data comes from a 1.5 Tesla Siemens MRI.
 """
 
 from dipy.data.fetcher import fetch_scil_b0, read_siemens_scil_b0
@@ -28,7 +28,7 @@ data = np.squeeze(img.get_data())
 ``img`` contains a nibabel Nifti1Image object. Data is the actual brain data as
 a numpy ndarray.
 
-Segment the brain using dipy's mask module.
+Segment the brain using DIPY's ``mask`` module.
 
 ``median_otsu`` returns the segmented brain data and a binary mask of the brain.
 It is possible to fine tune the parameters of ``median_otsu`` (``median_radius``
@@ -41,10 +41,10 @@ from dipy.segment.mask import median_otsu
 b0_mask, mask = median_otsu(data, 2, 1)
 
 """
-Saving the segmentation results is very easy using nibabel. We need the b0_mask,
-and the binary mask volumes. The affine matrix which transform the image's
-coordinates to the world coordinates is also needed. Here, we choose to save
-both images in float32.
+Saving the segmentation results is very easy using nibabel. We need the
+``b0_mask``, and the binary mask volumes. The affine matrix which transform the
+image's coordinates to the world coordinates is also needed. Here, we choose to
+save both images in ``float32``.
 """
 
 mask_img = nib.Nifti1Image(mask.astype(np.float32), img.affine)
@@ -55,7 +55,7 @@ nib.save(mask_img, fname + '_binary_mask.nii.gz')
 nib.save(b0_img, fname + '_mask.nii.gz')
 
 """
-Quick view of the results middle slice using matplotlib.
+Quick view of the results middle slice using ``matplotlib``.
 """
 
 import matplotlib.pyplot as plt
@@ -77,12 +77,12 @@ plt.savefig('median_otsu.png')
 .. figure:: median_otsu.png
    :align: center
 
-   **An application of median_otsu for brain segmentation**.
+   An application of median_otsu for brain segmentation.
 
 ``median_otsu`` can also automatically crop the outputs to remove the largest
 possible number of background voxels. This makes outputted data significantly
-smaller.  auto cropping in ``median_otsu`` is activated by setting the
-``autocrop`` parameter to True.
+smaller. Auto-cropping in ``median_otsu`` is activated by setting the
+``autocrop`` parameter to ``True``.
 """
 
 b0_mask_crop, mask_crop = median_otsu(data, 4, 4, autocrop=True)
@@ -96,3 +96,9 @@ b0_img_crop = nib.Nifti1Image(
     b0_mask_crop.astype(np.float32), img.affine)
 nib.save(mask_img_crop, fname + '_binary_mask_crop.nii.gz')
 nib.save(b0_img_crop, fname + '_mask_crop.nii.gz')
+
+"""
+
+.. include:: ../links_names.inc
+
+"""

--- a/doc/examples/bundle_registration.py
+++ b/doc/examples/bundle_registration.py
@@ -73,7 +73,7 @@ show_both_bundles([cb_subj1, cb_subj2],
 .. figure:: before_registration.png
    :align: center
 
-   **Before bundle registration**.
+   Before bundle registration.
 """
 
 show_both_bundles([cb_subj1, cb_subj2_aligned],
@@ -84,7 +84,7 @@ show_both_bundles([cb_subj1, cb_subj2_aligned],
 .. figure:: after_registration.png
    :align: center
 
-   **After bundle registration**.
+   After bundle registration.
 
 As you can see the two cingulum bundles are well aligned although they contain
 many streamlines of different length and shape.

--- a/doc/examples/combined_workflow_creation.py
+++ b/doc/examples/combined_workflow_creation.py
@@ -3,13 +3,13 @@
 Creating a new combined workflow.
 ============================================================
 
-A combined workflow is a series of dipy workflows organized together in a way
-that the output of a workflow serves as input for the next one.
+A ``CombinedWorkflow`` is a series of dipy_ workflows organized together in a
+way that the output of a workflow serves as input for the next one.
 """
 
 """
-First create your combined workflow class. Your combine workflow class file
-is usually located in the ../dipy/workflows directory.
+First create your ``CombinedWorkflow`` class. Your ``CombinedWorkflow`` class
+file is usually located in the ``dipy/workflows`` directory.
 """
 
 from dipy.workflows.combined_workflow import CombinedWorkflow
@@ -19,7 +19,7 @@ from dipy.workflows.combined_workflow import CombinedWorkflow
 combined workflow.
 """
 
-from dipy.workflows.denoise import  NLMeansFlow
+from dipy.workflows.denoise import NLMeansFlow
 from dipy.workflows.segment import MedianOtsuFlow
 
 """
@@ -83,7 +83,7 @@ class DenoiseAndSegment(CombinedWorkflow):
             self.run_sub_flow(me_flow, denoised, out_dir=out_dir)
 
 """
-Use self.get_io_iterator() in every workflow you create. This creates
+Use ``self.get_io_iterator()`` in every workflow you create. This creates
 an ``IOIterator`` object that create output file names and directory structure
 based on the inputs and some other advanced output strategy parameters.
 
@@ -91,20 +91,21 @@ Iterating on the ``IOIterator`` object you created previously you
 conveniently get all input and output paths for every input file
 found when globbin the input parameters.
 
-In the IOIterator loop you can see how we create a new NLMeans workflow then
-run it using self.run_sub_flow. Running it this way will pass any workflow
-specific parameter that was retreived from the command line and will append the
-ones you specify as optional parameters (out_dir in this case).
+In the ``IOIterator`` loop you can see how we create a new ``NLMeans`` workflow
+then run it using ``self.run_sub_flow``. Running it this way will pass any
+workflow specific parameter that was retreived from the command line and will
+append the ones you specify as optional parameters (``out_dir`` in this case).
 
-Lastly, the outputs paths are retrived using workflow.last_generated_outputs.
-This allows to use ``denoise`` as the input for the ``MedianOtsuFlow``
+Lastly, the outputs paths are retrived using
+``workflow.last_generated_outputs``. This allows to use ``denoise`` as the
+input for the ``MedianOtsuFlow``.
 """
 
 """
 
 This is it for the combined workflow class! Now to be able to call it easily via
 command line, you need this last bit of code. It is usually in an executable
-file located in ../dipy/bin/.
+file located in ``bin``.
 """
 
 from dipy.workflows.flow_runner import run_flow
@@ -119,9 +120,10 @@ if __name__ == "__main__":
 This is the only thing needed to make your workflow available through command
 line.
 
-Now just call the script you just made with -h to see the argparser help text.
+Now just call the script you just made with ``-h`` to see the argparser help
+text::
 
-`python combined_workflow_creation.py --help`
+   python combined_workflow_creation.py --help
 
 You should see all your parameters available along with some extra common ones
 like logging file and force overwrite. Also all the documentation you wrote
@@ -129,9 +131,12 @@ about each parameter is there. Also note that every sub workflow optional
 parameter is available.
 
 Now call it for real with a nifti file to see the results. Experiment
-with the parameters and see the results.
+with the parameters and see the results::
 
-`python combined_workflow_creation.py volume.nii.gz`
+   python combined_workflow_creation.py volume.nii.gz
+
+.. include:: ../links_names.inc
+
 """
 
 

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -5,8 +5,8 @@ Crossing-preserving contextual enhancement
 ==============================================
 
 This demo presents an example of crossing-preserving contextual enhancement of
-FOD/ODF fields [Meesters2016_ISMRM_], implementing the contextual PDE framework
-of [Portegies2015_PLoSOne]_ for processing HARDI data. The aim is to enhance the
+FOD/ODF fields [Meesters2016]_, implementing the contextual PDE framework
+of [Portegies2015a]_ for processing HARDI data. The aim is to enhance the
 alignment of elongated structures in the data such that crossing/junctions are
 maintained while reducing noise and small incoherent structures. This is
 achieved via a hypo-elliptic 2nd order PDE in the domain of coupled positions
@@ -23,7 +23,7 @@ PDE with evolution time :math:`t\geq 0` is given by:
 
 .. math::
 
-    \begin{cases}
+  \begin{cases}
   \frac{\partial}{\partial t} W({\bf y},{\bf n},t) &= ((D^{33}({\bf n} \cdot
           \nabla)^2 + D^{44} \Delta_{S^2})W)({\bf y},{\bf n},t)
   \\ W({\bf y},{\bf n},0) &= U({\bf y},{\bf n})
@@ -51,27 +51,29 @@ onto :math:`{\bf n}`.
 Note that the shift-twist convolution differs from a Euclidean convolution and
 takes into account the non-flat structure of the space :math:`\mathbb{R}^3\rtimes S^2`.
 
-The kernel :math:`P_t` has a stochastic interpretation [DuitsAndFranken_IJCV]_.
+The kernel :math:`P_t` has a stochastic interpretation [DuitsAndFranken2011]_.
 It can be seen as the limiting distribution obtained by accumulating random
 walks of particles in the position/orientation domain, where in each step the
 particles can (randomly) move forward/backward along their current orientation,
-and (randomly) change their orientation.  This is an extension to the 3D case of
+and (randomly) change their orientation. This is an extension to the 3D case of
 the process for contour enhancement of 2D images.
 
 .. figure:: _static/stochastic_process.jpg
    :scale: 60 %
    :align: center
 
-   The random motion of particles (a) and it's corresponding probability map (b) in 2D. The 3D kernel is shown on the right. Adapted from [Portegies2015_PLoSOne]_.
+   The random motion of particles (a) and its corresponding probability map
+   (b) in 2D. The 3D kernel is shown on the right. Adapted from
+   [Portegies2015a]_.
 
 In practice, as the exact analytical formulas for the kernel :math:`P_t`
-are unknown, we use the approximation given in [Portegies2015_SSVM]_.
+are unknown, we use the approximation given in [Portegies2015b]_.
 
 """
 
 """
 The enhancement is evaluated on the Stanford HARDI dataset
-(150 orientations, b=2000s/mm^2) where Rician noise is added. Constrained
+(150 orientations, b=2000 $s/mm^2$) where Rician noise is added. Constrained
 spherical deconvolution is used to model the fiber orientations.
 
 """
@@ -118,10 +120,10 @@ csd_fit_noisy = csd_model_noisy.fit(data_noisy_small)
 csd_shm_noisy = csd_fit_noisy.shm_coeff
 
 """
-Inspired by [RodriguesEurographics_], a lookup-table is created, containing
+Inspired by [Rodrigues2010]_, a lookup-table is created, containing
 rotated versions of the kernel :math:`P_t` sampled over a discrete set of
 orientations. In order to ensure rotationally invariant processing, the discrete
-orientations are required to be equally distributed over a sphere. Per default,
+orientations are required to be equally distributed over a sphere. By default,
 a sphere with 100 directions is used.
 
 """
@@ -253,27 +255,29 @@ fvtk.record(ren, out_path='enhancements.png', size=(900, 900))
    of noisy data.
 
 References
-~~~~~~~~~~
+----------
 
-.. [Meesters2016_ISMRM] S. Meesters, G. Sanguinetti, E. Garyfallidis,
-                        J. Portegies, R. Duits. (2016) Fast implementations of
-                        contextual PDE’s for HARDI data processing in DIPY.
-                        ISMRM 2016 conference.
-.. [Portegies2015_PLoSOne] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters,
-                           G.Girard, and R. Duits. (2015) Improving Fiber
-                           Alignment in HARDI by Combining Contextual PDE flow
-                           with Constrained Spherical Deconvolution. PLoS One.
-.. [Portegies2015_SSVM] J. Portegies, G. Sanguinetti, S. Meesters, and R. Duits.
-                        (2015) New Approximation of a Scale Space Kernel on SE(3)
-                        and Applications in Neuroimaging. Fifth International
-                        Conference on Scale Space and Variational Methods in
-                        Computer Vision
-.. [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant diffusions 
-                        on the space of positions and orientations and their 
-                        application to crossing-preserving smoothing of HARDI 
-                        images. International Journal of Computer Vision, 92:231-264.
-.. [RodriguesEurographics] P. Rodrigues, R. Duits, B. Romeny, A. Vilanova
-                           (2010). Accelerated Diffusion Operators for Enhancing DW-MRI. 
-                           Eurographics Workshop on Visual Computing for Biology and Medicine. 
-                           The Eurographics Association.
+.. [Meesters2016] S. Meesters, G. Sanguinetti, E. Garyfallidis, J. Portegies,
+   R. Duits. (2016) Fast implementations of contextual PDE’s for HARDI data
+   processing in DIPY. ISMRM 2016 conference.
+
+.. [Portegies2015a] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters,
+   G.Girard, and R. Duits. (2015) Improving Fiber Alignment in HARDI by
+   Combining Contextual PDE flow with Constrained Spherical Deconvolution.
+   PLoS One.
+
+.. [Portegies2015b] J. Portegies, G. Sanguinetti, S. Meesters, and R. Duits.
+   (2015) New Approximation of a Scale Space Kernel on SE(3) and Applications
+   in Neuroimaging. Fifth International Conference on Scale Space and
+   Variational Methods in Computer Vision.
+
+.. [DuitsAndFranken2011] R. Duits and E. Franken (2011) Left-invariant
+   diffusions on the space of positions and orientations and their application
+   to crossing-preserving smoothing of HARDI images. International Journal of
+   Computer Vision, 92:231-264.
+
+.. [Rodrigues2010] P. Rodrigues, R. Duits, B. Romeny, A. Vilanova (2010).
+   Accelerated Diffusion Operators for Enhancing DW-MRI. Eurographics Workshop
+   on Visual Computing for Biology and Medicine. The Eurographics Association.
+
 """

--- a/doc/examples/denoise_ascm.py
+++ b/doc/examples/denoise_ascm.py
@@ -36,7 +36,7 @@ from dipy.denoise.non_local_means import non_local_means
 from dipy.denoise.adaptive_soft_matching import adaptive_soft_matching
 
 """
-Choose one of the data from the datasets in DIPY
+Choose one of the data from the datasets in dipy_
 """
 
 fetch_sherbrooke_3shell()
@@ -127,7 +127,7 @@ print("The ascm result saved in denoised_ascm.png")
 .. figure:: denoised_ascm.png
    :align: center
 
-   **Showing the axial slice without (left) and with (middle) ASCM denoising**.
+   Showing the axial slice without (left) and with (middle) ASCM denoising.
 """
 
 """
@@ -168,7 +168,7 @@ print("The comparison result saved in ascm_comparison.png")
 .. figure:: ascm_comparison.png
    :align: center
 
-   **Comparing outputs of the NLMEANS and ASCM**.
+   Comparing outputs of the NLMEANS and ASCM.
 """
 
 """

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -105,7 +105,7 @@ print("The result saved in denoised_localpca.png")
 .. figure:: denoised_localpca.png
    :align: center
 
-   **Showing the middle axial slice of the local PCA denoised output**.
+   Showing the middle axial slice of the local PCA denoised output.
 """
 
 nib.save(nib.Nifti1Image(denoised_arr,

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -31,7 +31,7 @@ data = data[..., 1]
 
 print("vol size", data.shape)
 
-# lets create a noisy data with gaussian data
+# lets create a noisy data with Gaussian data
 
 """
 In order to call ``non_local_means`` first you need to estimate the standard

--- a/doc/examples/deterministic_fiber_tracking.py
+++ b/doc/examples/deterministic_fiber_tracking.py
@@ -18,8 +18,8 @@ tractography and unlike EuDX does not follow the peaks of the local models but
 uses the entire orientation distributions.
 
 This example is an extension of the
-:ref:``example_probabilistic_fiber_tracking`` example. We begin by loading the
-data and fitting a constrained spherical deconvolution (CSD) reconstruction
+:ref:`example_probabilistic_fiber_tracking` example. We begin by loading the
+data and fitting a Constrained Spherical Deconvolution (CSD) reconstruction
 model.
 """
 
@@ -55,7 +55,7 @@ FA = fractional_anisotropy(tenfit.evals)
 classifier = ThresholdTissueClassifier(FA, .2)
 
 """
-The fiber orientation distribution (FOD) of the CSD model estimates the
+The Fiber Orientation Distribution (FOD) of the CSD model estimates the
 distribution of small fiber bundles within each voxel. This distribution
 can be used for deterministic fiber tracking. As for probabilistic tracking,
 there are many ways to provide those distributions to the deterministic maximum

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -6,9 +6,11 @@ Fiber to bundle coherence measures
 
 This demo presents the fiber to bundle coherence (FBC) quantitative
 measure of the alignment of each fiber with the surrounding fiber bundles
-[Meesters2016_HBM]_. These measures are useful in “cleaning” the results of
+[Meesters2016]_. These measures are useful in “cleaning” the results of
 tractography algorithms, since low FBCs indicate which fibers are isolated and
-poorly aligned with their neighbors, see Fig. 1.
+poorly aligned with their neighbors, as shown in the figure below.
+
+.. _fiber_to_bundle_coherence:
 
 .. figure:: _static/fbc_illustration.png
    :scale: 60 %
@@ -21,7 +23,7 @@ poorly aligned with their neighbors, see Fig. 1.
    evaluating the kernel density estimator along the fibers. One spurious
    fiber is present which is isolated and badly aligned with the other fibers,
    and can be identified by a low LFBC value in the region where it deviates
-   from the bundle. Figure adapted from [Portegies2015_PLoSOne]_.
+   from the bundle. Figure adapted from [Portegies2015]_.
 
 Here we implement FBC measures based on kernel density estimation in the
 non-flat 5D position-orientation domain. First we compute the kernel density
@@ -30,14 +32,14 @@ and orientations) of the tractography. Then, the Local FBC (LFBC) is the
 result of evaluating the estimator along each element of the lifted fiber.
 A whole fiber measure, the relative FBC (RFBC), is calculated
 by the minimum of the moving average LFBC along the fiber.
-Details of the computation of FBC can be found in [Portegies2015_PLoSOne]_.
+Details of the computation of FBC can be found in [Portegies2015]_.
 
 """
 
 """
 The FBC measures are evaluated on the Stanford HARDI dataset
-(150 orientations, b=2000s/mm^2) which is one of the standard example datasets
-in DIPY.
+(150 orientations, b=2000 $s/mm^2$) which is one of the standard example
+datasets in dipy_.
 """
 
 import numpy as np
@@ -164,9 +166,9 @@ for i in range(len(streamlines)):
 streamlines = list(sfil)
 
 """
-Inspired by [Paulo_Eurographics]_, a lookup-table is created, containing
-rotated versions of the fiber propagation kernel :math:`P_t`
-[DuitsAndFranken_IJCV]_ rotated over a discrete set of orientations. See the
+Inspired by [Rodrigues2010]_, a lookup-table is created, containing rotated
+versions of the fiber propagation kernel :math:`P_t` [DuitsAndFranken2011]_
+rotated over a discrete set of orientations. See the
 `Contextual enhancement example <http://nipy.org/dipy/examples_built/contextual_enhancement.html>`_
 for more details regarding the kernel. In order to ensure rotationally
 invariant processing, the discrete orientations are required to be equally
@@ -210,8 +212,9 @@ fbc_sl_thres, clrs_thres, rfbc_thres = \
 
 """
 The results of FBC measures are visualized, showing the original fibers
-colored by LFBC, and the fibers after the cleaning procedure via RFBC
-thresholding.
+colored by LFBC (see :ref:`optic_radiation_before_cleaning`), and the fibers
+after the cleaning procedure via RFBC thresholding (see
+:ref:`optic_radiation_after_cleaning`).
 """
 
 # Visualize the results
@@ -245,42 +248,49 @@ fvtk.add(ren, actor.line(fbc_sl_thres, clrs_thres, linewidth=0.2))
 fvtk.record(ren, n_frames=1, out_path='OR_after.png', size=(900, 900))
 
 """
+.. _optic_radiation_before_cleaning:
+
 .. figure:: OR_before.png
    :align: center
 
    The optic radiation obtained through probabilistic tractography colored by
    local fiber to bundle coherence.
 
+.. _optic_radiation_after_cleaning:
+
 .. figure:: OR_after.png
    :align: center
 
    The tractography result is cleaned (shown in bottom) by removing fibers
-   with a relative FBC (RFBC) lower than the threshold tau=0.2.
+   with a relative FBC (RFBC) lower than the threshold :math:`\tau = 0.2`.
 
 Acknowledgments
-~~~~~~~~~~~~~~~
+---------------
 The techniques are developed in close collaboration with Pauly Ossenblok of
 the Academic Center of Epileptology Kempenhaeghe & Maastricht UMC+.
 
 References
-~~~~~~~~~~
+----------
 
-.. [Meesters2016_HBM] S. Meesters, G. Sanguinetti, E. Garyfallidis,
-                      J. Portegies, P. Ossenblok, R. Duits. (2016) Cleaning
-                      output of tractography via fiber to bundle coherence, a
-                      new open source implementation. Human Brain Mapping
-                      conference 2016.
-.. [Portegies2015_PLoSOne] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters,
-                           G.Girard, and R. Duits. (2015) Improving Fiber
-                           Alignment in HARDI by Combining Contextual PDE flow
-                           with Constrained Spherical Deconvolution. PLoS One.
-.. [DuitsAndFranken_IJCV] R. Duits and E. Franken (2011) Left-invariant
-                        diffusions on the space of positions and orientations
-                        and their application to crossing-preserving smoothing
-                        of HARDI images. International Journal of Computer
-                        Vision, 92:231-264.
-.. [Paulo_Eurographics] P. Rodrigues, R. Duits, B. Romeny, A. Vilanova (2010).
-                        Accelerated Diffusion Operators for Enhancing DW-MRI.
-                        Eurographics Workshop on Visual Computing for Biology
-                        and Medicine. The Eurographics Association.
+.. [Meesters2016] S. Meesters, G. Sanguinetti, E. Garyfallidis, J. Portegies,
+   P. Ossenblok, R. Duits. (2016) Cleaning output of tractography via fiber to
+   bundle coherence, a new open source implementation. Human Brain Mapping
+   Conference 2016.
+
+.. [Portegies2015] J. Portegies, R. Fick, G. Sanguinetti, S. Meesters,
+   G.Girard, and R. Duits. (2015) Improving Fiber Alignment in HARDI by
+   Combining Contextual PDE flow with Constrained Spherical Deconvolution. PLoS
+   One.
+
+.. [DuitsAndFranken2011] R. Duits and E. Franken (2011) Left-invariant
+   diffusions on the space of positions and orientations and their application
+   to crossing-preserving smoothing of HARDI images. International Journal of
+   Computer Vision, 92:231-264.
+
+.. [Rodrigues2010] P. Rodrigues, R. Duits, B. Romeny, A. Vilanova (2010).
+   Accelerated Diffusion Operators for Enhancing DW-MRI. Eurographics Workshop
+   on Visual Computing for Biology and Medicine. The Eurographics Association.
+
+.. include:: ../links_names.inc
+
 """

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -3,22 +3,22 @@
 Gradients and Spheres
 =====================
 
-This example shows how you can create GradientTables and Sphere objects using 
-Dipy.
+This example shows how you can create gradient tables and sphere objects using
+dipy_.
 
-Usually, as we saw in :ref:`example_quick_start`, you load your b-values and 
-b-vectors from disk and then you can create your own GradientTable. But,
-this time lets say that you are an MR physicist and you want to desing a new
+Usually, as we saw in :ref:`example_quick_start`, you load your b-values and
+b-vectors from disk and then you can create your own gradient table. But
+this time let's say that you are an MR physicist and you want to design a new
 gradient scheme or you are a scientist who wants to simulate many different
-gradient schemes. 
+gradient schemes.
 
-Now let's assume that you are interested in creating a multi-shell 
-acquisition with 2-shells, one at b=1000 and one at b=2500. For both shells
-let's say that we want a specific number of gradients (64) and we want to have 
-the points on the sphere evenly distributed. 
+Now let's assume that you are interested in creating a multi-shell
+acquisition with 2-shells, one at b=1000 $s/mm^2$ and one at b=2500 $s/mm^2$.
+For both shells let's say that we want a specific number of gradients (64) and
+we want to have the points on the sphere evenly distributed.
 
 This is possible using the ``disperse_charges`` which is an implementation of
-electrostatic repulsion [1]_.
+electrostatic repulsion [Jones1999]_.
 """
 
 import numpy as np
@@ -35,14 +35,14 @@ phi = 2 * np.pi * np.random.rand(n_pts)
 hsph_initial = HemiSphere(theta=theta, phi=phi)
 
 """
-Next, we call `disperse_charges` which will iteratively move the points so that
+Next, we call ``disperse_charges`` which will iteratively move the points so that
 the electrostatic potential energy is minimized.
 """
 
 hsph_updated, potential = disperse_charges(hsph_initial, 5000)
 
 """
-In ``hsph_updated` we have the updated HemiSphere with the points nicely 
+In ``hsph_updated`` we have the updated ``HemiSphere`` with the points nicely
 distributed on the hemisphere. Let's visualize them.
 """
 
@@ -59,7 +59,7 @@ fvtk.record(ren, out_path='initial_vs_updated.png', size=(300, 300))
 .. figure:: initial_vs_updated.png
    :align: center
 
-   **Example of electrostatic repulsion of red points which become green points**.
+   Example of electrostatic repulsion of red points which become green points.
 
 We can also create a sphere from the hemisphere and show it in the following way.
 """
@@ -76,7 +76,7 @@ fvtk.record(ren, out_path='full_sphere.png', size=(300, 300))
 .. figure:: full_sphere.png
    :align: center
 
-   **Full sphere**
+   Full sphere.
 
 It is time to create the Gradients. For this reason we will need to use the
 function ``gradient_table`` and fill it with the ``hsph_updated`` vectors that 
@@ -89,8 +89,9 @@ vertices = hsph_updated.vertices
 values = np.ones(vertices.shape[0])
 
 """
-We need to stacks of ``vertices`` one for every shell and we need two sets
-of b-values one at 1000 and one at 2500 as we discussed previously.
+We need two stacks of ``vertices``, one for every shell, and we need two sets
+of b-values, one at 1000 $s/mm^2$, and one at 2500 $s/mm^2$, as we discussed
+previously.
 """
 
 bvecs = np.vstack((vertices, vertices))
@@ -149,7 +150,7 @@ print(bvecs)
      [-0.48938584 -0.43780086  0.75420946]
      [ 0.          0.          0.        ]]
 
-Both b-values and b-vectors look correct. Let's now create the 
+Both b-values and b-vectors look correct. Let's now create the
 ``GradientTable``.
 """
 
@@ -177,10 +178,16 @@ fvtk.record(ren, out_path='gradients.png', size=(300, 300))
 .. figure:: gradients.png
    :align: center
 
-   **Diffusion Gradients**
+   Diffusion gradients.
 
-.. [1] Jones, DK. et al. Optimal strategies for measuring diffusion in 
-       anisotropic systems by magnetic resonance imaging, Magnetic Resonance
-       in Medicine, vol 42, no 3, 515-525, 1999. 
+References
+----------
+
+.. [Jones1999] Jones, DK. et al. Optimal strategies for measuring diffusion in
+   anisotropic systems by magnetic resonance imaging, Magnetic Resonance in
+   Medicine, vol 42, no 3, 515-525, 1999.
+
+.. include:: ../links_names.inc
+
 """
 

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -1,4 +1,7 @@
 """
+
+.. _intro_basic_tracking:
+
 ==============================
 Introduction to Basic Tracking
 ==============================
@@ -43,7 +46,7 @@ white_matter = (labels == 1) | (labels == 2)
 1. The first thing we need to begin fiber tracking is a way of getting
 directions from this diffusion data set. In order to do that, we can fit the
 data to a Constant Solid Angle ODF Model. This model will estimate the
-orientation distribution function (ODF) at each voxel. The ODF is the
+Orientation Distribution Function (ODF) at each voxel. The ODF is the
 distribution of water diffusion as a function of direction. The peaks of an ODF
 are good estimates for the orientation of tract segments at a point in the
 image.
@@ -74,10 +77,10 @@ classifier = ThresholdTissueClassifier(csa_peaks.gfa, .25)
 """
 3. Before we can begin tracking is to specify where to "seed" (begin) the fiber
 tracking. Generally, the seeds chosen will depend on the pathways one is
-interested in modeling. In this example, we'll use a 2x2x2 grid of seeds per
-voxel, in a sagittal slice of the Corpus Callosum.  Tracking from this region
-will give us a model of the Corpus Callosum tract.  This slice has label value
-2 in the labels image.
+interested in modeling. In this example, we'll use a $2 \times 2 \times 2$ grid
+of seeds per voxel, in a sagittal slice of the corpus callosum. Tracking from
+this region will give us a model of the corpus callosum tract. This slice has
+label value ``2`` in the labels image.
 """
 
 from dipy.tracking import utils
@@ -87,7 +90,7 @@ seeds = utils.seeds_from_mask(seed_mask, density=[2, 2, 2], affine=affine)
 
 """
 Finally, we can bring it all together using ``LocalTracking``. We will then
-display the resulting streamlines using the fvtk module.
+display the resulting streamlines using the ``fvtk`` module.
 """
 
 from dipy.tracking.local import LocalTracking
@@ -106,7 +109,7 @@ color = line_colors(streamlines)
 if fvtk.have_vtk:
     streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
 
-    # Create the 3d display.
+    # Create the 3D display.
     r = fvtk.ren()
     fvtk.add(r, streamlines_actor)
 
@@ -196,7 +199,7 @@ color = line_colors(streamlines)
 if fvtk.have_vtk:
     streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
 
-    # Create the 3d display.
+    # Create the 3D display.
     r = fvtk.ren()
     fvtk.add(r, streamlines_actor)
 
@@ -208,7 +211,7 @@ if fvtk.have_vtk:
 .. figure:: probabilistic.png
    :align: center
 
-   **Corpus Callosum Probabilistic**
+   Corpus callosum probabilistic tracking.
 """
 
 save_trk("CSD_prob.trk", streamlines, affine, labels.shape)

--- a/doc/examples/kfold_xval.py
+++ b/doc/examples/kfold_xval.py
@@ -6,8 +6,8 @@ K-fold cross-validation for model comparison
 
 Different models of diffusion MRI can be compared based on their accuracy in
 fitting the diffusion signal. Here, we demonstrate this by comparing two
-models: the diffusion tensor model (DTI) and constrained spherical
-deconvolution (CSD). These models differ from each other substantially. DTI
+models: the diffusion tensor model (DTI) and Constrained Spherical
+Deconvolution (CSD). These models differ from each other substantially. DTI
 approximates the diffusion pattern as a 3D Gaussian distribution, and has only
 6 free parameters. CSD, on the other hand, fits many more parameters. The
 models aare also not nested, so they cannot be compared using the
@@ -22,7 +22,7 @@ set. This method has been used for comparison of models such as DTI and CSD
 differences in the number of parameters in the model, and it can be used to
 compare models that are not nested.
 
-In `dipy`, we include an implementation of k-fold cross-validation. In this
+In dipy_, we include an implementation of k-fold cross-validation. In this
 method, the data is divided into $k$ different segments. In each iteration
 $\frac{1}{k}th$ of the data is held out and the model is fit to the other
 $\frac{k-1}{k}$ parts of the data. A prediction of the held out data is done
@@ -112,7 +112,7 @@ fig.savefig("model_predictions.png")
 .. figure:: model_predictions.png
    :align: center
 
-   **Model predictions**.
+   Model predictions.
 
 """
 

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -13,7 +13,7 @@ We will use streamlines generated using probabilistic tracking on CSA
 peaks. For brevity, we will include in this example only streamlines going
 through the corpus callosum connecting left to right superior frontal
 cortex. The process of tracking and finding these streamlines is fully
-demonstrated in the `streamline_tools.py` example. If this example has been
+demonstrated in the :ref:`streamline_tools` example. If this example has been
 run, we can read the streamlines from file. Otherwise, we'll run that example
 first, by importing it. This provides us with all of the variables that were
 created in that example:
@@ -91,7 +91,7 @@ fvtk.record(ren, n_frames=1, out_path='life_candidates.png',
 
 """
 
-Next, we initialize a LiFE model. We import the `dipy.tracking.life` module,
+Next, we initialize a LiFE model. We import the ``dipy.tracking.life`` module,
 which contains the classes and functions that implement the model:
 
 """
@@ -111,8 +111,8 @@ mid-point of the AC-PC-connecting line), we would use this::
 the inverse transformation from world space to the voxel space as the affine for
 the following model fit.
 
-The next step is to fit the model, producing a `FiberFit` class instance, that
-stores the data, as well as the results of the fitting procedure.
+The next step is to fit the model, producing a ``FiberFit`` class instance,
+that stores the data, as well as the results of the fitting procedure.
 
 The LiFE model posits that the signal in the diffusion MRI volume can be
 explained by the streamlines, by the equation
@@ -126,8 +126,8 @@ streamlines and $X$ is a design matrix. This matrix has the dimensions $m$ by
 $n$, where $m=n_{voxels} \cdot n_{directions}$, and $n_{voxels}$ is the set of
 voxels in the ROI that contains the streamlines considered in this model. The
 $i^{th}$ column of the matrix contains the expected contributions of the
-$i^{th}$ streamline (arbitrarly ordered) to each of the voxels. $X$ is a sparse
-matrix, because each streamline traverses only a small percentage of the
+$i^{th}$ streamline (arbitrarily ordered) to each of the voxels. $X$ is a
+sparse matrix, because each streamline traverses only a small percentage of the
 voxels. The  expected contributions of the streamline are calculated using a
 forward model, where each node of the streamline is modeled as a cylindrical
 fiber compartment with Gaussian diffusion, using the diffusion tensor model. See
@@ -139,7 +139,7 @@ fiber_fit = fiber_model.fit(data, candidate_sl, affine=np.eye(4))
 
 """
 
-The `FiberFit` class instance holds various properties of the model fit. For
+The ``FiberFit`` class instance holds various properties of the model fit. For
 example, it has the weights $\beta$, that are assigned to each streamline. In
 most cases, a tractography through some region will include redundant
 streamlines, and these streamlines will have $\beta_i$ that are 0.
@@ -196,15 +196,15 @@ streamlines have presumably been removed (in this case, about 50% of the
 streamlines).
 
 But how well does the model do in explaining the diffusion data? We can
-quantify that: the `FiberFit` class instance has a `predict` method, which can
+quantify that: the ``FiberFit`` class instance has a `predict` method, which can
 be used to invert the model and predict back either the data that was used to
 fit the model, or other unseen data (e.g. in cross-validation, see
 :ref:`kfold_xval`).
 
-Without arguments, the `.predict()` method will predict the diffusion signal
-for the same gradient table that was used in the fit data, but `gtab` and `S0`
-key-word arguments can be used to predict for other acquisition schemes and
-other baseline non-diffusion-weighted signals.
+Without arguments, the ``.predict()`` method will predict the diffusion signal
+for the same gradient table that was used in the fit data, but ``gtab`` and
+``S0`` keyword arguments can be used to predict for other acquisition schemes
+and other baseline non-diffusion-weighted signals.
 
 """
 
@@ -276,7 +276,7 @@ fig.savefig('error_histograms.png')
 .. figure:: error_histograms.png
    :align: center
 
-   **Improvement in error with fitting of the LiFE model**.
+   Improvement in error with fitting of the LiFE model.
 
 """
 
@@ -331,8 +331,7 @@ fig.savefig("spatial_errors.png")
 .. figure:: spatial_errors.png
    :align: center
 
-
-   **Spatial distribution of error and improvement**
+   Spatial distribution of error and improvement.
 
 """
 
@@ -351,12 +350,11 @@ For the Matlab implementation of LiFE, head over to `Franco Pestilli's github
 webpage <http://francopestilli.github.io/life/>`_.
 
 References
-~~~~~~~~~~~~~~~~~~~~~~
+----------
 
-.. [Pestilli2014] Pestilli, F., Yeatman, J, Rokem, A. Kay, K. and Wandell
-                  B.A. (2014). Validation and statistical inference in living
-                  connectomes. Nature Methods 11:
-                  1058-1063. doi:10.1038/nmeth.3098
+.. [Pestilli2014] Pestilli, F., Yeatman, J, Rokem, A. Kay, K. and Wandell B.A.
+   (2014). Validation and statistical inference in living connectomes. Nature
+   Methods 11: 1058-1063. doi:10.1038/nmeth.3098
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/piesno.py
+++ b/doc/examples/piesno.py
@@ -6,7 +6,7 @@ Noise estimation using PIESNO
 Often, one is interested in estimating the noise in the diffusion signal. One
 of the methods to do this is the Probabilistic Identification and Estimation of
 Noise (PIESNO) framework [Koay2009]_. Using this method, one can detect the
-standard deviation of the noise from diffusion-weighted imaging (DWI). PIESNO
+standard deviation of the noise from Diffusion-Weighted Imaging (DWI). PIESNO
 also works with multiple channel DWI datasets that are acquired from N array
 coils for both SENSE and GRAPPA reconstructions.
 
@@ -18,10 +18,10 @@ in the fourth dimension of the DWI dataset. White matter, gray matter or CSF
 voxels have diffusion intensities that vary quite a lot across different
 directions.
 
-2) From these estimated background voxels and the input number of coils N,
-PIESNO finds what sigma each Gaussian from each of the N coils would have
-generated the observed Rician (N=1) or non-central Chi (N>1) distributed noise
-profile in the DWI datasets.
+2) From these estimated background voxels and the input number of coils $N$,
+PIESNO finds what sigma each Gaussian from each of the $N$ coils would have
+generated the observed Rician ($N = 1$) or non-central Chi ($N > 1$)
+distributed noise profile in the DWI datasets.
 
 PIESNO makes an important assumption: the Gaussian noise standard deviation is
 assumed to be uniform. The noise is uniform across multiple slice locations or
@@ -76,8 +76,8 @@ plt.savefig('piesno.png', bbox_inches='tight')
 .. figure:: piesno.png
    :align: center
 
-   **Showing the mid axial slice of the b=0 image (left) and estimated
-   background voxels (right) used to estimate the noise standard deviation**.
+   Showing the mid axial slice of the b=0 image (left) and estimated
+   background voxels (right) used to estimate the noise standard deviation.
 """
 
 nib.save(nib.Nifti1Image(mask, img.affine, img.header),
@@ -96,10 +96,12 @@ example :ref:`example_snr_in_cc`) gives a value of 6.1.
 
 """
 
+References
+----------
+
 .. [Koay2009] Koay C.G., E. Ozarslan, C. Pierpaoli. Probabilistic
-              Identification and Estimation of Noise (PIESNO): A
-              self-consistent approach and its applications in MRI.
-              JMR, 199(1):94-103, 2009.
+   Identification and Estimation of Noise (PIESNO): A self-consistent approach
+   and its applications in MRI. JMR, 199(1):94-103, 2009.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/probabilistic_fiber_tracking.py
+++ b/doc/examples/probabilistic_fiber_tracking.py
@@ -14,9 +14,9 @@ point can be represented as a probability mass function (PMF) if the possible
 tracking directions are restricted to discrete numbers of well distributed
 points on a sphere.
 
-This example is an extension of the "introduction to basic tracking" example.
-We'll begin by repeating a few steps from that example, loading the data and
-fitting a constrained spherical deconvolution (CSD) model.
+This example is an extension of the :ref:`intro_basic_tracking` example. We'll
+begin by repeating a few steps from that example, loading the data and fitting
+a Constrained Spherical Deconvolution (CSD) model.
 """
 
 from dipy.data import read_stanford_labels
@@ -47,14 +47,14 @@ gfa = csa_model.fit(data, mask=white_matter).gfa
 classifier = ThresholdTissueClassifier(gfa, .25)
 
 """
-The fiber orientation distribution (FOD) of the CSD model estimates the
+The Fiber Orientation Distribution (FOD) of the CSD model estimates the
 distribution of small fiber bundles within each voxel. We can use this
 distribution for probabilistic fiber tracking. One way to do this is to
 represent the FOD using a discrete sphere. This discrete FOD can be used by the
-Probabilistic Direction Getter as a PMF for sampling tracking directions. We
+``ProbabilisticDirectionGetter`` as a PMF for sampling tracking directions. We
 need to clip the FOD to use it as a PMF because the latter cannot have negative
-values. (Ideally the FOD should be strictly positive, but because of noise
-and/or model failures sometimes it can have negative values).
+values. Ideally, the FOD should be strictly positive, but because of noise
+and/or model failures sometimes it can have negative values.
 """
 
 from dipy.direction import ProbabilisticDirectionGetter

--- a/doc/examples/quick_start.py
+++ b/doc/examples/quick_start.py
@@ -1,13 +1,13 @@
 """
 =========================
-Getting started with Dipy
+Getting started with DIPY
 =========================
 
 In diffusion MRI (dMRI) usually we use three types of files, a Nifti file with the
 diffusion weighted data, and two text files one with b-values and
 one with the b-vectors.
 
-In Dipy we provide tools to load and process these files and we also provide
+In dipy_ we provide tools to load and process these files and we also provide
 access to publically available datasets for those who haven't acquired yet
 their own datasets.
 
@@ -18,7 +18,7 @@ from dipy.data import fetch_sherbrooke_3shell
 fetch_sherbrooke_3shell()
 
 """
-By default these datasets will go in the .dipy folder inside your home directory.
+By default these datasets will go in the ``.dipy`` folder inside your home directory.
 Here is how you can access them.
 """
 
@@ -105,7 +105,7 @@ plt.savefig('data.png', bbox_inches='tight')
 .. figure:: data.png
    :align: center
 
-   **Showing the middle axial slice without (left) and with (right) diffusion weighting**.
+   Showing the middle axial slice without (left) and with (right) diffusion weighting.
 
 The next step is to load the b-values and b-vectors from the disk using
 the function ``read_bvals_bvecs``.
@@ -115,9 +115,9 @@ from dipy.io import read_bvals_bvecs
 bvals, bvecs = read_bvals_bvecs(fbval, fbvec)
 
 """
-In Dipy, we use an object called ``GradientTable`` which holds all the acquision
-specific parameters, e.g. b-values, b-vectors, timings and others. To create this
-object you can use the function ``gradient_table``.
+In DIPY, we use an object called ``GradientTable`` which holds all the
+acquisition specific parameters, e.g. b-values, b-vectors, timings and others.
+To create this object you can use the function ``gradient_table``.
 """
 
 from dipy.core.gradients import gradient_table

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -3,8 +3,8 @@
 Reconstruct with Constant Solid Angle (Q-Ball)
 =================================================
 
-We show how to apply a Constant Solid Angle ODF (Q-Ball) model from Aganj et.
-al (MRM 2010) to your datasets.
+We show how to apply a Constant Solid Angle ODF (Q-Ball) model from Aganj et
+al. [Aganj2010]_ to your datasets.
 
 First import the necessary modules:
 """
@@ -36,7 +36,7 @@ print('data.shape (%d, %d, %d, %d)' % data.shape)
 """
 data.shape ``(81, 106, 76, 160)``
 
-Remove most of the background using dipy's mask module.
+Remove most of the background using DIPY's mask module.
 """
 
 from dipy.segment.mask import median_otsu
@@ -112,9 +112,18 @@ fvtk.record(r, n_frames=1, out_path='csa_odfs.png', size=(600, 600))
 .. figure:: csa_odfs.png
    :align: center
 
-   **Constant Solid Angle ODFs**.
+   Constant Solid Angle ODFs.
 
 .. include:: ../links_names.inc
+
+References
+----------
+
+.. [Aganj2010] Aganj I, Lenglet C, Sapiro G, Yacoub E, Ugurbil K, Harel N.
+   "Reconstruction of the orientation distribution function in single- and
+   multiple-shell q-ball imaging within constant solid angle", Magnetic
+   Resonance in Medicine. 2010 Aug;64(2):554-66. doi: 10.1002/mrm.22365
+
 
 """
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -31,7 +31,7 @@ data = img.get_data()
 
 """
 You can verify the b-values of the datasets by looking at the attribute
-`gtab.bvals`.
+``gtab.bvals``.
 
 In CSD there is an important pre-processing step: the estimation of the fiber
 response function. In order to do this we look for regions of the brain where
@@ -94,7 +94,7 @@ fvtk.record(ren, out_path='csd_response.png', size=(200, 200))
 .. figure:: csd_response.png
    :align: center
 
-   **Estimated response function**.
+   Estimated response function.
 
 """
 
@@ -155,7 +155,7 @@ fvtk.record(ren, out_path='csd_recursive_response.png', size=(200, 200))
 .. figure:: csd_recursive_response.png
    :align: center
 
-   **Estimated response function using recursive calibration**.
+   Estimated response function using recursive calibration.
 
 """
 
@@ -197,7 +197,7 @@ fvtk.record(ren, out_path='csd_odfs.png', size=(600, 600))
 .. figure:: csd_odfs.png
    :align: center
 
-   **CSD ODFs**.
+   CSD ODFs.
 
 In Dipy we also provide tools for finding the peak directions (maxima) of the
 ODFs. For this purpose we recommend using ``peaks_from_model``.
@@ -223,7 +223,7 @@ fvtk.record(ren, out_path='csd_peaks.png', size=(600, 600))
 .. figure:: csd_peaks.png
    :align: center
 
-   **CSD Peaks**.
+   CSD Peaks.
 
 We can finally visualize both the ODFs and peaks in the same space.
 """
@@ -240,10 +240,19 @@ fvtk.record(ren, out_path='csd_both.png', size=(600, 600))
 .. figure:: csd_both.png
    :align: center
 
-   **CSD Peaks and ODFs**.
+   CSD Peaks and ODFs.
 
-.. [Tournier2007] J-D. Tournier, F. Calamante and A. Connelly, "Robust determination of the fibre orientation distribution in diffusion MRI: Non-negativity constrained super-resolved spherical deconvolution", Neuroimage, vol. 35, no. 4, pp. 1459-1472, 2007.
-.. [Tax2014] C.M.W. Tax, B. Jeurissen, S.B. Vos, M.A. Viergever, A. Leemans, "Recursive calibration of the fiber response function for spherical deconvolution of diffusion MRI data", Neuroimage, vol. 86, pp. 67-80, 2014.
+References
+----------
+
+.. [Tournier2007] J-D. Tournier, F. Calamante and A. Connelly, "Robust
+   determination of the fibre orientation distribution in diffusion MRI:
+   Non-negativity constrained super-resolved spherical deconvolution",
+   Neuroimage, vol. 35, no. 4, pp. 1459-1472, 2007.
+
+.. [Tax2014] C.M.W. Tax, B. Jeurissen, S.B. Vos, M.A. Viergever, A. Leemans,
+   "Recursive calibration of the fiber response function for spherical
+   deconvolution of diffusion MRI data", Neuroimage, vol. 86, pp. 67-80, 2014.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -75,7 +75,7 @@ print("peaks_from_model using " + str(multiprocessing.cpu_count())
       + " process ran in :" + str(time_parallel) + " seconds")
 
 """
-``peaks_from_model`` using 8 processes ran in :114.425682068 seconds
+``peaks_from_model`` using 8 processes ran in 114.425682068 seconds
 """
 
 start_time = time.time()
@@ -96,7 +96,7 @@ time_single = time.time() - start_time
 print("peaks_from_model ran in :" + str(time_single) + " seconds")
 
 """
-``peaks_from_model`` ran in :242.772505999 seconds
+``peaks_from_model`` ran in 242.772505999 seconds
 """
 
 print("Speedup factor : " + str(time_single / time_parallel))
@@ -107,8 +107,10 @@ Speedup factor : 2.12166099088
 In Windows if you get a runtime error about frozen executable please start
 your script by adding your code above in a ``main`` function and use:
 
+``
 if __name__ == '__main__':
     import multiprocessing
     multiprocessing.freeze_support()
     main()
+``
 """

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -12,7 +12,7 @@ biological tissues is non-Gaussian using the kurtosis tensor (KT)
 Measurements of non-Gaussian diffusion from the diffusion kurtosis model are of
 interest because they can be used to charaterize tissue microstructural
 heterogeneity [Jensen2010]_ and to derive concrete biophysical parameters, such
-as the density of axonal fibres and diffusion tortuosity [Fierem2011]_.
+as the density of axonal fibres and diffusion tortuosity [Fieremans2011]_.
 Moreover, DKI can be used to resolve crossing fibers in tractography and to
 obtain invariant rotational measures not limited to well-aligned fiber
 populations [NetoHe2015]_.
@@ -107,7 +107,7 @@ suppress by using 3D Gaussian smoothing (with a Gaussian kernel with
 fwhm=1.25) as suggested by pioneer DKI studies (e.g. [Jensen2005]_,
 [NetoHe2012]_). Although here the Gaussian smoothing is used so that results
 are comparable to these studies, it is important to note that more advanced
-noise and artifact suppression algorithms are available in Dipy (e.g. the
+noise and artifact suppression algorithms are available in dipy_ (e.g. the
 non-local means filter :ref:`example-denoise-nlmeans`).
 """
 
@@ -149,12 +149,12 @@ AD = dkifit.ad
 RD = dkifit.rd
 
 """
-Note that these four standard measures could also be computed from Dipy's DTI
+Note that these four standard measures could also be computed from DIPY's DTI
 module. Theoretically, computing these measures from both models should be
 analogous. However, according to recent studies, the diffusion statistics from
 the kurtosis model are expected to have better accuracy [Veraar2011]_,
 [NetoHe2012]_. For comparison purposes, we calculate below the FA, MD, AD, and
-RD using Dipy's TensorModel.
+RD using DIPY's ``TensorModel``.
 """
 
 tenmodel = dti.TensorModel(gtab)
@@ -204,8 +204,8 @@ fig1.savefig('Diffusion_tensor_measures_from_DTI_and_DKI.png')
 .. figure:: Diffusion_tensor_measures_from_DTI_and_DKI.png
    :align: center
 
-   **Diffusion tensor measures obtained from the diffusion tensor estimated
-    from DKI (upper panels) and DTI (lower panels).**.
+   Diffusion tensor measures obtained from the diffusion tensor estimated
+   from DKI (upper panels) and DTI (lower panels).
 
 In addition to the standard diffusion statistics, the DiffusionKurtosisFit
 instance can be used to estimate the non-Gaussian measures of mean kurtosis
@@ -244,7 +244,7 @@ fig2.savefig('Kurtosis_tensor_standard_measures.png')
 .. figure:: Kurtosis_tensor_standard_measures.png
    :align: center
 
-   **Kurtosis tensor standard measures obtained from the kurtosis tensor.**.
+   Kurtosis tensor standard measures obtained from the kurtosis tensor.
 
 The non-Gaussian behaviour of the diffusion signal is larger when water
 diffusion is restricted by compartments and barriers (e.g., myelin sheath).
@@ -254,9 +254,9 @@ than for the radial directions (larger amplitudes shown in the RK map).
 
 As mentioned above, DKI can also be used to derive concrete biophysical
 parameters by applying microstructural models to DT and KT estimated from DKI.
-For instance,  Fieremans et al. (2011) showed that DKI can be used to estimate
-the contribution of hindered and restricted diffusion for well-aligned fibers.
-These tensors can be also interpreted as the influences of intra- and
+For instance,  Fieremans et al. [Fieremans2011]_ showed that DKI can be used to
+estimate the contribution of hindered and restricted diffusion for well-aligned
+fibers. These tensors can be also interpreted as the influences of intra- and
 extra-cellular compartments and can be used to estimate the axonal volume
 fraction and diffusion extra-cellular tortuosity. According to recent studies,
 these latter measures can be used to distinguish processes of axonal loss from
@@ -343,12 +343,13 @@ fig3.savefig('Kurtosis_Microstructural_measures.png')
 .. figure:: Kurtosis_Microstructural_measures.png
    :align: center
 
-   ** Axonal water fraction (left panel) and tortuosity (right panel) values
+   Axonal water fraction (left panel) and tortuosity (right panel) values
    of well-aligned fiber regions overlaid on a top of a mean kurtosis all-brain
-   image.**.
+   image.
 
 
-References:
+References
+----------
 
 .. [TaxCMW2015] Tax CMW, Otte WM, Viergever MA, Dijkhuizen RM, Leemans A
                 (2014). REKINDLE: Robust extraction of kurtosis INDices with
@@ -361,10 +362,10 @@ References:
 .. [Jensen2010] Jensen JH, Helpern JA (2010). MRI quantification of
                 non-Gaussian water diffusion by kurtosis analysis. NMR in
                 Biomedicine 23(7): 698-710
-.. [Fierem2011] Fieremans E, Jensen JH, Helpern JA (2011). White matter
+.. [Fieremans2011] Fieremans E, Jensen JH, Helpern JA (2011). White matter
                 characterization with diffusion kurtosis imaging. NeuroImage
                 58: 177-188
-.. [Fierem2012] Fieremans E, Jensen JH, Helpern JA, Kim S, Grossman RI,
+.. [Fieremans2012] Fieremans E, Jensen JH, Helpern JA, Kim S, Grossman RI,
                 Inglese M, Novikov DS. (2012). Diffusion distinguishes between
                 axonal loss and demyelination in brain white matter.
                 Proceedings of the 20th Annual Meeting of the International

--- a/doc/examples/reconst_dsi_metrics.py
+++ b/doc/examples/reconst_dsi_metrics.py
@@ -127,7 +127,7 @@ plt.savefig('rtop.png')
 .. figure:: rtop.png
    :align: center
 
-   **Return to origin probability**.
+   Return to origin probability.
 
 Show the msd images and save them in msd.png. 
 """
@@ -147,19 +147,18 @@ plt.savefig('msd.png')
 .. figure:: msd.png
    :align: center
 
-   **Mean square displacement**.
+   Mean square displacement.
 
-.. [Descoteaux2011] Descoteaux M. et. al , "Multiple q-shell diffusion 
-					propagator imaging", Medical Image Analysis, vol 15,
-					No. 4, p. 603-621, 2011.
+.. [Descoteaux2011] Descoteaux M. et. al , "Multiple q-shell diffusion
+   propagator imaging", Medical Image Analysis, vol 15, no 4, p. 603-621,
+   2011.
 
 .. [Wu2007] Wu Y. et al., "Hybrid diffusion imaging", NeuroImage, vol 36,
-        	p. 617-629, 2007.
+   p. 617-629, 2007.
 
-.. [Wu2008] Wu Y. et al., "Computation of Diffusion Function Measures
-			in q -Space Using Magnetic Resonance Hybrid Diffusion Imaging",
-			IEEE TRANSACTIONS ON MEDICAL IMAGING, vol. 27, No. 6, p. 858-865,
-			2008
+.. [Wu2008] Wu Y. et al., "Computation of Diffusion Function Measures in
+   q-Space Using Magnetic Resonance Hybrid Diffusion Imaging", IEEE
+   Transactions on Medical Imaging, vol 27, no 6, p. 858-865, 2008.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -78,11 +78,11 @@ fvtk.record(ren, out_path='dsid.png', size=(300, 300))
 
 """
 .. figure:: dsid.png
-    :align: center
+   :align: center
 
-    **Ground truth ODF (left), DSI ODF (middle), DSI with Deconvolution ODF(right)**
+   Ground truth ODF (left), DSI ODF (middle), DSI with Deconvolution ODF (right).
 
 .. [Canales10] Canales-Rodriguez et al., Deconvolution in Diffusion Spectrum Imaging,
-			   Neuroimage, vol 50, no 1, 136-149, 2010.
+   Neuroimage, vol 50, no 1, p. 136-149, 2010.
 
 """

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -1,5 +1,7 @@
 """
 
+.. _reconst_dti:
+
 ============================================================
 Reconstruction of the diffusion signal with the Tensor model
 ============================================================
@@ -68,7 +70,7 @@ from dipy.data import fetch_stanford_hardi
 
 """
 Fetch will download the raw dMRI dataset of a single subject. The size of the
-dataset is 87 MBytes.  You only need to fetch once.
+dataset is 87 MBytes. You only need to fetch once.
 """
 
 fetch_stanford_hardi()
@@ -82,8 +84,8 @@ from dipy.data import read_stanford_hardi
 img, gtab = read_stanford_hardi()
 
 """
-img contains a nibabel Nifti1Image object (with the data) and gtab contains a
-GradientTable object (information about the gradients e.g. b-values and
+``img`` contains a nibabel Nifti1Image object (with the data) and gtab contains a
+``GradientTable`` object (information about the gradients e.g. b-values and
 b-vectors).
 """
 
@@ -94,8 +96,8 @@ print('data.shape (%d, %d, %d, %d)' % data.shape)
 data.shape ``(81, 106, 76, 160)``
 
 First of all, we mask and crop the data. This is a quick way to avoid
-calculating Tensors on the background of the image. This is done using dipy's
-mask module.
+calculating Tensors on the background of the image. This is done using dipy_'s
+``mask`` module.
 """
 
 from dipy.segment.mask import median_otsu
@@ -121,7 +123,7 @@ TensorModel in the following way:
 tenfit = tenmodel.fit(maskdata)
 
 """
-The fit method creates a TensorFit object which contains the fitting parameters
+The fit method creates a ``TensorFit`` object which contains the fitting parameters
 and other attributes of the model. For example we can generate fractional
 anisotropy (FA) from the eigen-values of the tensor. FA is used to characterize
 the degree to which the distribution of diffusion in a voxel is
@@ -158,9 +160,9 @@ easily remove these in the following way.
 FA[np.isnan(FA)] = 0
 
 """
-Saving the FA images is very easy using nibabel. We need the FA volume and the
+Saving the FA images is very easy using nibabel_. We need the FA volume and the
 affine matrix which transform the image's coordinates to the world coordinates.
-Here, we choose to save the FA in float32.
+Here, we choose to save the FA in ``float32``.
 """
 
 fa_img = nib.Nifti1Image(FA.astype(np.float32), img.affine)
@@ -168,28 +170,28 @@ nib.save(fa_img, 'tensor_fa.nii.gz')
 
 """
 You can now see the result with any nifti viewer or check it slice by slice
-using matplotlib_'s imshow. In the same way you can save the eigen values, the
-eigen vectors or any other properties of the Tensor.
+using matplotlib_'s ``imshow``. In the same way you can save the eigen values, the
+eigen vectors or any other properties of the tensor.
 """
 
 evecs_img = nib.Nifti1Image(tenfit.evecs.astype(np.float32), img.affine)
 nib.save(evecs_img, 'tensor_evecs.nii.gz')
 
 """
-Other tensor statistics can be calculated from the `tenfit` object. For example,
+Other tensor statistics can be calculated from the ``tenfit`` object. For example,
 a commonly calculated statistic is the mean diffusivity (MD). This is simply the
 mean of the  eigenvalues of the tensor. Since FA is a normalized
 measure of variance and MD is the mean, they are often used as complimentary
-measures. In `dipy`, there are two equivalent ways to calculate the mean
-diffusivity. One is by calling the `mean_diffusivity` module function on the
-eigen-values of the TensorFit class instance:
+measures. In DIPY, there are two equivalent ways to calculate the mean
+diffusivity. One is by calling the ``mean_diffusivity`` module function on the
+eigen-values of the ``TensorFit`` class instance:
 """
 
 MD1 = dti.mean_diffusivity(tenfit.evals)
 nib.save(nib.Nifti1Image(MD1.astype(np.float32), img.affine), 'tensors_md.nii.gz')
 
 """
-The other is to call the TensorFit class method:
+The other is to call the ``TensorFit`` class method:
 """
 
 MD2 = tenfit.md
@@ -239,13 +241,13 @@ fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids.png', size=(600, 600))
 .. figure:: tensor_ellipsoids.png
    :align: center
 
-   **Tensor Ellipsoids**.
+   Tensor Ellipsoids.
 """
 
 fvtk.clear(ren)
 
 """
-Finally, we can visualize the tensor orientation distribution functions
+Finally, we can visualize the tensor Orientation Distribution Functions
 for the same area as we did with the ellipsoids.
 """
 
@@ -260,7 +262,7 @@ fvtk.record(ren, n_frames=1, out_path='tensor_odfs.png', size=(600, 600))
 .. figure:: tensor_odfs.png
    :align: center
 
-   **Tensor ODFs**.
+   Tensor ODFs.
 
 Note that while the tensor model is an accurate and reliable model of the
 diffusion signal in the white matter, it has the drawback that it only has one
@@ -273,14 +275,15 @@ tracks. Fortunately, other reconstruction methods can be used to represent the
 diffusion and fiber orientations in those locations. These are presented in
 other examples.
 
+References
+----------
 
 .. [Basser1994] Basser PJ, Mattielo J, LeBihan (1994). MR diffusion tensor
-                spectroscopy and imaging.
+   spectroscopy and imaging.
 
-.. [Pajevic1999] Pajevic S, Pierpaoli (1999). Color schemes to represent
-                 the orientation of anisotropic tissues from diffusion tensor
-                 data: application to white matter fiber tract mapping in
-                 the human brain.
+.. [Pajevic1999] Pajevic S, Pierpaoli (1999). Color schemes to represent the
+   orientation of anisotropic tissues from diffusion tensor data: application
+   to white matter fiber tract mapping in the human brain.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -7,8 +7,8 @@ As shown previously (see :ref:`example_reconst_dti`), the diffusion tensor
 model is a simple way to characterize diffusion anisotropy. However, in regions
 near the cerebral ventricle and parenchyma can be underestimated by partial
 volume effects of the cerebral spinal fluid (CSF). This free water
-contamination can particularly corrupt diffusion tensor imaging analysis of
-microstructural changes when different groups of subject show different brain
+contamination can particularly corrupt Diffusion Tensor Imaging analysis of
+microstructural changes when different groups of subjects show different brain
 morphology (e.g. brain ventricle enlargement associated with brain tissue
 atrophy that occurs in several brain pathologies and ageing).
 
@@ -25,8 +25,8 @@ where $\mathbf{g}$ and $b$ are diffusion gradient direction and weighted
 (more information see :ref:`example_reconst_dti`), $S(\mathbf{g}, b)$ is the
 diffusion-weighted signal measured, $S_0$ is the signal in a measurement with
 no diffusion weighting, $\mathbf{D}$ is the diffusion tensor, $f$ the volume
-fraction of the free water component, and $D_iso$ is the isotropic value of the
-free water diffusion (normally set to $3.0 \times 10^{-3} mm^{2}s^{-1}$).
+fraction of the free water component, and $D_{iso}$ is the isotropic value of
+the free water diffusion (normally set to $3.0 \times 10^{-3} mm^{2}s^{-1}$).
 
 In this example, we show how to process a diffusion weighting dataset using the
 free water elimination.
@@ -44,7 +44,7 @@ from dipy.segment.mask import median_otsu
 
 """
 Without spatial constrains the free water elimination model cannot be solved
-in data acquired from one non-zero b-value _[Hoy2014]. Therefore, here we
+in data acquired from one non-zero b-value [Hoy2014]_. Therefore, here we
 download a dataset that was required from multiple b-values.
 """
 
@@ -52,9 +52,9 @@ fetch_cenir_multib(with_raw=False)
 
 """
 From the downloaded data, we read only the data acquired with b-values up to
-2000 $s.mm^{-2} to decrease the influence of non-Gaussian diffusion effects
-of the tisse which are not taken into account by the free water elimination
-model _[Hoy2014].
+2000 $s/mm^2$ to decrease the influence of non-Gaussian diffusion
+effects of the tisse which are not taken into account by the free water
+elimination model [Hoy2014]_.
 """
 
 bvals = [200, 400, 1000, 2000]
@@ -181,7 +181,7 @@ produces in general higher values of FA and lower values of MD than the
 standard DTI model. These differences in FA and MD estimation are expected
 due to the suppression of the free water isotropic diffusion components.
 Unexpected high amplitudes of FA are however observed in the periventricular
-gray mater. This is a known artefact of regions associated to voxels with high
+gray matter. This is a known artefact of regions associated to voxels with high
 water volume fraction (i.e. voxels containing basically CSF). We are able to
 remove this problematic voxels by excluding all FA values associated with
 measured volume fractions above a reasonable threshold of 0.7:
@@ -223,10 +223,12 @@ fig1.savefig('In_vivo_free_water_DTI_and_standard_DTI_corrected.png')
    images were removed by dismissing voxels above a volume fraction threshold
    of 0.7.
 
-References:
+References
+----------
 
 .. [Hoy2014] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
-             Optimization of a free water elimination two-compartmental model
-             for diffusion tensor imaging. NeuroImage 103, 323-333.
-             doi: 10.1016/j.neuroimage.2014.09.053
+   Optimization of a free water elimination two-compartmental model for
+   diffusion tensor imaging. NeuroImage 103, 323-333. doi:
+   10.1016/j.neuroimage.2014.09.053
+
 """

--- a/doc/examples/reconst_gqi.py
+++ b/doc/examples/reconst_gqi.py
@@ -23,9 +23,11 @@ fetch_taiwan_ntu_dsi()
 img, gtab = read_taiwan_ntu_dsi()
 
 """
-img contains a nibabel Nifti1Image object (data) and gtab contains a GradientTable
-object (gradient information e.g. b-values). For example to read the b-values
-it is possible to write print(gtab.bvals).
+img contains a nibabel Nifti1Image object (data) and gtab contains a
+``GradientTable`` object (gradient information e.g. b-values). For example to
+read the b-values it is possible to write::
+
+   ``print(gtab.bvals)``
 
 Load the raw diffusion data and the affine.
 """
@@ -48,13 +50,13 @@ Read the voxel size from the image header.
 voxel_size = img.header.get_zooms()[:3]
 
 """
-Instantiate the Model and apply it to the data.
+Instantiate the model and apply it to the data.
 """
 
 gqmodel = GeneralizedQSamplingModel(gtab, sampling_length=3)
 
 """
-The parameter `sampling_length` is used here to
+The parameter ``sampling_length`` is used here to
 
 Lets just use one slice only from the data.
 """
@@ -66,7 +68,7 @@ mask = dataslice[..., 0] > 50
 gqfit = gqmodel.fit(dataslice, mask=mask)
 
 """
-Load an odf reconstruction sphere
+Load an ODF reconstruction sphere
 """
 
 sphere = get_sphere('symmetric724')
@@ -82,7 +84,7 @@ print('ODF.shape (%d, %d, %d)' % ODF.shape)
 """
 ODF.shape ``(96, 96, 724)``
 
-Using peaks_from_model we can find the main peaks of the ODFs and other
+Using ``peaks_from_model`` we can find the main peaks of the ODFs and other
 properties.
 """
 
@@ -98,7 +100,7 @@ gqpeaks = peaks_from_model(model=gqmodel,
 gqpeak_values = gqpeaks.peak_values
 
 """
-gqpeak_indices show which sphere points have the maximum values.
+``gqpeak_indices`` show which sphere points have the maximum values.
 """
 
 gqpeak_indices = gqpeaks.peak_indices
@@ -112,7 +114,7 @@ GFA = gqpeaks.gfa
 print('GFA.shape (%d, %d)' % GFA.shape)
 
 """
-With parameter `return_odf=True` we can obtain the ODF using gqpeaks.ODF
+With parameter ``return_odf=True`` we can obtain the ODF using ``gqpeaks.ODF``
 """
 
 gqpeaks = peaks_from_model(model=gqmodel,
@@ -134,11 +136,11 @@ np.sum(gqpeaks.odf != ODF) == 0
 """
 True
 
-The advantage of using peaks_from_models is that it calculates the ODF only once and
-saves it or deletes if it is not necessary to keep.
+The advantage of using ``peaks_from_model`` is that it calculates the ODF only
+once and saves it or deletes if it is not necessary to keep.
 
-.. [Yeh2010] Yeh, F-C et al., Generalized Q-sampling imaging, IEEE
-             Transactions on Medical Imaging, vol 29, no 9, 2010.
+.. [Yeh2010] Yeh, F-C et al., Generalized Q-sampling imaging, IEEE Transactions
+   on Medical Imaging, vol 29, no 9, 2010.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/reconst_ivim.py
+++ b/doc/examples/reconst_ivim.py
@@ -39,7 +39,7 @@ from dipy.reconst.ivim import IvimModel
 from dipy.data.fetcher import read_ivim
 
 """
-We get an IVIM dataset using Dipy's data fetcher ``read_ivim``.
+We get an IVIM dataset using dipy_'s data fetcher ``read_ivim``.
 This dataset was acquired with 21 b-values in 3 different directions.
 Volumes corresponding to different directions were registered to each
 other, and averaged across directions. Thus, this dataset has 4 dimensions,
@@ -51,10 +51,9 @@ measured at 0 bvalue.
 img, gtab = read_ivim()
 
 """
-The variable ``img`` contains a ``nibabel`` NIfTI image object (with the data)
-and gtab contains a GradientTable object (information about
-the gradients e.g. b-values and b-vectors). We get the
-data from img using ``read_data``.
+The variable ``img`` contains a nibabel NIfTI image object (with the data)
+and gtab contains a GradientTable object (information about the gradients e.g.
+b-values and b-vectors). We get the data from img using ``read_data``.
 """
 
 data = img.get_data()
@@ -114,18 +113,19 @@ $\mathbf{S_{0}}$ and $\mathbf{D}$ by considering b-values greater than
 ``split_b_D`` (default: 400))and assuming a mono-exponential signal. This is
 based on the assumption that at high b-values the signal can be approximated
 as a mono exponential decay and by taking the logarithm of the signal values
-a linear fit can be obtained. Another linear fit for ``S0`` (bvals < ``split_b_S0``
-(default: 200)) follows and ``f`` is estimated using 1 - S0_prime/S0.
-Then a non-linear least squares fitting is performed to fit D_star and f.
-If the `two_stage` flag is set to `True` while initializing the model, a final
-non-linear least squares fitting is performed for all the parameters using Scipy's
-``leastsq`` or ``least_square`` function depending on which Scipy version you are
-using. All initializations for the model such as ``split_b_D`` are passed while
-creating the ``IvimModel``. If you are using Scipy 0.17, you can also set bounds by setting
-``bounds=([0., 0., 0., 0.], [np.inf, 1., 1., 1.]))`` while initializing
-the IvimModel. It is recommeded that you upgrade to Scipy 0.17 since
-the fitting results might at times return values which do not make sense
-physically. (For example a negative $\mathbf{f}$)
+a linear fit can be obtained. Another linear fit for ``S0`` (bvals <
+``split_b_S0`` (default: 200)) follows and ``f`` is estimated using $1 -
+S0_{prime}/S0$. Then a non-linear least squares fitting is performed to fit
+``D_star`` and ``f``. If the ``two_stage`` flag is set to ``True`` while
+initializing the model, a final non-linear least squares fitting is performed
+for all the parameters using Scipy's ``leastsq`` or ``least_square`` function
+depending on which Scipy version you are using. All initializations for the
+model such as ``split_b_D`` are passed while creating the ``IvimModel``. If you
+are using Scipy 0.17, you can also set bounds by setting ``bounds=([0., 0., 0.,
+0.], [np.inf, 1., 1., 1.]))`` while initializing the ``IvimModel``. It is
+recommeded that you upgrade to Scipy 0.17 since the fitting results might at
+times return values which do not make sense physically (for example, a negative
+$\mathbf{f}$).
 """
 
 ivimmodel = IvimModel(gtab)

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -21,7 +21,7 @@ the parallel and perpendicular Non-Gaussianity.
 The estimation of these properties from noisy DWIs requires that the
 fitting of the MAPMRI basis is regularized. We will show that this can
 be done using both constraining the diffusion propagator to positive
-values [Ozarslan2013]_ and analytic Laplacian Regularization [Fick2016_].
+values [Ozarslan2013]_ and analytic Laplacian Regularization [Fick2016a]_.
 
 First import the necessary modules:
 """
@@ -48,13 +48,15 @@ fetch_cenir_multib(with_raw=False)
 For this example we select only the shell with b-values equal to the one of the
 Human Connectome Project (HCP).
 
-data contains the voxel data and gtab contains a GradientTable
+``data`` contains the voxel data and ``gtab`` contains a ``GradientTable``
 object (gradient information e.g. b-values). For example, to show the b-values
-it is possible to write print(gtab.bvals).
+it is possible to write::
 
-For the values of the q-space
-indices to make sense it is necessary to explicitly state the big_delta and
-small_delta parameters in the gradient table.
+   ``print(gtab.bvals)``
+
+For the values of the q-space indices to make sense it is necessary to
+explicitly state the ``big_delta`` and ``small_delta`` parameters in the
+gradient table.
 """
 
 bvals = [1000, 2000, 3000]
@@ -70,12 +72,12 @@ data_small = data[40:65, 50:51, 35:60]
 print('data.shape (%d, %d, %d, %d)' % data.shape)
 
 """
-The MAPMRI Model can now be instantiated. The radial_order determines the
+The MAPMRI Model can now be instantiated. The ``radial_order`` determines the
 expansion order of the basis, i.e., how many basis functions are used to
 approximate the signal.
 
 First, we must decide to use the anisotropic or isotropic MAPMRI basis. As was
-shown in [Fick2016]_, the isotropic basis is best used for tractography
+shown in [Fick2016a]_, the isotropic basis is best used for tractography
 purposes, as the anisotropic basis has a bias towards smaller crossing angles
 in the ODF. For signal fitting and estimation of scalar quantities the
 anisotropic basis is suggested. The choice can be made by setting
@@ -84,13 +86,13 @@ anisotropic basis is suggested. The choice can be made by setting
 First, we must select the method of regularization and/or constraining the
 basis fitting.
 - "laplacian_regularization=True" makes it use Laplacian regularization
-  [Fick2016]_. This method essentially reduces spurious oscillations in the
+  [Fick2016a]_. This method essentially reduces spurious oscillations in the
   reconstruction by minimizing the Laplacian of the fitted signal.
   Several options can be given to select the regularization weight:
       -"regularization_weighting="GCV"" uses generalized cross-validation
        [Craven1978]_ to find an optimal weight.
       -"regularization_weighting=0.2" for example would omit the GCV and
-       just set it to 0.2 (found to be reasonable in HCP data [Fick2016]_).
+       just set it to 0.2 (found to be reasonable in HCP data [Fick2016a]_).
       -"regularization_weighting=np.array(weights)" would make the GCV use
        a custom range to find an optimal weight.
 - "positivity_constraint=True" makes it use the positivity constraint on the
@@ -135,7 +137,7 @@ Note that when we use only Laplacian regularization, the "GCV" option may
 select very low regularization weights in very anisotropic white matter such
 as the corpus callosum, resulting in corrupted scalar indices. In this example
 we therefore choose a preset value of 0.2, which has shown to be quite robust
-and also faster in practice [Fick2016]_.
+and also faster in practice [Fick2016a]_.
 
 We can then fit the MAPMRI model to the data.
 """
@@ -272,8 +274,9 @@ From left to right:
 - Return to axis probability (RTAP) is a directional index that quantifies
   the probability that a proton will be along the axis of the main eigenvector
   of a diffusion tensor during both diffusion gradient pulses. RTAP has been
-  related to the apparent axon diameter [Ozarslan2013, Fick2016]_ under several
-  strong assumptions on the tissue composition and acquisition protocol.
+  related to the apparent axon diameter [Ozarslan2013]_ [Fick2016a]_ under
+  several strong assumptions on the tissue composition and acquisition
+  protocol.
 - Return to plane probability (RTPP) is a directional index that quantifies the
   probability that a proton will be on the plane perpendicular to the main
   eigenvector of a diffusion tensor during both gradient pulses. RTPP is
@@ -288,6 +291,7 @@ physically meaningful we must use a b-value threshold in the MAPMRI model. This
 threshold makes the scale estimation in MAPMRI only use samples that
 realistically describe Gaussian diffusion, i.e., at low b-values.
 """
+
 map_model_both_ng = mapmri.MapmriModel(gtab, radial_order=radial_order,
                                        laplacian_regularization=True,
                                        laplacian_weighting=.05,
@@ -338,16 +342,18 @@ values in the CSF and higher in the white matter.
 Increases or decreases in these values do not point to a specific
 microstructural change, but can indicate clues as to what is happening, similar
 to Fractional Anisotropy. An initial simulation study that quantifies the added
-value of q-space indices over DTI indices is given in [Fick2016b]_
+value of q-space indices over DTI indices is given in [Fick2016b]_.
 
-The MAPMRI framework also allows for the estimation of orientation distribution
-functions (ODFs). We recommend to use the isotropic implementation for this
+The MAPMRI framework also allows for the estimation of Orientation Distribution
+Functions (ODFs). We recommend to use the isotropic implementation for this
 purpose, as the anisotropic implementation has a bias towards smaller crossing
 angles.
 
-For the isotropic basis we recommend to use a higher_order of 8, as the basis
-needs more generic and needs more basis functions to approximate the signal.
+For the isotropic basis we recommend to use a ``radial_order`` of 8, as the
+basis needs more generic and needs more basis functions to approximate the
+signal.
 """
+
 radial_order = 8
 map_model_both_iso = mapmri.MapmriModel(gtab, radial_order=radial_order,
                                         laplacian_regularization=True,
@@ -364,16 +370,17 @@ Load an odf reconstruction sphere
 sphere = get_sphere('symmetric724')
 
 """
-Compute the ODFs
-The radial order s can be increased to sharpen the results, but it might
-also make the odfs noisier. Always check the results visually.
+Compute the ODFs.
+
+The radial order ``s`` can be increased to sharpen the results, but it might
+also make the ODFs noisier. Always check the results visually.
 """
 
 odf = mapfit_both_iso.odf(sphere, s=2)
 print('odf.shape (%d, %d, %d, %d)' % odf.shape)
 
 """
-Display the ODFs
+Display the ODFs.
 """
 
 r = fvtk.ren()
@@ -385,26 +392,30 @@ fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
 .. figure:: odfs.png
    :align: center
 
-   **Orientation distribution functions**.
+   Orientation distribution functions (ODFs).
 
-.. [Ozarslan2013]_ Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A
-               novel diffusion imaging method for mapping tissue
-               microstructure", NeuroImage, 2013.
+References
+----------
 
-.. [Fick2016]_ Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
-               using Laplacian-regularized MAP-MRI and its application to HCP
-               data." NeuroImage (2016).
+.. [Ozarslan2013] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A
+   novel diffusion imaging method for mapping tissue microstructure",
+   NeuroImage, 2013.
 
-.. [Craven1978]_ Craven et al. "Smoothing Noisy Data with Spline Functions."
-               NUMER MATH 31.4 (1978): 377-403.
+.. [Fick2016a] Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
+   using Laplacian-regularized MAP-MRI and its application to HCP data."
+   NeuroImage (2016).
 
-.. [Hosseinbor2013]_ Hosseinbor et al. "Bessel fourier orientation
-               reconstruction (bfor): an analytical diffusion propagator
-               reconstruction for hybrid diffusion imaging and computation
-               of q-space indices. NeuroImage 64, 650–670.
-.. [Fick2016b]_ Fick et al. "A sensitivity analysis of Q-space indices with
-               respect to changes in axonal diameter, dispersion and tissue
-               composition. ISBI 2016.
+.. [Craven1978] Craven et al. "Smoothing Noisy Data with Spline Functions."
+   NUMER MATH 31.4 (1978): 377-403.
+
+.. [Hosseinbor2013] Hosseinbor et al. "Bessel fourier orientation
+   reconstruction (bfor): an analytical diffusion propagator reconstruction
+   for hybrid diffusion imaging and computation of q-space indices. NeuroImage
+   64, 650–670.
+
+.. [Fick2016b] Fick et al. "A sensitivity analysis of Q-space indices with
+   respect to changes in axonal diameter, dispersion and tissue composition.
+   ISBI 2016.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -19,11 +19,12 @@ from dipy.core.gradients import gradient_table
 """
 Download and read the data for this tutorial.
 
-fetch_isbi2013_2shell() provides data from the ISBI HARDI contest 2013 acquired 
-for two shells at b-values 1500 and 2500.
+``fetch_isbi2013_2shell()`` provides data from the `ISBI HARDI contest 2013
+<http://hardi.epfl.ch/static/events/2013_ISBI/>`_ acquired for two shells at
+b-values 1500 $s/mm^2$ and 2500 $s/mm^2$.
 
 The six parameters of these two functions define the ROI where to reconstruct
-the data. They respectively correspond to (xmin,xmax,ymin,ymax,zmin,zmax)
+the data. They respectively correspond to ``(xmin,xmax,ymin,ymax,zmin,zmax)``
 with x, y, z and the three axis defining the spatial positions of the voxels.
 """
 
@@ -35,18 +36,20 @@ data_small = data[10:40, 22, 10:40]
 print('data.shape (%d, %d, %d, %d)' % data.shape)
 
 """
-data contains the voxel data and gtab contains a GradientTable
+``data`` contains the voxel data and ``gtab`` contains a ``GradientTable``
 object (gradient information e.g. b-values). For example, to show the b-values
-it is possible to write print(gtab.bvals).
+it is possible to write::
+
+    ``print(gtab.bvals)``
 
 Instantiate the SHORE Model.
 
-radial_order is the radial order of the SHORE basis.
+``radial_order`` is the radial order of the SHORE basis.
 
-zeta is the scale factor of the SHORE basis.
+``zeta`` is the scale factor of the SHORE basis.
 
-lambdaN and lambdaL are the radial and angular regularization constants, 
-respectively.
+``lambdaN`` and ``lambdaL`` are the radial and angular regularization
+constants, respectively.
 
 For details regarding these four parameters see [Cheng2011]_ and [Merlet2013]_.
 """
@@ -91,15 +94,18 @@ fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
 .. figure:: odfs.png
    :align: center
 
-   **Orientation distribution functions**.
-   
-.. [Merlet2013] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
-				estimation via Compressive Sensing in diffusion MRI", Medical
-				Image Analysis, 2013.
+   Orientation distribution functions.
 
-.. [Cheng2011] Cheng J. et. al, "Theoretical Analysis and Pratical Insights
-			   on EAP Estimation via Unified HARDI Framework", MICCAI
-			   workshop on Computational Diffusion MRI, 2011.
+References
+----------
+
+.. [Merlet2013] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
+   estimation via Compressive Sensing in diffusion MRI", Medical Image
+   Analysis, 2013.
+
+.. [Cheng2011] Cheng J. et. al, "Theoretical Analysis and Pratical Insights on
+   EAP Estimation via Unified HARDI Framework", MICCAI workshop on
+   Computational Diffusion MRI, 2011.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/reconst_shore_metrics.py
+++ b/doc/examples/reconst_shore_metrics.py
@@ -44,7 +44,7 @@ Instantiate the Model.
 asm = ShoreModel(gtab)
 
 """
-Lets just use only one slice only from the data.
+Let's just use only one slice only from the data.
 """
 
 dataslice = data[30:70, 20:80, data.shape[2] // 2]
@@ -88,7 +88,7 @@ print('Calculating... msd')
 msd = asmfit.msd()
 
 """
-Show the maps and save them in SHORE_maps.png.
+Show the maps and save them to a file.
 """
 
 fig = plt.figure(figsize=(6, 6))
@@ -110,20 +110,21 @@ plt.savefig('SHORE_maps.png')
 .. figure:: SHORE_maps.png
    :align: center
 
-   **rtop and msd calculated using the SHORE model**.
+   rtop and msd calculated using the SHORE model.
 
+References
+----------
 
 .. [Descoteaux2011] Descoteaux M. et. al , "Multiple q-shell diffusion
-					propagator imaging", Medical Image Analysis, vol 15,
-					No. 4, p. 603-621, 2011.
+   propagator imaging", Medical Image Analysis, vol 15, No. 4, p. 603-621,
+   2011.
 
-.. [Wu2007] Wu Y. et. al, "Hybrid diffusion imaging", NeuroImage, vol 36,
-        	p. 617-629, 2007.
+.. [Wu2007] Wu Y. et. al, "Hybrid diffusion imaging", NeuroImage, vol 36, p.
+   617-629, 2007.
 
-.. [Wu2008] Wu Y. et. al, "Computation of Diffusion Function Measures
-			in q -Space Using Magnetic Resonance Hybrid Diffusion Imaging",
-			IEEE TRANSACTIONS ON MEDICAL IMAGING, vol. 27, No. 6, p. 858-865,
-			2008.
+.. [Wu2008] Wu Y. et. al, "Computation of Diffusion Function Measures in
+   q-Space Using Magnetic Resonance Hybrid Diffusion Imaging", IEEE
+   TRANSACTIONS ON MEDICAL IMAGING, vol. 27, No. 6, p. 858-865, 2008.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/restore_dti.py
+++ b/doc/examples/restore_dti.py
@@ -13,13 +13,13 @@ example, some groups of participants (e.g. young children, patient groups,
 etc.) are particularly prone to motion and differences in tensor parameters and
 derived statistics (such as FA) due to motion would be confounded with actual
 differences in the physical properties of the white matter. An example of this
-was shown in a paper by Yendiki et al. [1]_.
+was shown in a paper by Yendiki et al. [Yendiki2013]_.
 
 One of the strategies to deal with this problem is to apply an automatic method
 for detecting outliers in the data, excluding these outliers and refitting the
 model without the presence of these outliers. This is often referred to as
 "robust model fitting". One of the common algorithms for robust tensor fitting
-is called RESTORE, and was first proposed by Chang et al. [2]_.
+is called RESTORE, and was first proposed by Chang et al. [Chang2005]_.
 
 In the following example, we will demonstrate how to use RESTORE on a simulated
 dataset, which we will corrupt by adding intermittent noise.
@@ -52,9 +52,9 @@ import dipy.viz.fvtk as fvtk
 import matplotlib.pyplot as plt
 
 """
-If needed, the fetch_stanford_hardi function will download the raw dMRI dataset
-of a single subject. The size of this dataset is 87 MBytes. You only need to
-fetch once.
+If needed, the ``fetch_stanford_hardi`` function will download the raw dMRI
+dataset of a single subject. The size of this dataset is 87 MBytes. You only
+need to fetch once.
 """
 
 dpd.fetch_stanford_hardi()
@@ -62,9 +62,9 @@ img, gtab = dpd.read_stanford_hardi()
 
 """
 We initialize a DTI model class instance using the gradient table used in the
-measurement. By default, dti.Tensor model will use a weighted least-squares
-algorithm (described in [2]_) to fit the parameters of the model. We initialize
-this model as a baseline for comparison of noise-corrupted models:
+measurement. By default, ``dti.TensorModel`` will use a weighted least-squares
+algorithm (described in [Chang2005]_) to fit the parameters of the model. We
+initialize this model as a baseline for comparison of noise-corrupted models:
 """
 
 dti_wls = dti.TensorModel(gtab)
@@ -111,7 +111,7 @@ fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids_wls.png',
 .. figure:: tensor_ellipsoids_wls.png
    :align: center
 
-   **Tensor Ellipsoids**.
+   Tensor Ellipsoids.
 """
 
 fvtk.clear(ren)
@@ -149,11 +149,11 @@ resulting tensor field will be distorted
 .. figure:: tensor_ellipsoids_wls_noisy.png
    :align: center
 
-   **Tensor Ellipsoids from noisy data**.
+   Tensor Ellipsoids from noisy data.
 
 To estimate the parameters from the noisy data using RESTORE, we need to
 estimate what would be a reasonable amount of noise to expect in the
-measurement. To do that, we use the `dipy.denoise.noise_estimate` module:  
+measurement. To do that, we use the ``dipy.denoise.noise_estimate`` module:
 
 """
 
@@ -183,12 +183,12 @@ fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids_restore_noisy.png',
 .. figure:: tensor_ellipsoids_restore_noisy.png
    :align: center
 
-   **Tensor Ellipsoids from noisy data recovered with RESTORE**.
+   Tensor Ellipsoids from noisy data recovered with RESTORE.
 
 The tensor field looks rather restored to its noiseless state in this
 image, but to convince ourselves further that this did the right thing, we will
 compare  the distribution of FA in this region relative to the baseline, using
-the RESTORE estimate and the WLS estimate.
+the RESTORE estimate and the WLS estimate [Chung2006]_.
 """
 
 fig_hist, ax = plt.subplots(1)
@@ -219,16 +219,16 @@ fibers cross), you might want to use a different method to fit your data.
 References
 ----------
 
-.. [1] Yendiki, A, Koldewynb, K, Kakunooria, S, Kanwisher, N, and Fischl,
-       B. (2013). Spurious group differences due to head motion in a diffusion
-       MRI study. Neuroimage.
+.. [Yendiki2013] Yendiki, A, Koldewynb, K, Kakunooria, S, Kanwisher, N, and
+   Fischl, B. (2013). Spurious group differences due to head motion in a
+   diffusion MRI study. Neuroimage.
 
-.. [2] Chang, L-C, Jones, DK and Pierpaoli, C (2005). RESTORE: robust estimation
-       of tensors by outlier rejection. MRM, 53: 1088-95.
+.. [Chang2005] Chang, L-C, Jones, DK and Pierpaoli, C (2005). RESTORE: robust
+   estimation of tensors by outlier rejection. MRM, 53: 1088-95.
 
-.. [3] Chung, SW, Lu, Y, Henry, R-G, (2006). Comparison of bootstrap
-       approaches for estimation of uncertainties of DTI parameters.
-       NeuroImage 33, 531-541.
+.. [Chung2006] Chung, SW, Lu, Y, Henry, R-G, (2006). Comparison of bootstrap
+   approaches for estimation of uncertainties of DTI parameters. NeuroImage 33,
+   531-541.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/segment_clustering_features.py
+++ b/doc/examples/segment_clustering_features.py
@@ -176,8 +176,8 @@ fvtk.record(ren, n_frames=1, out_path='center_of_mass_feature.png', size=(600, 6
 .. figure:: center_of_mass_feature.png
    :align: center
 
-   **Showing the center of mass of each streamline and colored according to
-   the QuickBundles results**.
+   Showing the center of mass of each streamline and colored according to
+   the QuickBundles results.
 
 .. _clustering-examples-MidpointFeature:
 
@@ -229,8 +229,8 @@ fvtk.record(ren, n_frames=1, out_path='midpoint_feature.png', size=(600, 600))
 .. figure:: midpoint_feature.png
    :align: center
 
-   **Showing the middle point of each streamline and colored according to the
-   QuickBundles results**.
+   Showing the middle point of each streamline and colored according to the
+   QuickBundles results.
 
 .. _clustering-examples-ArcLengthFeature:
 
@@ -275,7 +275,7 @@ fvtk.record(ren, n_frames=1, out_path='arclength_feature.png', size=(600, 600))
 .. figure:: arclength_feature.png
    :align: center
 
-   **Showing the streamlines colored according to their length**.
+   Showing the streamlines colored according to their length.
 
 .. _clustering-examples-VectorOfEndpointsFeature:
 
@@ -325,11 +325,10 @@ fvtk.record(ren, n_frames=1, out_path='vector_of_endpoints_feature.png', size=(6
 .. figure:: vector_of_endpoints_feature.png
    :align: center
 
-   **Showing the streamlines colored according to their orientation**.
+   Showing the streamlines colored according to their orientation.
 
 .. include:: ../links_names.inc
 
 .. [Garyfallidis12] Garyfallidis E. et al., QuickBundles a method for
-                    tractography simplification, Frontiers in Neuroscience, vol
-                    6, no 175, 2012.
+   tractography simplification, Frontiers in Neuroscience, vol 6, no 175, 2012.
 """

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -201,11 +201,13 @@ fvtk.record(ren, n_frames=1, out_path='cosine_metric.png', size=(600, 600))
 .. figure:: cosine_metric.png
    :align: center
 
-   **Showing the streamlines colored according to their orientation**.
+   Showing the streamlines colored according to their orientation.
 
 .. include:: ../links_names.inc
 
+References
+----------
+
 .. [Garyfallidis12] Garyfallidis E. et al., QuickBundles a method for
-                    tractography simplification, Frontiers in Neuroscience, vol
-                    6, no 175, 2012.
+   tractography simplification, Frontiers in Neuroscience, vol 6, no 175, 2012.
 """

--- a/doc/examples/segment_extending_clustering_framework.py
+++ b/doc/examples/segment_extending_clustering_framework.py
@@ -7,47 +7,51 @@ QuickBundles is a flexible algorithm that requires only a distance metric and
 an adjacency threshold to perform clustering. There is a wide variety of metrics
 that could be used to cluster streamlines.
 
-The purpose of this tutorial is to show how to easily create new `Feature` and
-new `Metric` classes that can be used by QuickBundles.
+The purpose of this tutorial is to show how to easily create new ``Feature`` and
+new ``Metric`` classes that can be used by QuickBundles.
 
 .. _clustering-framework:
 
 Clustering framework
 ====================
-Dipy provides a simple, flexible and fast framework to do clustering of
+dipy_ provides a simple, flexible and fast framework to do clustering of
 sequential data (e.g. streamlines).
 
-A *sequential datum* in Dipy is represented as a numpy array of size
-:math:`(N \times D)` where each row of the array represents a D dimensional
+A *sequential datum* in DIPY is represented as a numpy array of size
+:math:`(N \times D)`, where each row of the array represents a $D$ dimensional
 point of the sequence. A set of these sequences is represented as a list of
 numpy arrays of size :math:`(N_i \times D)` for :math:`i=1:M` where $M$ is the
 number of sequences in the set.
 
 This clustering framework is modular and divided in three parts:
-1) feature extraction
-2) distance computation
-3) clustering algorithm
+
+#. Feature extraction
+
+#. Distance computation
+
+#. Clustering algorithm
 
 The **feature extraction** part includes any preprocessing needed to be done on
 the data before computing distances between them (e.g. resampling the number of
 points of a streamline). To define a new way of extracting features, one has to
-subclass `Feature` (see below).
+subclass ``Feature`` (see below).
 
 The **distance computation** part includes any metric capable of evaluating a
 distance between two set of features previously extracted from the data. To
-define a new way of extracting features, one has to subclass `Metric` (see below).
+define a new way of extracting features, one has to subclass ``Metric`` (see
+below).
 
 The **clustering algorithm** part represents the clustering algorithm itself
 (e.g. QuickBundles, K-means, Hierarchical Clustering). More precisely, it
 includes any algorithms taking as input a list of sequential data and
-outputting a `ClusterMap` object.
+outputting a ``ClusterMap`` object.
 
 
 Extending `Feature`
 ===================
 This section will guide you through the creation of a new feature extraction
 method that can be used in the context of this clustering framework. For a
-list of available features in Dipy see :ref:`example_segment_clustering_features`.
+list of available features in DIPY see :ref:`example_segment_clustering_features`.
 
 Assuming a set of streamlines, the type of features we want to extract is the
 arc length (i.e. the sum of the length of each segment for a given streamline).
@@ -59,9 +63,9 @@ from dipy.segment.metric import Feature
 from dipy.tracking.streamline import length
 
 """
-We now define the class 'ArcLengthFeature' that will perform the desired
-feature extraction. When subclassing `Feature`, two methods have to be
-redefined: `infer_shape` and `extract`.
+We now define the class ``ArcLengthFeature`` that will perform the desired
+feature extraction. When subclassing ``Feature``, two methods have to be
+redefined: ``infer_shape`` and ``extract``.
 
 Also, an important property about feature extraction is whether or not
 its process is invariant to the order of the points within a streamline.
@@ -84,12 +88,12 @@ class ArcLengthFeature(Feature):
     def extract(self, streamline):
         """ Extracts features from `streamline`. """
         # return np.sum(np.sqrt(np.sum((streamline[1:] - streamline[:-1]) ** 2)))
-        # or use a Dipy's function that computes the arc length of a streamline.
+        # or use a DIPY's function that computes the arc length of a streamline.
         return length(streamline)
 
 
 """
-The new feature extraction `ArcLengthFeature` is ready to be used. Let's use
+The new feature extraction ``ArcLengthFeature`` is ready to be used. Let's use
 it to cluster a set of streamlines by their arc length. For educational
 purposes we will try to cluster a small streamline bundle known from
 neuroanatomy as the fornix.
@@ -107,8 +111,8 @@ streams, hdr = tv.read(fname)
 streamlines = [i[0] for i in streams]
 
 """
-Perform QuickBundles clustering using the metric `SumPointwiseEuclideanMetric`
-and our `ArcLengthFeature`.
+Perform QuickBundles clustering using the metric
+``SumPointwiseEuclideanMetric`` and our ``ArcLengthFeature``.
 """
 
 from dipy.segment.clustering import QuickBundles
@@ -137,14 +141,14 @@ fvtk.record(ren, n_frames=1, out_path='fornix_clusters_arclength.png', size=(600
 .. figure:: fornix_clusters_arclength.png
    :align: center
 
-   **Showing the different clusters obtained by using the arc length**.
+   Showing the different clusters obtained by using the arc length.
 
 
 Extending `Metric`
 ==================
 This section will guide you through the creation of a new metric that can be
 used in the context of this clustering framework. For a list of available
-metrics in Dipy see :ref:`example_segment_clustering_metrics`.
+metrics in DIPY see :ref:`example_segment_clustering_metrics`.
 
 Assuming a set of streamlines, we want a metric that computes the cosine
 distance giving the vector between endpoints of each streamline (i.e. one
@@ -158,10 +162,10 @@ from dipy.segment.metric import Metric
 from dipy.segment.metric import VectorOfEndpointsFeature
 
 """
-We now define the class `CosineMetric` that will perform the desired
-distance computation. When subclassing `Metric`, two methods have to be
-redefined: `are_compatible` and `dist`. Moreover, when implementing the
-`dist` method, one needs to make sure the distance returned is symmetric
+We now define the class ``CosineMetric`` that will perform the desired
+distance computation. When subclassing ``Metric``, two methods have to be
+redefined: ``are_compatible`` and ``dist``. Moreover, when implementing the
+``dist`` method, one needs to make sure the distance returned is symmetric
 (i.e. `dist(A, B) == dist(B, A)`).
 """
 
@@ -191,7 +195,7 @@ class CosineMetric(Metric):
         return np.arccos(cos_theta) / np.pi  # Normalized cosine distance
 
 """
-The new distance `CosineMetric` is ready to be used. Let's use
+The new distance ``CosineMetric`` is ready to be used. Let's use
 it to cluster a set of streamlines according to the cosine distance of the
 vector between their endpoints. For educational purposes we will try to
 cluster a small streamline bundle known from neuroanatomy as the fornix.
@@ -209,7 +213,7 @@ streams, hdr = tv.read(fname)
 streamlines = [i[0] for i in streams]
 
 """
-Perform QuickBundles clustering using our metric `CosineMetric`.
+Perform QuickBundles clustering using our metric ``CosineMetric``.
 """
 
 from dipy.segment.clustering import QuickBundles
@@ -238,5 +242,8 @@ fvtk.record(ren, n_frames=1, out_path='fornix_clusters_cosine.png', size=(600, 6
 .. figure:: fornix_clusters_cosine.png
    :align: center
 
-   **Showing the different clusters obtained by using the cosine metric**.
+   Showing the different clusters obtained by using the cosine metric.
+
+.. include:: ../links_names.inc
+
 """

--- a/doc/examples/segment_quickbundles.py
+++ b/doc/examples/segment_quickbundles.py
@@ -100,7 +100,7 @@ fvtk.record(ren, n_frames=1, out_path='fornix_initial.png', size=(600, 600))
 .. figure:: fornix_initial.png
    :align: center
 
-   **Initial Fornix dataset**.
+   Initial Fornix dataset.
 
 Show the centroids of the fornix after clustering (with random colors):
 """
@@ -117,7 +117,7 @@ fvtk.record(ren, n_frames=1, out_path='fornix_centroids.png', size=(600, 600))
 .. figure:: fornix_centroids.png
    :align: center
 
-   **Showing the different QuickBundles centroids with random colors**.
+   Showing the different QuickBundles centroids with random colors.
 
 Show the labeled fornix (colors from centroids).
 """
@@ -135,7 +135,7 @@ fvtk.record(ren, n_frames=1, out_path='fornix_clusters.png', size=(600, 600))
 .. figure:: fornix_clusters.png
    :align: center
 
-   **Showing the different clusters**.
+   Showing the different clusters.
 
 It is also possible to save the complete `ClusterMap` object with pickling.
 """
@@ -150,6 +150,9 @@ Finally, here is a video of QuickBundles applied on a larger dataset.
     <iframe width="420" height="315" src="http://www.youtube.com/embed/kstL7KKqu94" frameborder="0" allowfullscreen></iframe>
 
 .. include:: ../links_names.inc
+
+References
+----------
 
 .. [Garyfallidis12] Garyfallidis E. et al., QuickBundles a method for
                     tractography simplification, Frontiers in Neuroscience, vol

--- a/doc/examples/sfm_reconst.py
+++ b/doc/examples/sfm_reconst.py
@@ -5,8 +5,8 @@
 Reconstruction with the Sparse Fascicle Model
 ==============================================
 
-In this example, we will use the Sparse Fascicle Model [Rokem2015]_, to
-reconstruct the fiber orientation distribution function (fODF) in every voxel.
+In this example, we will use the Sparse Fascicle Model (SFM) [Rokem2015]_, to
+reconstruct the fiber Orientation Distribution Function (fODF) in every voxel.
 
 First, we import the modules we will use in this example:
 """
@@ -65,7 +65,7 @@ the data, and the regularization constraints. The regularization parameter
 $\lambda$ sets the `l1_ratio`, which controls the balance between L1-sparsity
 (low sum of weights), and low L2-sparsity (low sum-of-squares of the weights).
 
-Just like constrained spherical deconvolution (see :ref:`reconst-csd`), the SFM
+Just like Constrained Spherical Deconvolution (see :ref:`reconst-csd`), the SFM
 requires the definition of a response function. We'll take advantage of the
 automated algorithm in the :mod:`csdeconv` module to find this response
 function:
@@ -80,8 +80,8 @@ The ``response`` return value contains two entries. The first is an array with
 the eigenvalues of the response function and the second is the average S0 for
 this response.
 
-It is a very good practice to always validate the result of auto_response. For,
-this purpose we can print it and have a look at its values.
+It is a very good practice to always validate the result of ``auto_response``.
+For, this purpose we can print it and have a look at its values.
 """
 
 print(response)
@@ -155,7 +155,7 @@ fvtk.record(ren, out_path='sf_both.png', size=(1000, 1000))
 .. figure:: sf_both.png
    :align: center
 
-   **SFM Peaks and ODFs**.
+   SFM Peaks and ODFs.
 
 To see how to use this information in tracking, proceed to :ref:`sfm-track`.
 

--- a/doc/examples/sfm_tracking.py
+++ b/doc/examples/sfm_tracking.py
@@ -6,11 +6,11 @@ Tracking with the Sparse Fascicle Model
 ==================================================
 
 Tracking requires a per-voxel model. Here, the model is the Sparse Fascicle
-Model, described in [Rokem2015]_. This model reconstructs the diffusion signal
-as a combination of the signals from different fascicles (see also
+Model (SFM), described in [Rokem2015]_. This model reconstructs the diffusion
+signal as a combination of the signals from different fascicles (see also
 :ref:`sfm-reconst`).
 
-To begin, we read the Stanford HARDI data-set into memory:
+To begin, we read the Stanford HARDI data set into memory:
 """
 
 from dipy.data import read_stanford_labels
@@ -20,8 +20,9 @@ labels = labels_img.get_data()
 affine = hardi_img.affine
 
 """
-This dataset provides a label map (generated using Freesurfer), in which the
-white matter voxels are labeled as either 1 or 2:
+This data set provides a label map (generated using `FreeSurfer
+<https://surfer.nmr.mgh.harvard.edu/>`_), in which the white matter voxels are
+labeled as either 1 or 2:
 """
 
 white_matter = (labels == 1) | (labels == 2)
@@ -161,8 +162,8 @@ References
 ----------
 
 .. [Rokem2015] Ariel Rokem, Jason D. Yeatman, Franco Pestilli, Kendrick
-   N. Kay, Aviv Mezer, Stefan van der Walt, Brian A. Wandell
-   (2015). Evaluating the accuracy of diffusion MRI models in white
-   matter. PLoS ONE 10(4): e0123272. doi:10.1371/journal.pone.0123272
+   N. Kay, Aviv Mezer, Stefan van der Walt, Brian A. Wandell (2015). Evaluating
+   the accuracy of diffusion MRI models in white matter. PLoS ONE 10(4):
+   e0123272. doi:10.1371/journal.pone.0123272
 
 """

--- a/doc/examples/simulate_dki.py
+++ b/doc/examples/simulate_dki.py
@@ -1,9 +1,12 @@
 """
+
+.. _simulate_dki:
+
 ==========================
 DKI MultiTensor Simulation
 ==========================
 
-In this example we show how to simulate the diffusion kurtosis imaging (DKI)
+In this example we show how to simulate the Diffusion Kurtosis Imaging (DKI)
 data of a single voxel. DKI captures information about the non-Gaussian
 properties of water diffusion which is a consequence of the existence of tissue
 barriers and compartments. In these simulations compartmental heterogeneity is
@@ -24,8 +27,8 @@ from dipy.reconst.dti import (decompose_tensor, from_lower_triangular)
 
 """
 For the simulation we will need a GradientTable with the b-values and
-b-vectors. Here we use the GradientTable of the sample Dipy dataset
-'small_64D'.
+b-vectors. Here we use the GradientTable of the sample dipy_ dataset
+``small_64D``.
 """
 
 fimg, fbvals, fbvecs = get_data('small_64D')
@@ -33,7 +36,7 @@ bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
 
 """
 DKI requires data from more than one non-zero b-value. Since the dataset
-'small_64D' was acquired with one non-zero bvalue we artificialy produce a
+``small_64D`` was acquired with one non-zero bvalue we artificialy produce a
 second non-zero b-value.
 """
 
@@ -41,8 +44,8 @@ bvals = np.concatenate((bvals, bvals * 2), axis=0)
 bvecs = np.concatenate((bvecs, bvecs), axis=0)
 
 """
-The b-values and gradient directions are then converted to Dipy's
-GradientTable format.
+The b-values and gradient directions are then converted to DIPY's
+``GradientTable`` format.
 """
 
 gtab = gradient_table(bvals, bvecs)
@@ -63,10 +66,10 @@ mevals = np.array([[0.00099, 0, 0],
 
 """
 In ``angles`` we save in polar coordinates (:math:`\theta, \phi`) the principal
-axis of each compartment tensor. To simulate crossing fibers at 70 degrees
-the compartments of the first fiber are aligned to the x-axis while the
-compartments of the second fiber are aligned to the x-z plane with an angular
-deviation of 70 degrees from the first one.
+axis of each compartment tensor. To simulate crossing fibers at 70$^{\circ}$
+the compartments of the first fiber are aligned to the X-axis while the
+compartments of the second fiber are aligned to the X-Z plane with an angular
+deviation of 70$^{\circ}$ from the first one.
 """
 
 angles = [(90, 0), (90, 0), (20, 0), (20, 0)]
@@ -82,7 +85,7 @@ fractions = [fie*50, (1 - fie)*50, fie*50, (1 - fie)*50]
 
 """
 Having defined the parameters for all tissue compartments, the elements of the
-diffusion tensor (dt), the elements of the kurtosis tensor (kt) and the DW
+diffusion tensor (DT), the elements of the kurtosis tensor (KT) and the DW
 signals simulated from the DKI model can be obtain using the function
 ``multi_tensor_dki``.
 """
@@ -91,7 +94,7 @@ signal_dki, dt, kt = multi_tensor_dki(gtab, mevals, S0=200, angles=angles,
                                       fractions=fractions, snr=None)
 
 """
-We can also add rician noise with a specific SNR.
+We can also add Rician noise with a specific SNR.
 """
 
 signal_noisy, dt, kt = multi_tensor_dki(gtab, mevals, S0=200,
@@ -100,8 +103,8 @@ signal_noisy, dt, kt = multi_tensor_dki(gtab, mevals, S0=200,
 
 """
 For comparison purposes, we also compute the DW signal if only the diffusion
-tensor components are taken into account. For this we use Dipy's function
-single_tensor which requires that dt is decomposed into its eigenvalues and
+tensor components are taken into account. For this we use DIPY's function
+``single_tensor`` which requires that dt is decomposed into its eigenvalues and
 eigenvectors.
 """
 
@@ -125,18 +128,23 @@ plt.savefig('simulated_dki_signal.png')
 """
 .. figure:: simulated_dki_signal.png
    :align: center
-   **Simulated signals obtain from the DTI and DKI models**.
+
+   Simulated signals obtain from the DTI and DKI models.
 
 Non-Gaussian diffusion properties in tissues are responsible to smaller signal
 attenuations for larger bvalues when compared to signal attenuations from free
-gaussian water diffusion. This feature can be shown from the figure above,
+Gaussian water diffusion. This feature can be shown from the figure above,
 since signals simulated from the DKI models reveals larger DW signal
 intensities than the signals obtained only from the diffusion tensor
 components.
 
-References:
+References
+----------
 
-[RNH2015] R. Neto Henriques et al., "Exploring the 3D geometry of the diffusion
-          kurtosis tensor - Impact on the development of robust tractography
-          procedures and novel biomarkers", NeuroImage (2015) 111, 85-99.
+.. [RNH2015] R. Neto Henriques et al., "Exploring the 3D geometry of the
+   diffusion kurtosis tensor - Impact on the development of robust tractography
+   procedures and novel biomarkers", NeuroImage (2015) 111, 85-99.
+
+.. include:: ../links_names.inc
+
 """

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -50,7 +50,7 @@ signal, sticks = multi_tensor(gtab, mevals, S0=100, angles=angles,
                          fractions=fractions, snr=None)
 
 """
-We can also add rician noise with a specific SNR.
+We can also add Rician noise with a specific SNR.
 """
 
 signal_noisy, sticks = multi_tensor(gtab, mevals, S0=100, angles=angles,
@@ -76,7 +76,7 @@ plt.savefig('simulated_signal.png')
 """
 For the ODF simulation we will need a sphere. Because we are interested in a
 simulation of only a single voxel, we can use a sphere with very high
-resolution. We generate that by subdividing the triangles of one of Dipy's
+resolution. We generate that by subdividing the triangles of one of dipy_'s
 cached spheres, which we can read in the following way.
 """
 
@@ -101,5 +101,8 @@ fvtk.record(ren, out_path='multi_tensor_simulation.png', size=(300, 300))
 .. figure:: multi_tensor_simulation.png
    :align: center
 
-   **Simulating a MultiTensor ODF**
+   Simulating a MultiTensor ODF.
+
+.. include:: ../links_names.inc
+
 """

--- a/doc/examples/snr_in_cc.py
+++ b/doc/examples/snr_in_cc.py
@@ -4,31 +4,28 @@
 SNR estimation for Diffusion-Weighted Images
 =============================================
 
-Computing the Signal-to-Noise-Ratio (SNR) of DW images is still an open question,
-as SNR depends on the white matter structure of interest as well as
+Computing the Signal-to-Noise-Ratio (SNR) of DW images is still an open
+question, as SNR depends on the white matter structure of interest as well as
 the gradient direction corresponding to each DWI.
 
+In classical MRI, SNR can be defined as the ratio of the mean of the signal
+divided by the standard deviation of the underlying Gaussian noise, that is
+$SNR = mean(signal) / std(noise)$. The noise standard deviation can be computed
+from the background in any of the DW images. How do we compute the mean of the
+signal, and what signal?
 
-In classical MRI, SNR can be defined as the ratio of the mean
-of the signal divided by the standard deviation of the
-underlying Gaussian noise, that is SNR = mean(signal) / std(noise).
-The noise standard deviation can be
-computed from the background in any of the DW images. How do we compute
-the mean of the signal, and what signal?
+The strategy here is to compute a 'worst-case' SNR for DWI. Several white
+matter structures such as the corpus callosum (CC), corticospinal tract (CST),
+or the superior longitudinal fasciculus (SLF) can be easily identified from the
+colored-FA (CFA) map. In this example, we will use voxels from the CC, which
+have the characteristic of being highly red in the CFA map since they are
+mainly oriented in the left-right direction. We know that the DW image closest
+to the X-direction will be the one with the most attenuated diffusion signal.
+This is the strategy adopted in several recent papers (see [Descoteaux2011]_
+and [Jones2013]_). It gives a good indication of the quality of the DWI data.
 
-
-The strategy here is to compute a 'worst-case' SNR for DWI. Several white matter
-structures such as the corpus callosum (CC), corticospinal tract (CST), or
-the superior longitudinal fasciculus (SLF) can be easily identified from
-the colored-FA (cfa) map. In this example, we will use voxels from the CC,
-which have the characteristic of being highly RED in the cfa map since they are mainly oriented in
-the left-right direction. We know that the DW image
-closest to the x-direction will be the one with the most attenuated diffusion signal.
-This is the strategy adopted in several recent papers (see [1]_ and [2]_). It gives a good
-indication of the quality of the DWI data.
-
-
-First, we compute the tensor model in a brain mask (see the DTI example for more explanation).
+First, we compute the tensor model in a brain mask (see the :ref:`reconst_dti`
+example for further explanations).
 
 """
 
@@ -80,8 +77,8 @@ CC_box[bounds_min[0]:bounds_max[0],
        bounds_min[1]:bounds_max[1],
        bounds_min[2]:bounds_max[2]] = 1
 
-mask_cc_part, cfa = segment_from_cfa(tensorfit, CC_box,
-				     threshold, return_cfa=True)
+mask_cc_part, cfa = segment_from_cfa(tensorfit, CC_box, threshold,
+    return_cfa=True)
 
 cfa_img = nib.Nifti1Image((cfa*255).astype(np.uint8), affine)
 mask_cc_part_img = nib.Nifti1Image(mask_cc_part.astype(np.uint8), affine)
@@ -145,11 +142,11 @@ axis_Y = np.argmin(np.sum((gtab.bvecs-np.array([0, 1, 0]))**2, axis=-1))
 axis_Z = np.argmin(np.sum((gtab.bvecs-np.array([0, 0, 1]))**2, axis=-1))
 
 for direction in [0, axis_X, axis_Y, axis_Z]:
-	SNR = mean_signal[direction]/noise_std
-	if direction == 0 :
-		print("SNR for the b=0 image is :", SNR)
-	else :
-		print("SNR for direction", direction, " ", gtab.bvecs[direction], "is :", SNR)
+    SNR = mean_signal[direction]/noise_std
+    if direction == 0 :
+        print("SNR for the b=0 image is :", SNR)
+    else :
+        print("SNR for direction", direction, " ", gtab.bvecs[direction], "is :", SNR)
 
 """SNR for the b=0 image is : ''42.0695455758''"""
 """SNR for direction 58  [ 0.98875  0.1177  -0.09229] is : ''5.46995373635''"""
@@ -159,25 +156,26 @@ for direction in [0, axis_X, axis_Y, axis_Z]:
 """
 
 Since the CC is aligned with the X axis, the lowest SNR is for that gradient
-direction. In comparison, the DW images in
-the perpendical Y and Z axes have a high SNR. The b0 still exhibits the highest SNR,
-since there is no signal attenuation.
+direction. In comparison, the DW images in the perpendical Y and Z axes have a
+high SNR. The b0 still exhibits the highest SNR, since there is no signal
+attenuation.
 
-Hence, we can say the Stanford diffusion
-data has a 'worst-case' SNR of approximately 5, a
-'best-case' SNR of approximately 24, and a SNR of 42 on the b0 image.
-
-"""
+Hence, we can say the Stanford diffusion data has a 'worst-case' SNR of
+approximately 5, a 'best-case' SNR of approximately 24, and a SNR of 42 on the
+b0 image.
 
 """
-References:
 
-.. [1] Descoteaux, M., Deriche, R., Le Bihan, D., Mangin, J.-F., and Poupon, C.
-       Multiple q-shell diffusion propagator imaging.
-       Medical image analysis, 15(4), 603, 2011.
+"""
+References
+----------
 
-.. [2] Jones, D. K., Knosche, T. R., & Turner, R.
-       White Matter Integrity, Fiber Count, and Other Fallacies: The Dos and Don'ts of Diffusion MRI.
-       NeuroImage, 73, 239, 2013.
+.. [Descoteaux2011] Descoteaux, M., Deriche, R., Le Bihan, D., Mangin, J.-F.,
+   and Poupon, C. Multiple q-shell diffusion propagator imaging. Medical Image
+   Analysis, 15(4), 603, 2011.
+
+.. [Jones2013] Jones, D. K., Knosche, T. R., & Turner, R. White Matter
+   Integrity, Fiber Count, and Other Fallacies: The Dos and Don'ts of Diffusion
+   MRI. NeuroImage, 73, 239, 2013.
 
 """

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -29,9 +29,9 @@ streams, hdr = trackvis.read(fname)
 streamlines = [s[0] for s in streams]
 
 """
-Similarly you can use `trackvis.write` to save the streamlines.
+Similarly you can use ``trackvis.write`` to save the streamlines.
 
-2. Read/writh streamlines with numpy.
+2. Read/write streamlines with numpy.
 """
 
 streamlines_np = np.array(streamlines, dtype=np.object)
@@ -43,9 +43,9 @@ streamlines2 = list(np.load('fornix.npy'))
 3. We also work on our HDF5 based file format which can read/write massive datasets
 (as big as the size of you free disk space). With `Dpy` we can support
 
-	* direct indexing from the disk
-	* memory usage always low
-	* extentions to include different arrays in the same file
+  * direct indexing from the disk
+  * memory usage always low
+  * extensions to include different arrays in the same file
 
 Here is a simple example.
 """

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -7,7 +7,7 @@ This example shows how to calculate the lengths of a set of streamlines and
 also how to compress the streamlines without considerably reducing their
 lengths or overall shape.
 
-A streamline in Dipy is represented as a numpy array of size
+A streamline in dipy_ is represented as a numpy array of size
 :math:`(N \times 3)` where each row of the array represent a 3D point of the
 streamline. A set of streamlines is represented with a list of
 numpy arrays of size :math:`(N_i \times 3)` for :math:`i=1:M` where $M$ is the
@@ -135,7 +135,8 @@ fvtk.record(ren, out_path='simulated_cosine_bundle.png', size=(900, 900))
 .. figure:: simulated_cosine_bundle.png
    :align: center
 
-   **Initial bundle (down), downsampled at 12 equidistant points (middle), downsampled not equidistantly(up)**
+   Initial bundle (down), downsampled at 12 equidistant points (middle),
+   downsampled not equidistantly (up).
 
 From the figure above we can see that all 3 bundles look quite similar. However,
 when we plot the histogram of the number of points used for each streamline, it
@@ -159,7 +160,7 @@ plt.savefig('n_pts_histogram.png')
 .. figure:: n_pts_histogram.png
    :align: center
 
-   **Histogram of the number of points of the streamlines**
+   Histogram of the number of points of the streamlines.
 
 Finally, we can also show that the lengths of the streamlines haven't changed
 considerably after applying the two methods of downsampling.
@@ -182,6 +183,8 @@ plt.savefig('lengths_plots.png')
 .. figure:: lengths_plots.png
    :align: center
 
-   **Lengths of each streamline for every one of the 3 bundles**
+   Lengths of each streamline for every one of the 3 bundles.
+
+.. include:: ../links_names.inc
 
 """

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -1,11 +1,12 @@
 """
+.. _streamline_tools:
 
 =========================================================
 Connectivity Matrices, ROI Intersections and Density Maps
 =========================================================
 
 This example is meant to be an introduction to some of the streamline tools
-available in dipy. Some of the functions covered in this example are
+available in dipy_. Some of the functions covered in this example are
 ``target``, ``connectivity_matrix`` and ``density_map``. ``target`` allows one
 to filter streamlines that either pass through or do not pass through some
 region of the brain, ``connectivity_matrix`` groups and counts streamlines
@@ -88,7 +89,7 @@ other_streamlines = list(other_streamlines)
 assert len(other_streamlines) + len(cc_streamlines) == len(streamlines)
 
 """
-We can use some of dipy's visualization tools to display the ROI we targeted
+We can use some of dipy_'s visualization tools to display the ROI we targeted
 above and all the streamlines that pass though that ROI. The ROI is the yellow
 region near the center of the axial image.
 """
@@ -208,7 +209,7 @@ visualized together. In order to save the streamlines in a ".trk" file we'll
 need to move them to "trackvis space", or the representation of streamlines
 specified by the trackvis Track File format.
 
-To do that, we will use tools available in [nibabel](http://nipy.org/nibabel)
+To do that, we will use tools available in `nibabel <http://nipy.org/nibabel>`_)
 """
 
 import nibabel as nib
@@ -236,7 +237,7 @@ nib.trackvis.write("lr-superiorfrontal.trk", for_save, trackvis_header)
 
 """
 Let's take a moment here to consider the representation of streamlines used in
-dipy. Streamlines are a path though the 3d space of an image represented by a
+DIPY. Streamlines are a path though the 3D space of an image represented by a
 set of points. For these points to have a meaningful interpretation, these
 points must be given in a known coordinate system. The ``affine`` attribute of
 the ``streamline_generator`` object specifies the coordinate system of the
@@ -270,11 +271,12 @@ image.
 .. rubric:: Footnotes
 
 .. [#] The image `aparc-reduced.nii.gz`, which we load as ``labels_img``, is a
-    modified version of label map `aparc+aseg.mgz` created by freesurfer.  The
-    corpus callosum region is a combination of the freesurfer labels 251-255.
-    The remaining freesurfer labels were re-mapped and reduced so that they lie
-    between 0 and 88. To see the freesurfer region, label and name, represented
-    by each value see `label_info.txt` in `~/.dipy/stanford_hardi`.
+    modified version of label map `aparc+aseg.mgz` created by `FreeSurfer
+    <https://surfer.nmr.mgh.harvard.edu/>`_. The corpus callosum region is a
+    combination of the FreeSurfer labels 251-255. The remaining FreeSurfer
+    labels were re-mapped and reduced so that they lie between 0 and 88. To
+    see the FreeSurfer region, label and name, represented by each value see
+   `label_info.txt` in `~/.dipy/stanford_hardi`.
 .. [#] An affine transformation is a mapping between two coordinate systems
     that can represent scaling, rotation, sheer, translation and reflection.
     Affine transformations are often represented using a 4x4 matrix where the

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -35,12 +35,12 @@ regtools.overlay_images(static, moving, 'Static', 'Overlay', 'Moving', 'input_im
 .. figure:: input_images.png
    :align: center
 
-   **Input images**.
+   Input images.
 """
 
 """
 We want to find an invertible map that transforms the moving image (circle)
-into the static image (the C letter)
+into the static image (the C letter).
 
 The first decision we need to make is what similarity metric is appropriate
 for our problem. In this example we are using two binary images, so the Sum
@@ -53,8 +53,8 @@ metric = SSDMetric(dim)
 """
 Now we define an instance of the registration class. The SyN algorithm uses
 a multi-resolution approach by building a Gaussian Pyramid. We instruct the
-registration instance to perform at most [n_0, n_1, ..., n_k] iterations at
-each level of the pyramid. The 0-th level corresponds to the finest resolution.  
+registration instance to perform at most $[n_0, n_1, ..., n_k]$ iterations at
+each level of the pyramid. The 0-th level corresponds to the finest resolution.
 """
 
 level_iters = [200, 100, 50, 25]
@@ -80,7 +80,7 @@ regtools.plot_2d_diffeomorphic_map(mapping, 10, 'diffeomorphic_map.png')
 .. figure:: diffeomorphic_map.png
    :align: center
 
-   **Deformed lattice under the resulting diffeomorphic map**.
+   Deformed lattice under the resulting diffeomorphic map.
 """
 
 """
@@ -95,7 +95,7 @@ regtools.overlay_images(static, warped_moving, 'Static','Overlay','Warped moving
 .. figure:: direct_warp_result.png
    :align: center
 
-   **Moving image transformed under the (direct) transformation in green on top of the static image (in red)**.
+   Moving image transformed under the (direct) transformation in green on top of the static image (in red).
 """
 
 """
@@ -111,11 +111,11 @@ regtools.overlay_images(warped_static, moving,'Warped static','Overlay','Moving'
 .. figure:: inverse_warp_result.png
    :align: center
 
-   **Static image transformed under the (inverse) transformation in red on top of the moving image (in green)**.
+   Static image transformed under the (inverse) transformation in red on top of the moving image (in green).
 """
 
 """
-Now let's register a couple of slices from a B0 image using the Cross
+Now let's register a couple of slices from a b0 image using the Cross
 Correlation metric. Also, let's inspect the evolution of the registration.
 To do this we will define a function that will be called by the registration
 object at each stage of the optimization process. We will draw the current
@@ -146,7 +146,7 @@ t1, b0 = read_syn_data()
 data = np.array(b0.get_data(), dtype = np.float64)
 
 """
-We first remove the skull from the B0 volume
+We first remove the skull from the b0 volume
 """
 
 b0_mask, mask = median_otsu(data, 4, 4)
@@ -198,7 +198,7 @@ regtools.overlay_images(static, moving, 'Static', 'Overlay', 'Moving',
 .. figure:: t1_slices_input.png
    :align: center
 
-   **Input images**.
+   Input images.
 """
 
 regtools.overlay_images(static, warped, 'Static', 'Overlay', 'Warped moving',
@@ -208,7 +208,7 @@ regtools.overlay_images(static, warped, 'Static', 'Overlay', 'Warped moving',
 .. figure:: t1_slices_res.png
    :align: center
 
-   **Moving image transformed under the (direct) transformation in green on top of the static image (in red)**.
+   Moving image transformed under the (direct) transformation in green on top of the static image (in red).
 """
 
 '''
@@ -223,7 +223,7 @@ regtools.overlay_images(inv_warped, moving, 'Warped static', 'Overlay', 'moving'
 .. figure:: t1_slices_res2.png
    :align: center
 
-   **Static image transformed under the (inverse) transformation in red on top of the moving image (in green)**.
+   Static image transformed under the (inverse) transformation in red on top of the moving image (in green).
 """
 
 '''
@@ -236,10 +236,18 @@ regtools.plot_2d_diffeomorphic_map(mapping, 5, 'diffeomorphic_map_b0s.png')
 .. figure:: diffeomorphic_map_b0s.png
    :align: center
 
-   **Deformed lattice under the resulting diffeomorphic map**.
+   Deformed lattice under the resulting diffeomorphic map.
 
-.. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009). Symmetric Diffeomorphic Image Registration with Cross- Correlation: Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1), 26-41.\
-.. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced Normalization Tools ( ANTS ), 1-35.
+References
+----------
+
+.. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009).
+   Symmetric Diffeomorphic Image Registration with Cross- Correlation:
+   Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1),
+   26-41.
+
+.. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+   Normalization Tools ( ANTS ), 1-35.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -20,7 +20,7 @@ from dipy.viz import regtools
 
 """
 Let's fetch two b0 volumes, the first one will be the b0 from the Stanford
-HARDI dataset 
+HARDI dataset
 """
 
 from dipy.data import fetch_stanford_hardi, read_stanford_hardi
@@ -85,7 +85,7 @@ regtools.overlay_slices(static, resampled, None, 1, 'Static', 'Moving', 'input_3
 .. figure:: input_3d.png
    :align: center
 
-   **Static image in red on top of the pre-aligned moving image (in green)**.
+   Static image in red on top of the pre-aligned moving image (in green).
 """
 
 """
@@ -98,8 +98,8 @@ metric = CCMetric(3)
 """
 Now we define an instance of the registration class. The SyN algorithm uses
 a multi-resolution approach by building a Gaussian Pyramid. We instruct the
-registration object to perform at most [n_0, n_1, ..., n_k] iterations at
-each level of the pyramid. The 0-th level corresponds to the finest resolution.  
+registration object to perform at most $[n_0, n_1, ..., n_k]$ iterations at
+each level of the pyramid. The 0-th level corresponds to the finest resolution.
 """
 
 level_iters = [10, 10, 5]
@@ -130,7 +130,9 @@ regtools.overlay_slices(static, warped_moving, None, 1, 'Static', 'Warped moving
 .. figure:: warped_moving.png
    :align: center
 
-   **Moving image transformed under the (direct) transformation in green on top of the static image (in red)**.
+   Moving image transformed under the (direct) transformation in green on top
+   of the static image (in red).
+
 """
 
 """
@@ -145,10 +147,19 @@ regtools.overlay_slices(warped_static, moving, None, 1, 'Warped static', 'Moving
 .. figure:: warped_static.png
    :align: center
 
-   **Static image transformed under the (inverse) transformation in red on top of the moving image (in green). Note that the moving image has lower resolution**.
+   Static image transformed under the (inverse) transformation in red on top of
+   the moving image (in green). Note that the moving image has lower resolution.
 
-.. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009). Symmetric Diffeomorphic Image Registration with Cross- Correlation: Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1), 26-41.
-.. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced Normalization Tools ( ANTS ), 1-35.
+References
+----------
+
+.. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009).
+   Symmetric Diffeomorphic Image Registration with Cross- Correlation:
+   Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1),
+   26-41.
+
+.. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+   Normalization Tools ( ANTS ), 1-35.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/tissue_classification.py
+++ b/doc/examples/tissue_classification.py
@@ -53,7 +53,7 @@ plt.savefig('t1_image.png', bbox_inches='tight', pad_inches=0)
 .. figure:: t1_image.png
    :align: center
 
-   **T1-weighted image of healthy adult**.
+   T1-weighted image of healthy adult.
 
 Now we will define the other two parameters for the segmentation algorithm.
 We will segment three classes, namely corticospinal fluid (CSF), white matter
@@ -107,8 +107,8 @@ Now we plot the resulting segmentation.
 .. figure:: final_seg.png
    :align: center
 
-   **Each tissue class is color coded separately, red for the WM, yellow for
-   the GM and light blue for the CSF**.
+   Each tissue class is color coded separately, red for the WM, yellow for
+   the GM and light blue for the CSF.
 
 And we will also have a look at the probability maps for each tissue class.
 """
@@ -137,8 +137,15 @@ plt.show()
    :align: center
    :scale: 120
 
-   **These are the probability maps of each of the three tissue classes**.
+   These are the probability maps of each of the three tissue classes.
 
-.. [Zhang2001] Zhang, Y., Brady, M. and Smith, S. Segmentation of Brain MR Images Through a Hidden Markov Random Field Model and the Expectation-Maximization Algorithm IEEE Transactions on Medical Imaging, 20(1): 45-56, 2001
-.. [Avants2011] Avants, B. B., Tustison, N. J., Wu, J., Cook, P. A. and Gee, J. C. An open source multivariate framework for n-tissue segmentation with evaluation on public data. Neuroinformatics, 9(4): 381–400, 2011.
+.. [Zhang2001] Zhang, Y., Brady, M. and Smith, S. Segmentation of Brain MR
+   Images Through a Hidden Markov Random Field Model and the
+   Expectation-Maximization Algorithm IEEE Transactions on Medical Imaging,
+   20(1): 45-56, 2001
+
+.. [Avants2011] Avants, B. B., Tustison, N. J., Wu, J., Cook, P. A. and Gee,
+   J. C. An open source multivariate framework for n-tissue segmentation with
+   evaluation on public data. Neuroinformatics, 9(4): 381–400, 2011.
+
 """

--- a/doc/examples/tracking_eudx_odf.py
+++ b/doc/examples/tracking_eudx_odf.py
@@ -5,7 +5,7 @@ Deterministic Tracking with EuDX on ODF Peaks
 =============================================
 
 .. NOTE::
-    Dipy has updated tools for fiber tracking. Our new machinery for fiber
+    DIPY has updated tools for fiber tracking. Our new machinery for fiber
     tracking is featured in the example titled Introduction to Basic Tracking.
     The tools demonstrated in this example are no longer actively being
     maintained and will likely be deprecated at some point.
@@ -79,7 +79,7 @@ fvtk.record(r, n_frames=1, out_path='csa_tracking.png', size=(600, 600))
 .. figure:: csa_tracking.png
    :align: center
 
-   **Deterministic streamlines with EuDX on ODF peaks field modulated by GFA**.
+   Deterministic streamlines with EuDX on ODF peaks field modulated by GFA.
 
 It is also possible to use EuDX with multiple ODF peaks, which is very helpful when
 tracking in crossing areas.
@@ -106,7 +106,7 @@ fvtk.record(r, n_frames=1, out_path='csa_tracking_mpeaks.png', size=(600, 600))
 .. figure:: csa_tracking_mpeaks.png
    :align: center
 
-   **Deterministic streamlines with EuDX on multiple ODF peaks**.
+   Deterministic streamlines with EuDX on multiple ODF peaks.
 
 .. [Garyfallidis12] Garyfallidis E., "Towards an accurate brain tractography", PhD thesis, University of Cambridge, 2012.
 

--- a/doc/examples/tracking_eudx_tensor.py
+++ b/doc/examples/tracking_eudx_tensor.py
@@ -20,7 +20,7 @@ import numpy as np
 import nibabel as nib
 
 if not os.path.exists('tensor_fa.nii.gz'):
-	import reconst_dti
+    import reconst_dti
 
 """
 EuDX will use the directions (eigen vectors) of the Tensors to propagate
@@ -105,10 +105,10 @@ lightweight `fvtk` module.
 """
 
 try:
-	from dipy.viz import fvtk
+    from dipy.viz import fvtk
 except ImportError:
-	raise ImportError('Python vtk module is not installed')
-	sys.exit()
+    raise ImportError('Python vtk module is not installed')
+    sys.exit()
 
 """
 Create a scene.
@@ -138,9 +138,13 @@ fvtk.record(ren, n_frames=1, out_path='tensor_tracks.png', size=(600, 600))
 .. figure:: tensor_tracks.png
    :align: center
 
-   **Deterministic streamlines with EuDX on a Tensor Field**.
+   Deterministic streamlines with EuDX on a Tensor Field.
 
-.. [Garyfallidis12] Garyfallidis E., "Towards an accurate brain tractography", PhD thesis, University of Cambridge, 2012.
+References
+----------
+
+.. [Garyfallidis12] Garyfallidis E., "Towards an accurate brain tractography",
+   PhD thesis, University of Cambridge, 2012.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/tracking_quick_start.py
+++ b/doc/examples/tracking_quick_start.py
@@ -3,7 +3,7 @@
 Tracking Quick Start
 ====================
 
-This example shows how to perform fast fiber tracking using DIPY
+This example shows how to perform fast fiber tracking using dipy_
 [Garyfallidis12]_.
 
 We will use Constrained Spherical Deconvolution (CSD) [Tournier07]_ for local
@@ -53,7 +53,7 @@ maskdata, mask = median_otsu(data, 3, 1, False,
                              vol_idx=range(10, 50), dilate=2)
 
 """
-For the constrained spherical deconvolution we need to estimate the response
+For the Constrained Spherical Deconvolution we need to estimate the response
 function (see :ref:`example_reconst_csd`) and create a model.
 """
 
@@ -78,9 +78,9 @@ csd_peaks = peaks_from_model(model=csd_model,
 
 """
 For the tracking part, we will use the fiber directions from the ``csd_model``
-but stop tracking in areas where fractional anisotropy (FA) is low (< 0.1).
+but stop tracking in areas where fractional anisotropy is low (< 0.1).
 To derive the FA, used here as a stopping criterion, we would need to fit a
-tensor model first. Here, we fit the Tensor using weighted least squares (WLS).
+tensor model first. Here, we fit the tensor using weighted least squares (WLS).
 """
 
 tensor_model = TensorModel(gtab, fit_method='WLS')
@@ -98,7 +98,7 @@ tissue_classifier = ThresholdTissueClassifier(fa, 0.1)
 """
 Now, we need to set starting points for propagating each track. We call those
 seeds. Using ``random_seeds_from_mask`` we can select a specific number of
-seeds (``seeds_count``) in each voxel where the mask `fa > 0.3` is true.
+seeds (``seeds_count``) in each voxel where the mask ``fa > 0.3`` is true.
 """
 
 seeds = random_seeds_from_mask(fa > 0.3, seeds_count=1)
@@ -180,13 +180,23 @@ save_nifti('fa_map.nii.gz', fa, img.affine)
 In Windows if you get a runtime error about frozen executable please start
 your script by adding your code above in a ``main`` function and use:
 
+``
 if __name__ == '__main__':
     import multiprocessing
     multiprocessing.freeze_support()
     main()
+``
 
-.. [Garyfallidis12] Garyfallidis E., "Towards an accurate brain tractography", PhD thesis, University of Cambridge, 2012.
-.. [Tournier07] J-D. Tournier, F. Calamante and A. Connelly, "Robust determination of the fibre orientation distribution in diffusion MRI: Non-negativity constrained super-resolved spherical deconvolution", Neuroimage, vol. 35, no. 4, pp. 1459-1472, 2007.
+References
+----------
+
+.. [Garyfallidis12] Garyfallidis E., "Towards an accurate brain tractography",
+   PhD thesis, University of Cambridge, 2012.
+
+.. [Tournier07] J-D. Tournier, F. Calamante and A. Connelly, "Robust
+   determination of the fibre orientation distribution in diffusion MRI:
+   Non-negativity constrained super-resolved spherical deconvolution",
+   Neuroimage, vol. 35, no. 4, pp. 1459-1472, 2007.
 
 
 .. include:: ../links_names.inc

--- a/doc/examples/tracking_tissue_classifier.py
+++ b/doc/examples/tracking_tissue_classifier.py
@@ -205,26 +205,26 @@ fvtk.record(ren, out_path='all_streamlines_binary_classifier.png',
 ACT Tissue Classifier
 ---------------------
 Anatomically-constrained tractography (ACT) [Smith2012]_ uses information from
-anatomical images to determine when the tractography stops. The 'include_map'
+anatomical images to determine when the tractography stops. The ``include_map``
 defines when the streamline reached a 'valid' stopping region (e.g. gray
-matter partial volume estimation (PVE) map) and the 'exclude_map' defines when
+matter partial volume estimation (PVE) map) and the ``exclude_map`` defines when
 the streamline reached an 'invalid' stopping region (e.g. corticospinal fluid
 PVE map). The background of the anatomical image should be added to the
-'include_map' to keep streamlines exiting the brain (e.g. through the
+``include_map`` to keep streamlines exiting the brain (e.g. through the
 brain stem). The ACT tissue classifier uses a trilinear interpolation
 at the tracking position.
 
 **Parameters**
 
-- include_map: numpy array [:, :, :],
-- exclude_map: numpy array [:, :, :],
+- ``include_map``: numpy array ``[:, :, :]``,
+- ``exclude_map``: numpy array ``[:, :, :]``,
 
 **Stopping criterion**
 
-- 'ENDPOINT': include_map > 0.5,
-- 'OUTSIDEIMAGE': tracking point outside of include_map or exclude_map,
+- 'ENDPOINT': ``include_map`` > 0.5,
+- 'OUTSIDEIMAGE': tracking point outside of ``include_map`` or ``exclude_map``,
 - 'TRACKPOINT': no direction is available,
-- 'INVALIDPOINT': exclude_map > 0.5.
+- 'INVALIDPOINT': ``exclude_map`` > 0.5.
 """
 
 from dipy.tracking.local import ActTissueClassifier

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -28,6 +28,7 @@
  sfm_reconst.py
  gradients_spheres.py
  simulate_multi_tensor.py
+ simulate_dki.py
  restore_dti.py
  streamline_length.py
  reconst_shore.py

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -3,7 +3,7 @@
 Advanced interactive visualization
 ==================================
 
-In DIPY we created a thin interface to access many of the capabilities
+In dipy_ we created a thin interface to access many of the capabilities
 available in the Visualization Toolkit framework (VTK) but tailored to the
 needs of structural and diffusion imaging. Initially the 3D visualization
 module was named ``fvtk``, meaning functions using vtk. This is still available
@@ -41,8 +41,8 @@ from dipy.data.fetcher import fetch_bundles_2_subjects, read_bundles_2_subjects
 fetch_bundles_2_subjects()
 
 """
-The following function outputs a dictionary with the required bundles e.g., af
-left (left arcuate fasciculus) and maps, e.g., FA for a specific subject.
+The following function outputs a dictionary with the required bundles e.g. ``af
+left`` (left arcuate fasciculus) and maps, e.g. FA for a specific subject.
 """
 
 res = read_bundles_2_subjects('subj_1', ['t1', 'fa'],
@@ -281,8 +281,8 @@ def win_callback(obj, event):
 show_m.initialize()
 
 """
-Finally, please set the following variable to True to interact with the 
-datasetsin 3D.
+Finally, please set the following variable to ``True`` to interact with the
+datasets in 3D.
 """
 
 interactive = False
@@ -305,7 +305,13 @@ else:
 .. figure:: bundles_and_3_slices.png
    :align: center
 
-   **A few bundles with interactive slicing**.
+   A few bundles with interactive slicing.
 """
 
 del show_m
+
+"""
+
+.. include:: ../links_names.inc
+
+"""

--- a/doc/examples/viz_bundles.py
+++ b/doc/examples/viz_bundles.py
@@ -67,7 +67,7 @@ window.record(renderer, out_path='bundle1.png', size=(600, 600))
 .. figure:: bundle1.png
    :align: center
 
-   **One orientation color for every streamline**.
+   One orientation color for every streamline.
 
 You may wonder how we knew how to set the camera. This is very easy. You just
 need to run ``window.show`` once see how you want to see the object and then
@@ -103,12 +103,12 @@ window.record(renderer, out_path='bundle2.png', size=(600, 600))
 .. figure:: bundle2.png
    :align: center
 
-   **Every point with a color from FA**.
+   Every point with a color from FA.
 
 Show every point with a value from a volume with your colormap
 ==============================================================
 
-Here we will need to input the ``fa`` map in ``streamtube`` or ``
+Here we will need to input the ``fa`` map in ``streamtube``
 """
 
 renderer.clear()
@@ -133,13 +133,14 @@ window.record(renderer, out_path='bundle3.png', size=(600, 600))
 .. figure:: bundle3.png
    :align: center
 
-   **Every point with a color from FA using a non default colormap**.
+   Every point with a color from FA using a non default colormap.
 
 
 Show every bundle with a specific color
 ========================================
 
-You can have a bundle with a specific color. Here orange.
+You can have a bundle with a specific color. In this example, we are chosing
+orange.
 """
 
 renderer.clear()
@@ -154,7 +155,7 @@ window.record(renderer, out_path='bundle4.png', size=(600, 600))
 .. figure:: bundle4.png
    :align: center
 
-   **Entire bundle with a specific color**.
+   Entire bundle with a specific color.
 
 Show every streamline of a bundle with a different color
 ========================================================
@@ -217,7 +218,7 @@ window.record(renderer, out_path='bundle6.png', size=(600, 600))
 .. figure:: bundle6.png
    :align: center
 
-   **Random colors per points per streamline**.
+   Random colors per points per streamline.
 
 In summary, we showed that there are many useful ways for visualizing maps
 on bundles.

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -99,7 +99,7 @@ window.record(renderer, out_path='slices.png', size=(600, 600),
 .. figure:: slices.png
    :align: center
 
-   **Simple slice viewer**.
+   Simple slice viewer.
 
 Render slices from FA with your colormap
 ========================================
@@ -147,7 +147,7 @@ window.record(renderer, out_path='slices_lut.png', size=(600, 600),
 .. figure:: slices_lut.png
    :align: center
 
-   **Simple slice viewer with an HSV colormap**.
+   Simple slice viewer with an HSV colormap.
 
 
 Create a mosaic
@@ -209,5 +209,5 @@ window.record(renderer, out_path='mosaic.png', size=(900, 600),
 .. figure:: mosaic.png
    :align: center
 
-   **A mosaic of all the slices in the T1 volume**.
+   A mosaic of all the slices in the T1 volume.
 """

--- a/doc/examples/viz_surfaces.py
+++ b/doc/examples/viz_surfaces.py
@@ -3,11 +3,11 @@
 Visualize surfaces
 ==================
 
-Here is a simple tutorial that shows how to visualize surfaces using DIPY. It
-also shows how to load/save, get/set and update vtkPolyData and show
+Here is a simple tutorial that shows how to visualize surfaces using dipy_. It
+also shows how to load/save, get/set and update ``vtkPolyData`` and show
 surfaces.
 
-vtkPolyData is a structure used by VTK to represent surfaces and other data
+``vtkPolyData`` is a structure used by VTK to represent surfaces and other data
 structures. Here we show how to visualize a simple cube but the same idea
 should apply for any surface.
 """
@@ -15,7 +15,7 @@ should apply for any surface.
 import numpy as np
 
 """
-Import useful functions from dipy.viz.utils
+Import useful functions from ``dipy.viz.utils``
 """
 
 import dipy.io.vtk as io_vtk
@@ -28,7 +28,7 @@ from dipy.utils.optpkg import optional_package
 vtk, have_vtk, setup_module = optional_package('vtk')
 
 """
-Create an empty vtkPolyData
+Create an empty ``vtkPolyData``
 """
 
 my_polydata = vtk.vtkPolyData()
@@ -61,14 +61,14 @@ my_triangles = np.array([[0,  6,  4],
 
 
 """
-Set vertices and triangles in poly data
+Set vertices and triangles in the ``vtkPolyData``
 """
 
 ut_vtk.set_polydata_vertices(my_polydata, my_vertices)
 ut_vtk.set_polydata_triangles(my_polydata, my_triangles)
 
 """
-Save polydata
+Save the ``vtkPolyData``
 """
 
 file_name = "my_cube.vtk"
@@ -76,7 +76,7 @@ io_vtk.save_polydata(my_polydata, file_name)
 print("Surface saved in " + file_name)
 
 """
-Load polydata
+Load the ``vtkPolyData``
 """
 
 cube_polydata = io_vtk.load_polydata(file_name)
@@ -113,5 +113,8 @@ window.record(renderer, out_path='cube.png', size=(600, 600))
 .. figure:: cube.png
    :align: center
 
-   **An example of a simple surface visualized with DIPY**.
+   An example of a simple surface visualized with DIPY.
+
+.. include:: ../links_names.inc
+
 """

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -190,5 +190,5 @@ window.record(show_manager.ren, size=current_size, out_path="viz_ui.png")
 .. figure:: viz_ui.png
    :align: center
 
-   **User interface example**.
+   User interface example.
 """

--- a/doc/examples/workflow_creation.py
+++ b/doc/examples/workflow_creation.py
@@ -3,16 +3,18 @@
 Creating a new workflow.
 ============================================================
 
-A workflow is a series of dipy operations with fixed inputs and outputs
+A workflow is a series of dipy_ operations with fixed inputs and outputs
 that is callable via command line or another interface.
 
-For example, after installing dipy, you can call anywhere from your command line:
+For example, after installing dipy_, you can call anywhere from your command
+line::
+
 $ dipy_nlmeans t1.nii.gz t1_denoised.nii.gz
 """
 
 """
 First create your workflow. Usually this would be in its own python file in
-the ../dipy/workflows directory.
+the ``<../dipy/workflows>`` directory.
 """
 
 import shutil
@@ -91,7 +93,7 @@ For the example, it just appends text to an input file.
 
 This is it for the workflow! Now to be able to call it easily via command
 line, you need to add this bit of code. Usually this is in a separate
-executable file located in ../dipy/bin/.
+executable file located in ``bin``.
 """
 
 from dipy.workflows.flow_runner import run_flow
@@ -106,17 +108,22 @@ if __name__ == "__main__":
 This is the only thing needed to make your workflow available through command
 line.
 
-Now just call the script you just made with -h to see the argparser help text.
+Now just call the script you just made with ``-h`` to see the argparser help
+text::
 
-`python workflow_creation.py --help`
+   python workflow_creation.py --help
 
 You should see all your parameters available along with some extra common ones
 like logging file and force overwrite. Also all the documentation you wrote
 about each parameter is there.
 
-Now call it for real with a text file
+Now call it for real with a text file::
 
-`python workflow_creation.py ./text_file.txt`
+   python workflow_creation.py ./text_file.txt
+
+
+.. include:: ../links_names.inc
+
 """
 
 

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -197,6 +197,7 @@ Simulations
 
 - :ref:`example_simulate_multi_tensor`
 - :ref:`example_reconst_dsid`
+- :ref:`example_simulate_dki`
 
 ---------------
 Multiprocessing

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -96,11 +96,11 @@ Practical
 
   True, sometimes Python can be slow, if you are using multiple nested
   ``for`` loops, for example.
-  In that case, we use Cython, which takes execution up to C speed.
+  In that case, we use Cython_, which takes execution up to C speed.
 
 3. **What numerical libraries do you use in Python?**
 
-  The best ever designed numerical library - NumPy.
+  The best ever designed numerical library - NumPy_.
 
 2. **Which Python console do you recommend?**
 
@@ -117,12 +117,12 @@ Practical
 4. **What about interactive visualization?**
 
   There is already interaction in the ``fvtk`` module, but we have started a
-  new project only for visualization which we plan to integrate in ``dipy``
+  new project only for visualization which we plan to integrate in dipy_
   in the near future.  For more information, have a look at http://fos.me
 
 5. **Which file formats do you support?**
 
-  Nifti (.nii), Dicom (Siemens(read-only)), Trackvis (.trk), Dipy (.dpy),
+  Nifti (.nii), Dicom (Siemens(read-only)), Trackvis (.trk), DIPY (.dpy),
   Numpy (.npy, ,npz), text and any other formats supported by nibabel and
   pydicom.
 
@@ -130,12 +130,12 @@ Practical
   using `scipy.io.loadmat`. For higher versions >= 7.3, you can use pytables_
   or any other python-to-hdf5 library e.g. h5py.
 
-  For object serialization you can use `dipy.io.pickles` functions
-  `load_pickle`, `save_pickle`.
+  For object serialization you can use ``dipy.io.pickles`` functions
+  ``load_pickle``, ``save_pickle``.
 
 6. **What is dpy**?
 
-  ``dpy`` is an ``hdf5`` file format which we use in dipy to store
+  ``dpy`` is an ``hdf5`` file format which we use in DIPY to store
   tractography and other information. This allows us to store huge
   tractographies and load different parts of the datasets
   directly from the disk as if it were in memory.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ Highlights
 **********
 
 
-**Dipy 0.12.0** is now available. New features include:
+**DIPY 0.12.0** is now available. New features include:
 
 - IVIM Simultaneous modeling of perfusion and diffusion.
 - MAPL, tissue microstructure estimation using Laplacian-regularized MAP-MRI.
@@ -31,7 +31,7 @@ Highlights
 - New system for automatically generating command line interfaces.
 - Faster computation of cross correlation for image registration.
 
-**Dipy 0.11.0** is now available. New features include:
+**DIPY 0.11.0** is now available. New features include:
 
 - New framework for contextual enhancement of ODFs.
 - Compatibility with numpy (1.11).
@@ -43,7 +43,7 @@ Highlights
 - DSI now can use datasets with multiple b0s.
 - Fixed different issues with Windows 64bit and Python 3.5.
 
-**Dipy 0.10.1** is now available. New features in this release include:
+**DIPY 0.10.1** is now available. New features in this release include:
 
 - Compatibility with new versions of scipy (0.16) and numpy (1.10).
 - New cleaner visualization API, including compatibility with VTK 6, and functions to create your own interactive visualizations.
@@ -59,14 +59,14 @@ See :ref:`older highlights <old_highlights>`.
 Announcements
 *************
 
-- :ref:`Dipy 0.12 <release0.12>` released June 26, 2017.
-- :ref:`Dipy 0.11 <release0.11>` released February 21, 2016.
-- :ref:`Dipy 0.10 <release0.10>` released December 4, 2015.
-- :ref:`Dipy 0.9.2 <release0.9>` released, March 18, 2015.
-- :ref:`Dipy 0.8.0 <release0.8>` released, January 6, 2015.
-- Dipy_ was an official exhibitor in `HBM 2015 <http://ohbm.loni.usc.edu>`_.
-- Dipy was featured in `The Scientist Magazine <http://www.the-scientist.com/?articles.view/articleNo/41266/title/White-s-the-Matter>`_, Nov, 2014.
-- `Dipy paper`_ accepted in Frontiers of Neuroinformatics, January 22nd, 2014.
+- :ref:`DIPY 0.12 <release0.12>` released June 26, 2017.
+- :ref:`DIPY 0.11 <release0.11>` released February 21, 2016.
+- :ref:`DIPY 0.10 <release0.10>` released December 4, 2015.
+- :ref:`DIPY 0.9.2 <release0.9>` released, March 18, 2015.
+- :ref:`DIPY 0.8.0 <release0.8>` released, January 6, 2015.
+- dipy_ was an official exhibitor in `HBM 2015 <http://ohbm.loni.usc.edu>`_.
+- DIPY was featured in `The Scientist Magazine <http://www.the-scientist.com/?articles.view/articleNo/41266/title/White-s-the-Matter>`_, Nov, 2014.
+- `DIPY paper`_ accepted in Frontiers of Neuroinformatics, January 22nd, 2014.
 
 See some of our :ref:`past announcements <old_news>`
 
@@ -109,7 +109,7 @@ a slice should look like.
 Next Steps
 **********
 
-You can learn more about how you to use Dipy_ with  your datasets by reading the examples in our :ref:`documentation`.
+You can learn more about how you to use dipy_ with  your datasets by reading the examples in our :ref:`documentation`.
 
 .. We need the following toctree directive to include the documentation
 .. in the document hierarchy - see http://sphinx.pocoo.org/concepts.html

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -25,7 +25,7 @@ If you are on Debian or Ubuntu Linux we recommend you try
 Using Anaconda:
 ===============
 
-On all platforms, you can use Anaconda_ to install Dipy. To do so issue the following command in a terminal::
+On all platforms, you can use Anaconda_ to install DIPY. To do so issue the following command in a terminal::
 
     conda install dipy -c conda-forge
 
@@ -47,22 +47,22 @@ use the Anaconda_ distribution (see below for :ref:`alternatives`).
 library, which supports reading and writing of neuroimaging data formats. Open
 a terminal and type ::
 
-        pip install nibabel
+    pip install nibabel
 
-#. Finally, we are ready to install 'dipy` itself. Same as with `nibabel` above,
+#. Finally, we are ready to install DIPY itself. Same as with `nibabel` above,
 we will type at the terminal shell command line ::
 
-		pip install dipy
+    pip install dipy
 
 When the installation has finished we can check if it is successful in the following way. From a Python console script try ::
 
-		>>> import dipy
+    >>> import dipy
 
 This should work with no error.
 
 #. Some of the visualization methods require the VTK_ library and this can be installed using Anaconda ::
 
-		conda install vtk
+    conda install vtk
 
 
 OSX
@@ -74,21 +74,21 @@ OSX
 
 #. Even with Anaconda installed, you will still need to install the nibabel_ library, which supports reading and writing of neuroimaging data formats. Open a terminal and type ::
 
-        pip install nibabel
+    pip install nibabel
 
-#. Finally, we are ready to install 'dipy` itself. Same as with `nibabel` above, we will type at the terminal shell command line ::
+#. Finally, we are ready to install DIPY itself. Same as with `nibabel` above, we will type at the terminal shell command line ::
 
-        pip install dipy
+    pip install dipy
 
 When the installation has finished we can check if it is successful in the following way. From a Python console script try ::
 
-		>>> import dipy
+    >>> import dipy
 
 This should work with no error.
 
 #. Some of the visualization methods require the VTK_ library and this can be installed using Anaconda ::
 
-		conda install vtk
+    conda install vtk
 
 Linux
 -----
@@ -141,7 +141,7 @@ Common problems:
 Multiple installations
 ----------------------
 
-Make sure that you have uninstalled all previous versions of Dipy before installing a new one. A simple and general way to uninstall Dipy is by removing the installation directory. You can find where Dipy is installed by using::
+Make sure that you have uninstalled all previous versions of DIPY before installing a new one. A simple and general way to uninstall DIPY is by removing the installation directory. You can find where DIPY is installed by using::
 
     import dipy
     dipy.__file__
@@ -156,16 +156,16 @@ If you have problems installing Anaconda_ we recommend using Canopy_ or pythonxy
 
 Memory issues
 -------------
-Dipy can process large diffusion datasets. For this reason we recommend using a 64bit operating system which can allocate larger memory chunks than 32bit operating systems. If you don't have a 64bit computer that is okay Dipy works with 32bit too.
+DIPY can process large diffusion datasets. For this reason we recommend using a 64bit operating system which can allocate larger memory chunks than 32bit operating systems. If you don't have a 64bit computer that is okay DIPY works with 32bit too.
 
 .. _python-versions:
 
 Note on python versions
 -----------------------
 
-Most of the functionality in Dipy supports versions of Python from 2.6 to 3.5.
+Most of the functionality in DIPY supports versions of Python from 2.6 to 3.5.
 However, some visualization functionality depends on VTK_, which currently does not work with Python 3 versions.
-Therefore, if you want to use the visualization functions in Dipy, please use it with Python 2.
+Therefore, if you want to use the visualization functions in DIPY, please use it with Python 2.
 
 .. _from-source:
 
@@ -184,8 +184,8 @@ latest changes.  In that case, you can use::
 For more information about this see :ref:`following-latest`.
 
 After you've cloned the repository, you will have a new directory, containing
-the dipy ``setup.py`` file, among others.  We'll call this directory - that
-contains the ``setup.py`` file - the *dipy source root directory*.  Sometimes
+the DIPY ``setup.py`` file, among others.  We'll call this directory - that
+contains the ``setup.py`` file - the *DIPY source root directory*.  Sometimes
 we'll also call it the ``<dipy root>`` directory.
 
 Building and installing
@@ -196,17 +196,17 @@ Building and installing
 Install from source for Unix (e.g Linux, OSX)
 ---------------------------------------------
 
-Change directory into the *dipy source root directory* .
+Change directory into the *DIPY source root directory*.
 
 To install for the system::
 
     python setup.py install
 
-To build dipy in the source tree (locally) so you can run the code in the source tree (recommended for following the latest source) run::
+To build DIPY in the source tree (locally) so you can run the code in the source tree (recommended for following the latest source) run::
 
     python setup.py build_ext --inplace
 
-add the *dipy source root directory* into your ``PYTHONPATH`` environment variable. Search google for ``PYTHONPATH`` for details or see `python module path`_ for an introduction.
+add the *DIPY source root directory* into your ``PYTHONPATH`` environment variable. Search google for ``PYTHONPATH`` for details or see `python module path`_ for an introduction.
 
 When adding dipy_ to the ``PYTHONPATH``, we usually add the ``PYTHONPATH`` at
 the end of ``~/.bashrc`` or (OSX) ``~/.bash_profile`` so we don't need to
@@ -265,13 +265,13 @@ To build from source, you will also need to install a compiler. The easiest way
 to do that is to install a current version of Visual Studio.
 
 Start a command shell like ``cmd`` or Powershell_ and change directory into the
-*dipy source root directory*.
+*DIPY source root directory*.
 
 To install into your system::
 
     python setup.py install --compiler=mingw32
 
-To install inplace - so that dipy is running out of the source code directory::
+To install inplace - so that DIPY is running out of the source code directory::
 
     python setup.py develop
 
@@ -299,11 +299,11 @@ From here follow the :ref:`install-source-nix` instructions.
 OpenMP with OSX
 ---------------
 OpenMP_ is a standard library for efficient multithreaded applications. This
-is used in Dipy for speeding up many different parts of the library (e.g., denoising
+is used in DIPY for speeding up many different parts of the library (e.g., denoising
 and bundle registration). If you do not have an OpenMP-enabled compiler, you can
-still compile Dipy from source using the above instructions, but it might not take
+still compile DIPY from source using the above instructions, but it might not take
 advantage of the multithreaded parts of the code. To be able to compile
-Dipy from source with OpenMP on Mac OSX, you will have to do a few more things. First
+DIPY from source with OpenMP on Mac OSX, you will have to do a few more things. First
 of all, you will need to install the Homebrew_ package manager. Next you will need
 to install and configure the compiler. You have two options: using the GCC compiler
 or the CLANG compiler. This depends on your python installation:
@@ -313,12 +313,12 @@ Under Anaconda
 
 If you are using Anaconda, you will need to use GCC. Run the following::
 
-	brew reinstall gcc --without-multilib
+    brew reinstall gcc --without-multilib
 
 This should take about 45 minutes to complete. Then add to your bash
 configuration (usually in ``~/.bash_profile``), the following::
 
-	export PATH="/usr/local/Cellar/gcc/5.2.0/bin/gcc-5:$PATH
+    export PATH="/usr/local/Cellar/gcc/5.2.0/bin/gcc-5:$PATH
 
 
 Under Homebrew Python or python.org Python
@@ -327,12 +327,12 @@ Under Homebrew Python or python.org Python
 If you are already using the Homebrew Python, or the standard python.org Python,
 you will need to use the CLANG compiler with OMP. Run::
 
-	brew install clang-omp
+    brew install clang-omp
 
 And then edit the ``setup.py`` file to include the following line (e.g., on line 14,
 at the top of the file, but after the initial imports)::
 
-	os.environ['CC'] = '/usr/local/bin/clang-omp'
+    os.environ['CC'] = '/usr/local/bin/clang-omp'
 
 
 Building and installing

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,7 +1,7 @@
 .. _introduction:
 
 ===============
- What is dipy?
+ What is DIPY?
 ===============
 
 * **a python package** for analyzing ``diffusion MRI data``
@@ -16,7 +16,7 @@ e-mail list neuroimaging@python.org with subject starting with ``[Dipy]``.
 .. figure:: _static/pretty_tracks.png
    :align: center
 
-   **This is a depiction of tractography created with dipy**
+   This is a depiction of tractography created with DIPY.
 
    If you want to learn more how you can create these with your datasets 
    read the examples in our :ref:`documentation` .

--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -74,6 +74,7 @@
 .. _nose: http://somethingaboutorange.com/mrl/projects/nose
 .. _`python coverage tester`: http://nedbatchelder.com/code/modules/coverage.html
 .. _cython: http://cython.org
+.. _travis-ci: https://travis-ci.org/
 
 .. Other python projects
 .. _numpy: http://numpy.scipy.org

--- a/doc/mission.rst
+++ b/doc/mission.rst
@@ -6,7 +6,7 @@
 
 Mission of Statement
 
-The purpose of dipy is to make it **easier to do better diffusion MR imaging research**. Following up with the nipy mission statement we aim to build software that is
+The purpose of dipy_ is to make it **easier to do better diffusion MR imaging research**. Following up with the nipy mission statement we aim to build software that is
 
     * **clearly written**
     * **clearly explained**
@@ -16,3 +16,5 @@ The purpose of dipy is to make it **easier to do better diffusion MR imaging res
 We hope that, if we fail to do this, you will let us know and we will try and make it better. 
 
 See also :ref:`introduction`
+
+.. include:: links_names.inc

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -4,17 +4,16 @@
 Older Highlights
 ****************
 
-**Dipy** was an **official exhibitor** for OHBM 2015.
+DIPY was an **official exhibitor** for OHBM 2015.
 
 .. raw :: html
 
-	<div style="width: 80% max-width=800px">
-		<a href="http://www.humanbrainmapping.org/i4a/pages/index.cfm?pageID=3625" target="_blank"><img alt=" " class="align-center" src="_static/hbm2015_exhibitors.jpg" style="width: 90%;max-height: 90%">
-        </a>
-	</div>
+  <div style="width: 80% max-width=800px">
+    <a href="http://www.humanbrainmapping.org/i4a/pages/index.cfm?pageID=3625" target="_blank"><img alt=" " class="align-center" src="_static/hbm2015_exhibitors.jpg" style="width: 90%;max-height: 90%"></a>
+  </div>
 
 
-**Dipy 0.9.2** is now available for :ref:`download <installation>`. Here is a summary of the new features.
+**DIPY 0.9.2** is now available for :ref:`download <installation>`. Here is a summary of the new features.
 
 * Anatomically Constrained Tissue Classifiers for Tracking
 * Massive speedup of Constrained Spherical Deconvolution (CSD)
@@ -27,22 +26,21 @@ Older Highlights
 * Sparse Fascicle Model supports acquisitions with multiple b-values
 
 
-**Dipy 0.8.0** is now available for :ref:`download <installation>`. The new
+**DIPY 0.8.0** is now available for :ref:`download <installation>`. The new
 release contains state-of-the-art algorithms for diffusion MRI registration, reconstruction, denoising, statistical evaluation, fiber tracking and validation of tracking.
 
-For more information about Dipy_, read the `dipy paper`_  in Frontiers in Neuroinformatics.
+For more information about dipy_, read the `DIPY paper`_  in Frontiers in Neuroinformatics.
 
 .. raw :: html
 
-	<div style="width: 80% max-width=800px">
-		<a href="http://www.frontiersin.org/Neuroinformatics/10.3389/fninf.2014.00008/abstract" target="_blank"><img alt=" " class="align-center" src="_static/dipy_paper_logo.jpg" style="width: 90%;max-height: 90%">
-        </a>
-	</div>
+  <div style="width: 80% max-width=800px">
+    <a href="http://www.frontiersin.org/Neuroinformatics/10.3389/fninf.2014.00008/abstract" target="_blank"><img alt=" " class="align-center" src="_static/dipy_paper_logo.jpg" style="width: 90%;max-height: 90%"></a>
+  </div>
 
 So, how similar are your bundles to the real anatomy? Learn how to optimize your analysis as we did to create the fornix of the figure above, by reading the tutorials in our :ref:`gallery <examples>`.
 
 
-In Dipy_ we care about methods which can solve complex problems efficiently and robustly. QuickBundles is one of the many state-of-the art algorithms found in Dipy. It can be used to simplify large datasets of streamlines. See our :ref:`gallery <examples>` of examples and try QuickBundles with your data. Here is a video of QuickBundles applied on a simple dataset.
+In dipy_ we care about methods which can solve complex problems efficiently and robustly. QuickBundles is one of the many state-of-the art algorithms found in DIPY. It can be used to simplify large datasets of streamlines. See our :ref:`gallery <examples>` of examples and try QuickBundles with your data. Here is a video of QuickBundles applied on a simple dataset.
 
 .. raw:: html
 

--- a/doc/old_news.rst
+++ b/doc/old_news.rst
@@ -6,19 +6,19 @@ Past announcements
 **********************
 
 
-- **Dipy 0.7.1** is available for :ref:`download <installation>` with **3X**
+- **DIPY 0.7.1** is available for :ref:`download <installation>` with **3X**
     more tutorials than 0.6.0! In addition, a `journal paper`_ focusing on
-    teaching the fundamentals of Dipy is available in Frontiers of Neuroinformatics.
-- A new **hands on Dipy** seminar to 50 neuroscientists from Canada, as part of QBIN's "Do's and dont's of diffusion MRI" workshop, 8 April, 2014.
-- The creators of Dipy will attend both ISMRM and HBM 2015. Come and meet us!
-- `Dipy paper`_ accepted in Frontiers of Neuroinformatics, 22 January, 2014.
-- **Dipy 0.7.1** Released!, 16 January, 2014.
-- **Dipy 0.7.0** Released!, 23 December, 2013.
+    teaching the fundamentals of DIPY is available in Frontiers of Neuroinformatics.
+- A new **hands on DIPY** seminar to 50 neuroscientists from Canada, as part of QBIN's "Do's and dont's of diffusion MRI" workshop, 8 April, 2014.
+- The creators of DIPY will attend both ISMRM and HBM 2015. Come and meet us!
+- `DIPY paper`_ accepted in Frontiers of Neuroinformatics, 22 January, 2014.
+- **DIPY 0.7.1** Released!, 16 January, 2014.
+- **DIPY 0.7.0** Released!, 23 December, 2013.
 - **Spherical Deconvolution** algorithms are now included in the current development version 0.7.0dev. See the examples in :ref:`gallery <examples>`, 24 June 2013.
-- A team of Dipy developers **wins** the `IEEE ISBI HARDI challenge <http://hardi.epfl.ch/static/events/2013_ISBI/workshop.html#results>`_, 7 April, 2013.
-- **Hands on Dipy** seminar took place at the dMRI course of the CREATE-MIA summer school, 5-7 June, McGill, Montreal, 2013.
-- **Dipy 0.6.0** Released!, 30 March, 2013.
-- **Dipy 3rd Sprint**, Berkeley, CA, 8-18 April, 2013.
-- **IEEE ISBI HARDI challenge** 2013 chooses **Dipy**, February, 2013.
+- A team of DIPY developers **wins** the `IEEE ISBI HARDI challenge <http://hardi.epfl.ch/static/events/2013_ISBI/workshop.html#results>`_, 7 April, 2013.
+- **Hands on DIPY** seminar took place at the dMRI course of the CREATE-MIA summer school, 5-7 June, McGill, Montreal, 2013.
+- **DIPY 0.6.0** Released!, 30 March, 2013.
+- **DIPY 3rd Sprint**, Berkeley, CA, 8-18 April, 2013.
+- **IEEE ISBI HARDI challenge** 2013 chooses **DIPY**, February, 2013.
  
 

--- a/doc/release0.10.rst
+++ b/doc/release0.10.rst
@@ -1,7 +1,7 @@
 .. _release0.10:
 
 ====================================
- Release notes for Dipy version 0.10
+ Release notes for DIPY version 0.10
 ====================================
 
 GitHub stats for 2015/03/18 - 2015/11/19 (tag: 0.9.2)

--- a/doc/release0.11.rst
+++ b/doc/release0.11.rst
@@ -1,7 +1,7 @@
 .. _release0.11:
 
 ====================================
- Release notes for Dipy version 0.11
+ Release notes for DIPY version 0.11
 ====================================
 
 GitHub stats for 2015/12/03 - 2016/02/21 (tag: 0.10)

--- a/doc/release0.12.rst
+++ b/doc/release0.12.rst
@@ -1,7 +1,7 @@
 .. _release0.12:
 
 ====================================
- Release notes for Dipy version 0.12
+ Release notes for DIPY version 0.12
 ====================================
 
 

--- a/doc/release0.6.rst
+++ b/doc/release0.6.rst
@@ -1,5 +1,5 @@
 ===================================
- Release notes for dipy version 0.6
+ Release notes for DIPY version 0.6
 ===================================
 
 GitHub stats for 2011/02/12 - 2013/03/20 

--- a/doc/release0.7.rst
+++ b/doc/release0.7.rst
@@ -1,5 +1,5 @@
 ===================================
- Release notes for dipy version 0.7
+ Release notes for DIPY version 0.7
 ===================================
 
 GitHub stats for 2013/03/29 - 2013/12/23 (tag: 0.6.0)

--- a/doc/release0.8.rst
+++ b/doc/release0.8.rst
@@ -1,7 +1,7 @@
 .. _release0.8:
 
 ===================================
- Release notes for dipy version 0.8
+ Release notes for DIPY version 0.8
 ===================================
 
 GitHub stats for 2013/12/24 - 2014/12/26 (tag: 0.7.0)

--- a/doc/release0.9.rst
+++ b/doc/release0.9.rst
@@ -1,7 +1,7 @@
 .. _release0.9:
 
 ===================================
- Release notes for Dipy version 0.9
+ Release notes for DIPY version 0.9
 ===================================
 
 GitHub stats for 2015/01/06 - 2015/03/18 (tag: 0.8.0)

--- a/doc/theory/b_and_q.rst
+++ b/doc/theory/b_and_q.rst
@@ -18,10 +18,10 @@ acquisition:
 
 ..  math::
 
-   R   =  \int_0^T ( \int_0^t \rho ( \tau ) \, d{ \tau } )^2 \, d{t}.
+   R = \int_0^T ( \int_0^t \rho ( \tau ) \, d{ \tau } )^2 \, d{t}.
 
 (See Basser, Matiello and LeBihan, 1994.) Another formulation involves
-the introduction of `k-space`. In standard in-plane MR image encoding
+the introduction of k-space. In standard in-plane MR image encoding
 
 .. math::
 

--- a/doc/theory/gqi.rst
+++ b/doc/theory/gqi.rst
@@ -4,7 +4,7 @@
 Generalised Q-Sampling Imaging
 ==============================
 
-These notes are to help the user of the dipy module understand 
+These notes are to help the user of the DIPY module understand 
 Frank Yeh's Generalised Q-Sampling Imaging (GQI) [reference?].
 
 The starting point is the classical formulation of joint k-space 


### PR DESCRIPTION
Fix typos and formatting in .rst files and Python examples'
documentations:
- Fix typos in files.
- Replace tabs for two white spaces.
- Fix errors in citation and DIPY internal cross-refs.
- Add missing cross-refs (e.g. Aganj MRM 2010).
- Add links where necessary (ISBI HARDI Contest 2013 and FreeSurfer).
- Fix LaTeX math formatting errors.
- Make the example/DIPY code object markdown consistent (inverted commas).
- Capitalize the acronym long names' first/corresponding letters (e.g.
  Constrained Spherical Deconvolution).
- Capitalize acronyms (e.g. FA).
- Make the writing of terms consistent in terms of uppercase/lowercase
  (e.g. b0 vs. B0; cospus callosum vs. Corpus Callosum, etc.).
- Use the [NameYear] convention for citations.
- Place all citations under a 'References' section, and use the subsection
  markdown for the section.
- Use inverted commas consistently to reference code objects.
- Make the b-value units consistent across files (s/mm^2).
- Create and include missing figures for 'reconst_fwdti.py'.
- Write DIPY instead of any of its variants in the documentation.
- Link the first appearance of dipy in every file (use dipy_).