### PR TITLE
Forecast

### DIFF
--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -354,6 +354,31 @@ class ForecastFit(OdfFit):
         md = (self.d_par + 2*self.d_perp)/3.0
         return md
 
+    def predict(self, gtab=None, S0=1.0):
+        r""" Calculates the fODF for a given discrete sphere.
+
+        Parameters
+        ----------
+        gtab : GradientTable, optional
+            gradient directions and bvalues container class. 
+        S0 : float, optional
+            the signal at b-value=0
+            
+        """
+        if gtab is None:
+            gtab = self.gtab
+        
+        M_diff = forecast_matrix(self.sh_order,  
+                                 self.d_par,
+                                 self.d_perp,
+                                 gtab.bvals)
+
+        rho = rho_matrix(self.sh_order, gtab.bvecs)
+        M = M_diff * rho
+        S = S0 * np.dot(M, self._sh_coef)
+        
+        return S
+
     @property
     def sh_coeff(self):
         """The FORECAST SH coefficients

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -418,15 +418,15 @@ def forecast_error_func(x, b_unique, E):
     r""" Calculates the difference between the mean signal calculated using 
     the parameter vector x and the average signal E using FORECAST and SMT
     """
-    c0 = np.cos(x[0])**2
-    c1 = np.cos(x[1])**2
+    c0 = np.cos(x[0])**2 * 3e-03
+    c1 = np.cos(x[1])**2 * 3e-03
 
     if c0 >= c1:
-        d_par = c0 * 3e-03
-        d_perp = c1 * 3e-03
+        d_par = c0
+        d_perp = c1
     else:
-        d_par = c1 * 3e-03
-        d_perp = c0 * 3e-03
+        d_par = c1
+        d_perp = c0
 
     E_ = 0.5 * np.exp(-b_unique*d_perp) * Psi_l(0, (b_unique * (d_par-d_perp)))
 
@@ -573,7 +573,7 @@ def rho_matrix(sh_order, vecs):
 
 
 def lb_forecast(sh_order):
-    r"""Returns the Laplace Beltrami regularization matrix for FORECAST
+    r"""Returns the Laplace-Beltrami regularization matrix for FORECAST
     """
     n_c = int((sh_order + 1)*(sh_order + 2)/2)
     diagL = np.zeros(n_c)

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -1,0 +1,568 @@
+from __future__ import division
+
+from warnings import warn
+import numpy as np
+from dipy.reconst.cache import Cache
+from dipy.reconst.multi_voxel import multi_voxel_fit
+from dipy.reconst.shm import real_sph_harm
+from dipy.core.gradients import gradient_table
+from scipy.special import erf
+from math import factorial
+from dipy.core.geometry import cart2sphere
+from dipy.data import get_sphere
+from dipy.reconst.odf import OdfModel, OdfFit
+from scipy.optimize import leastsq
+from dipy.utils.optpkg import optional_package
+cvxpy, have_cvxpy, _ = optional_package("cvxpy")
+
+
+class ForecastModel(OdfModel, Cache):
+    r"""Fiber ORientation Estimated using Continuous Axially Symmetric Tensors 
+    (FORECAST) [1,2,3]_. FORECAST is a Spherical Deconvolution reconstruction model
+    for multi-shell diffusion data which enables the calculation of a voxel
+    adaptive response function using the Spherical Mean Tecnique (SMT) [2,3]_. 
+
+    With FORECAST it is possible to calculate crossing invariant parallel
+    diffusivity, perpendicular diffusivity, mean diffusivity, and fractional
+    anisotropy [2]_
+
+    References
+    ----------
+    .. [1] Anderson A. W., "Measurement of Fiber Orientation Distributions
+           Using High Angular Resolution Diffusion Imaging", Magnetic
+           Resonance in Medicine, 2005.
+
+    .. [2] Kaden E. et. al, "Quantitative Mapping of the Per-Axon Diffusion 
+           Coefficients in Brain White Matter", Magnetic Resonance in 
+           Medicine, 2016.
+
+    .. [3] Zucchelli E. et. al, "A generalized SMT-based framework for
+           Diffusion MRI microstructural model estimation", MICCAI Workshop
+           on Computational DIFFUSION MRI (CDMRI), 2017.
+    Notes
+    -----
+    The implementation of FORECAST may require CVXPY (http://www.cvxpy.org/).
+    """
+
+    def __init__(self,
+                 gtab,
+                 sh_order=8,
+                 lambda_LB=1e-3,
+                 optimizer='wls',
+                 sphere=None,
+                 lambda_csd=1.0):
+        r""" Analytical and continuous modeling of the diffusion signal with
+        respect to the FORECAST basis [1,2,3]_.
+        This implementation is a modification of the original FORECAST 
+        model presented in [1]_ adapted for multi-shell data as in [2,3]_ .
+
+        The main idea is to model the diffusion signal as the combination of a
+        single fiber response function $F(\mathbf{b})$ times the fODF 
+        $\rho(\mathbf{v})$
+
+        ..math::
+            :nowrap:
+                \begin{equation}
+                    E(\mathbf{b}) = \int_{\mathbf{v} \in \mathcal{S}^2} \rho(\mathbf{v}) F({\mathbf{b}} | \mathbf{v}) d \mathbf{v}
+                \end{equation}
+
+        where $\mathbf{b}$ is the b-vector (b-value times gradient direction)
+        and $\mathbf{v}$ is an unit vector representing a fiber direction.
+
+        In FORECAST $\rho$ is modeled using real symmetric Spherical Harmonics
+        (SH) and $F(\mathbf(b))$ is an axially symmetric tensor.
+
+
+        Parameters
+        ----------
+        gtab : GradientTable,
+            gradient directions and bvalues container class.
+        sh_order : unsigned int,
+            an even integer that represent the SH order of the basis (max 12)
+        lambda_LB: float,
+            Laplace-Beltrami regularization weight.
+        optimizer : str,
+            optimizer. The possible values are Weighted Least Squares ('wls'),
+            Positivity Constraints using CVXPY ('pos') and the Constraint 
+            Spherical Deconvolution algorithm ('csd'). Default is 'wls'.
+        sphere : array, shape (N,3),
+            sphere points where to enforce positivity when 'pos' or 'csd'
+            optimizer are selected.
+        lambda_csd : float,
+            csd regularization weight.
+
+        References
+        ----------
+        .. [1] Anderson A. W., "Measurement of Fiber Orientation Distributions
+               Using High Angular Resolution Diffusion Imaging", Magnetic
+               Resonance in Medicine, 2005.
+
+        .. [2] Kaden E. et. al, "Quantitative Mapping of the Per-Axon Diffusion 
+               Coefficients in Brain White Matter", Magnetic Resonance in 
+               Medicine, 2016.
+
+        .. [3] Zucchelli M. et. al, "A generalized SMT-based framework for
+               Diffusion MRI microstructural model estimation", MICCAI Workshop
+               on Computational DIFFUSION MRI (CDMRI), 2017.
+
+        Examples
+        --------
+        In this example, where the data, gradient table and sphere tessellation
+        used for reconstruction are provided, we model the diffusion signal
+        with respect to the FORECAST and compute the fODF, parallel and 
+        perpendicular diffusivity.
+
+        from dipy.data import get_sphere, get_3shell_gtab
+        gtab = get_3shell_gtab()
+
+        from dipy.sims.voxel import MultiTensor
+        mevals = np.array(([0.0017, 0.0003, 0.0003],
+                            [0.0017, 0.0003, 0.0003]))
+        angl = [(0, 0), (60, 0)]
+        data, sticks = MultiTensor(
+            gtab, mevals, S0=100.0, angles=angl,
+            fractions=[50, 50], snr=None)
+
+        from dipy.reconst.forecast import ForecastModel
+        fm= ForecastModel(gtab, sh_order=6)
+        f_fit = fm.fit(data)
+        d_par = f_fit.dpar
+        d_perp = f_fit.dperp
+
+        sphere = get_sphere('symmetric724')
+        fodf = f_fit.odf(sphere)
+        """
+
+        # round the bvals in order to avoid numerical errors
+        self.bvals = np.round(gtab.bvals/100) * 100
+        self.bvecs = gtab.bvecs
+        self.gtab = gtab
+        if sh_order >= 0 and not(bool(sh_order % 2)) and sh_order<=12:
+            self.sh_order = sh_order
+        else:
+            msg = "sh_order must be a non-zero even positive number "
+            msg += "between 2 and 12"
+            raise ValueError(msg)
+
+        if sphere is None:
+            sphere = get_sphere('repulsion100')
+            self.vertices = sphere.vertices[
+                0:int(sphere.vertices.shape[0]/2), :]
+
+        else:
+            self.vertices = sphere
+
+        self.b0s_mask = gtab.b0s_mask
+        self.one_0_bvals = np.r_[0, self.bvals[~self.b0s_mask]]
+        self.one_0_bvecs = np.r_[np.array([0, 0, 0]).reshape(
+            1, 3), self.bvecs[~self.b0s_mask, :]]
+
+        self.rho = rho_matrix(self.sh_order, self.one_0_bvecs)
+
+        self.b_unique = np.sort(np.unique(self.bvals[self.bvals > 0]))
+        self.wls = True
+        self.csd = False
+        self.pos = False
+
+        if optimizer == 'pos':
+            if have_cvxpy:
+                self.wls = False
+                self.pos = True
+            else:
+                msg = 'cvxpy is needed to inforce positivity constraints.'
+                raise ValueError(msg)
+
+        if optimizer == 'csd':
+            self.csd = True
+
+        self.L = lb_forecast(self.sh_order)
+        self.lambda_lb = lambda_LB
+        self.lambda_csd = lambda_csd
+        self.fod = rho_matrix(sh_order, self.vertices)
+
+    @multi_voxel_fit
+    def fit(self, data):
+
+        data_b0 = data[self.b0s_mask].mean()
+        data_single_b0 = np.r_[data_b0, data[~self.b0s_mask]] / data_b0
+        data_single_b0 = np.clip(data_single_b0, 0, 1.0)
+
+        # calculates the mean signal at each b_values
+        means = find_signal_means(self.b_unique, data_single_b0, self.bvals)
+
+        n_c = int((self.sh_order + 1)*(self.sh_order + 2)/2)
+
+        lv = self.vertices.shape[0]
+
+        # average diffusivity initialization
+        x = np.array([np.pi/4, np.pi/4])
+
+        x, status = leastsq(forecast_error_func, x,
+                            args=(self.b_unique, means))
+
+        # squared to avoid negative diffusivities
+        c0 = np.cos(x[0])**2
+        c1 = np.cos(x[1])**2
+
+        if c0 >= c1:
+            d_par = c0 * 3e-03
+            d_perp = c1 * 3e-03
+        else:
+            d_par = c1 * 3e-03
+            d_perp = c0 * 3e-03
+
+        # round to avoid memory explosion
+        diff_key = str(int(np.round(d_par*1e05))) + \
+            str(int(np.round(d_perp*1e05)))
+
+        M_diff = self.cache_get('forecast_matrix', key=diff_key)
+        if M_diff is None:
+            M_diff = forecast_matrix(
+                self.sh_order,  d_par, d_perp, self.one_0_bvals)
+            self.cache_set('forecast_matrix', key=diff_key, value=M_diff)
+
+        M = M_diff * self.rho
+        M0 = M[:, 0]
+        c0 = np.sqrt(1.0/(4*np.pi))
+
+        if self.wls:
+            data_r = data_single_b0 - M0*c0
+
+            Mr = M[:, 1:]
+            Lr = self.L[1:, 1:]
+
+            pseudoInv = np.dot(np.linalg.inv(
+                np.dot(Mr.T, Mr) + self.lambda_lb*Lr), Mr.T)
+            coef = np.dot(pseudoInv, data_r)
+            coef = np.r_[c0, coef]
+
+        if self.csd:
+            values = np.dot(self.fod, coef)
+            low_peak_mean = np.mean(values)
+            low_peaks = values < (0.1*low_peak_mean)
+
+            lpl = np.ones((300, 1))
+
+            L = self.fod[low_peaks, :]
+            counter = 0
+            while not np.array_equal(low_peaks, lpl) and L.shape[0] > 0:
+                lpl = low_peaks
+                pseudoInv = np.linalg.inv(
+                    np.dot(M.T, M) + self.lambda_csd*np.dot(L.T, L))
+                data_corr = np.dot(M.T, data_single_b0[:, None])
+
+                coef = np.dot(pseudoInv, data_corr)[:, 0]
+
+                coef = coef/coef[0] * c0
+
+                values = np.dot(self.fod, coef)
+
+                low_peak_mean = np.mean(values)
+                low_peaks = values < (0.1*low_peak_mean)
+
+                L = self.fod[low_peaks, :]
+                counter = counter + 1
+
+                if counter > 50:
+                    warn('CSD convergence not reached')
+                    break
+
+        if self.pos:
+            c = cvxpy.Variable(M.shape[1])
+            design_matrix = cvxpy.Constant(M)
+            objective = cvxpy.Minimize(
+                cvxpy.sum_squares(design_matrix * c - data_single_b0) +
+                self.lambda_lb * cvxpy.quad_form(c, self.L))
+
+            constraints = [c[0] == c0, self.fod * c >= 0]
+            prob = cvxpy.Problem(objective, constraints)
+            try:
+                prob.solve()
+                coef = np.asarray(c.value).squeeze()
+            except:
+                warn('Optimization did not find a solution')
+                coef = np.zeros(M.shape[1])
+                coef[0] = c0
+
+        return ForecastFit(self, coef, d_par, d_perp)
+
+
+class ForecastFit(OdfFit):
+
+    def __init__(self, model, sh_coef, d_par, d_perp):
+        """ Calculates diffusion properties for a single voxel
+
+        Parameters
+        ----------
+        model : object,
+            AnalyticalModel
+        sh_coef : 1d ndarray,
+            forecast sh coefficients
+        d_par : float,
+            parallel diffusivity
+        d_perp : float,
+            perpendicular diffusivity
+        """
+
+        self.model = model
+        self._sh_coef = sh_coef
+        self.gtab = model.gtab
+        self.sh_order = model.sh_order
+
+        self.d_par = d_par
+        self.d_perp = d_perp
+
+        self.M = None
+        self.rho = None
+
+        self.Y_ = None
+
+    def odf(self, sphere):
+        r""" Calculates the fODF for a given discrete sphere.
+
+        Parameters
+        ----------
+        sphere : Sphere,
+            the odf sphere
+        """
+        if self.rho == None:
+            self.rho = rho_matrix(self.sh_order, sphere.vertices)
+
+        odf = np.dot(self.rho, self._sh_coef)
+
+        return odf
+
+    def fractional_anisotropy(self):
+        r""" Calculates the fractional anisotropy.
+        """
+        fa = np.sqrt(0.5 * (2*(self.d_par - self.d_perp)**2) /
+                     (self.d_par**2 + 2*self.d_perp**2))
+        return fa
+
+    def mean_diffusivity(self):
+        r""" Calculates the mean diffusivity.
+        """
+        md = (self.d_par + 2*self.d_perp)/3.0
+        return md
+
+    @property
+    def sh_coeff(self):
+        """The FORECAST SH coefficients
+        """
+        return self._sh_coef
+
+    @property
+    def dpar(self):
+        """The parallel diffusivity
+        """
+        return self.d_par
+
+    @property
+    def dperp(self):
+        """The perpendicular diffusivity
+        """
+        return self.d_perp
+
+
+def find_signal_means(b_unique, data_norm, bvals):
+    r"""Calculates the mean signal for each shell
+
+    Parameters
+    ----------
+    b_unique : 1d ndarray,
+        unique b-values in a vector excluding zero
+    data_norm : 1d ndarray,
+        normalized diffusion signal
+    bvals : 1d ndarray,
+        the b-values.
+
+    Returns
+    -------
+    means : 1d ndarray
+        the average of the signal for each b-values
+
+    """
+
+    lb = len(b_unique)
+    means = np.zeros(lb)
+
+    for u in range(lb):
+        ind = bvals == b_unique[u]
+        shell = data_norm[ind]
+
+        means[u] = np.mean(shell)
+
+    return means
+
+
+def forecast_error_func(x, b_unique, E):
+    r""" Calculates the difference between the mean signal calculated using 
+    the parameter vector x and the average signal E using FORECAST and SMT
+    """
+    c0 = np.cos(x[0])**2
+    c1 = np.cos(x[1])**2
+
+    if c0 >= c1:
+        d_par = c0 * 3e-03
+        d_perp = c1 * 3e-03
+    else:
+        d_par = c1 * 3e-03
+        d_perp = c0 * 3e-03
+
+    E_ = 0.5 * np.exp(-b_unique*d_perp) * Psi_l(0, (b_unique * (d_par-d_perp)))
+
+    v = E-E_
+    return v
+
+
+def I_l(l, b):
+    if np.isscalar(b):
+        if b <= 1e-08:
+            v = 2.0/(l+1)
+        else:
+            if l == 0:
+                v = (np.sqrt(np.pi)*erf(np.sqrt(b))) / (b**(0.5))
+
+            if l == 2:
+                v = (np.sqrt(np.pi)*erf(np.sqrt(b)) - 2*np.exp(-b) *
+                     np.sqrt(b)) / (2*b**(1.5))
+
+            if l == 4:
+                v = (3 * np.sqrt(np.pi)*erf(np.sqrt(b)) - 2*np.exp(-b) *
+                     np.sqrt(b)*(2*b+3)) / (4*b**(2.5))
+
+            if l == 6:
+                v = (15 * np.sqrt(np.pi)*erf(np.sqrt(b)) - 2*np.exp(-b) *
+                     np.sqrt(b)*(4*b**2 + 10*b+15)) / (8*b**(3.5))
+
+            if l == 8:
+                v = (105 * np.sqrt(np.pi)*erf(np.sqrt(b)) - 2*np.exp(-b) *
+                     np.sqrt(b)*(8*b**3 + 28*b**2 + 70*b+105)) / (16*b**(4.5))
+
+            if l == 10:
+                v = (945 * np.sqrt(np.pi)*erf(np.sqrt(b)) - 2*np.exp(-b) *
+                     np.sqrt(b)*(16*b**4 + 72*b**3 + 252*b**2 + 630*b+945)) /\
+                    (32*b**(5.5))
+
+            if l == 12:
+                v = (10395 * np.sqrt(np.pi)*erf(np.sqrt(b)) - 2*np.exp(-b) *
+                     np.sqrt(b)*(32*b**5 + 176*b**4 + 792*b**3 + 2772*b**2 +
+                     6930*b+10395)) / (64*b**(6.5))
+
+    else:
+        v = np.zeros(len(b))
+        ind = b <= 1e-08
+        v[ind] = 2.0/(l+1)
+        b_not = b[~ind]
+        if l == 0:
+            v[~ind] = (np.sqrt(np.pi)*erf(np.sqrt(b_not))) / (b_not**(0.5))
+
+        if l == 2:
+            v[~ind] = (np.sqrt(np.pi)*erf(np.sqrt(b_not)) - 2*np.exp(-b_not) *
+                       np.sqrt(b_not)) / (2*b_not**(1.5))
+
+        if l == 4:
+            v[~ind] = (3 * np.sqrt(np.pi)*erf(np.sqrt(b_not)) - 2 * \
+                       np.exp(-b_not)*np.sqrt(b_not)*(2*b_not+3)) / \
+                      (4*b_not**(2.5))
+
+        if l == 6:
+            v[~ind] = (15 * np.sqrt(np.pi)*erf(np.sqrt(b_not)) - 2 * \
+                       np.exp(-b_not) * np.sqrt(b_not)*(4*b_not**2 + \
+                       10*b_not+15)) / (8*b_not**(3.5))
+
+        if l == 8:
+            v[~ind] = (105 * np.sqrt(np.pi)*erf(np.sqrt(b_not)) - \
+                       2*np.exp(-b_not) * np.sqrt(b_not)*(8*b_not**3 + 28 * \
+                       b_not**2 + 70*b_not+105)) / (16*b_not**(4.5))
+
+        if l == 10:
+            v[~ind] = (945 * np.sqrt(np.pi)*erf(np.sqrt(b_not)) - 2 * \
+                       np.exp(-b_not)*np.sqrt(b_not) * (16*b_not**4 + 72 * \
+                       b_not**3 + 252*b_not**2 + 630*b_not+945)) / \
+                      (32*b_not**(5.5))
+
+        if l == 12:
+            v[~ind] = (10395 * np.sqrt(np.pi)*erf(np.sqrt(b_not)) - 2 *\
+                       np.exp(-b_not)*np.sqrt(b_not)*(32*b_not**5 + \
+                       176*b_not**4 + 792*b_not**3 + 2772*b_not**2 + 6930*
+                       b_not+10395)) / (64*b_not**(6.5))
+
+    return v
+
+
+def Psi_l(l, b):
+    if l == 0:
+        v = I_l(0, b)
+
+    if l == 2:
+        v = 0.5*(3*I_l(2, b) - I_l(0, b))
+
+    if l == 4:
+        v = (1.0/8)*(35*I_l(4, b) - 30*I_l(2, b) + 3*I_l(0, b))
+
+    if l == 6:
+        v = (1.0/16)*(231*I_l(6, b) - 315 * \
+             I_l(4, b) + 105*I_l(2, b) - 5*I_l(0, b))
+
+    if l == 8:
+        v = (1.0/128)*(6435*I_l(8, b) - 12012*I_l(6, b) + \
+            6930 * I_l(4, b) - 1260*I_l(2, b) + 35*I_l(0, b))
+
+    if l == 10:
+        v = (46189/256.0)*I_l(10, b) - (109395/256.0)*I_l(8, b) + \
+            (90090/256.0) * I_l(6, b)-(30030/256.0)*I_l(4, b) + \
+            (3465/256.0)*I_l(2, b) - (63/256.0)*I_l(0, b)
+
+    if l == 12:
+        v = (676039/1024.0)*I_l(12, b) - (1939938/1024.0)*I_l(10, b) + \
+            (2078505/1024.0)*I_l(8, b) - (1021020 / 1024.0)*I_l(6, b) + \
+            (225225/1024.0)*I_l(4, b) - (18018/1024.0)*I_l(2, b) + \
+            (231/1024.0)*I_l(0, b)
+
+    return v
+
+
+def forecast_matrix(sh_order,  d_par, d_perp, bvals):
+    r"""Compute the FORECAST radial matrix 
+    """
+    n_c = int((sh_order + 1)*(sh_order + 2)/2)
+    M = np.zeros((bvals.shape[0], n_c))
+    counter = 0
+    for l in range(0, sh_order + 1, 2):
+        for m in range(-l, l + 1):
+            M[:, counter] = 2*np.pi * \
+                np.exp(-bvals*d_perp) * Psi_l(l, bvals*(d_par-d_perp))
+            counter += 1
+    return M
+
+
+def rho_matrix(sh_order, vecs):
+    r"""Compute the SH matrix $\rho$
+    """
+
+    r, theta, phi = cart2sphere(vecs[:, 0], vecs[:, 1], vecs[:, 2])
+    theta[np.isnan(theta)] = 0
+
+    n_c = int((sh_order + 1)*(sh_order + 2)/2)
+    rho = np.zeros((vecs.shape[0], n_c))
+    counter = 0
+    for l in range(0, sh_order + 1, 2):
+        for m in range(-l, l + 1):
+            rho[:, counter] = real_sph_harm(m, l, theta, phi)
+            counter += 1
+    return rho
+
+
+def lb_forecast(sh_order):
+    r"""Returns the Laplace Beltrami regularization matrix for FORECAST
+    """
+    n_c = int((sh_order + 1)*(sh_order + 2)/2)
+    diagL = np.zeros(n_c)
+    counter = 0
+    for l in range(0, sh_order + 1, 2):
+        for m in range(-l, l + 1):
+            diagL[counter] = (l * (l + 1)) ** 2
+            counter += 1
+
+    return np.diag(diagL)

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -49,7 +49,7 @@ def test_forecast_positive_constrain():
     f_fit = fm.fit(data.S)
 
     sphere = get_sphere('repulsion100')
-    fodf = f_fit.odf(sphere)
+    fodf = f_fit.odf(sphere, clip_negative=False)
     assert_equal(fodf[fodf < 0].sum(), 0)
 
     coeff = f_fit.sh_coeff
@@ -62,12 +62,12 @@ def test_forecast_csd():
     fm = ForecastModel(data.gtab, optimizer='csd',
                        sphere=data.sphere, lambda_csd=data.lambda_csd)
     f_fit = fm.fit(data.S)
-    fodf_csd = f_fit.odf(sphere)
+    fodf_csd = f_fit.odf(sphere, clip_negative=False)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
                        lambda_LB=data.lambda_LB, optimizer='wls')
     f_fit = fm.fit(data.S)
-    fodf_wls = f_fit.odf(sphere)
+    fodf_wls = f_fit.odf(sphere, clip_negative=False)
 
     value = fodf_wls[fodf_wls < 0].sum() < fodf_csd[fodf_csd < 0].sum()
     assert_equal(value, 1)

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -33,7 +33,7 @@ def setup():
         data.gtab, data.mevals, S0=100.0, angles=data.angl,
         fractions=[50, 50], snr=None)
     data.sh_order = 6
-    data.lambda_LB = 1e-8
+    data.lambda_lb = 1e-8
     data.lambda_csd = 1.0
     sphere = get_sphere('repulsion100')
     data.sphere = sphere.vertices[0:int(sphere.vertices.shape[0]/2), :]
@@ -43,7 +43,7 @@ def setup():
 def test_forecast_positive_constrain():
     fm = ForecastModel(data.gtab,
                        sh_order=data.sh_order,
-                       lambda_LB=data.lambda_LB,
+                       lambda_lb=data.lambda_lb,
                        optimizer='pos',
                        sphere=data.sphere)
     f_fit = fm.fit(data.S)
@@ -65,7 +65,7 @@ def test_forecast_csd():
     fodf_csd = f_fit.odf(sphere, clip_negative=False)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_LB=data.lambda_LB, optimizer='wls')
+                       lambda_lb=data.lambda_lb, optimizer='wls')
     f_fit = fm.fit(data.S)
     fodf_wls = f_fit.odf(sphere, clip_negative=False)
 
@@ -126,7 +126,7 @@ def test_forecast_odf():
 def test_forecast_indices():
     # check anisotropic tensor
     fm = ForecastModel(data.gtab, sh_order=2,
-                       lambda_LB=data.lambda_LB, optimizer='wls')
+                       lambda_lb=data.lambda_lb, optimizer='wls')
     f_fit = fm.fit(data.S)
 
     d_par = f_fit.dpar
@@ -151,7 +151,7 @@ def test_forecast_indices():
         fractions=[50, 50], snr=None)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_LB=data.lambda_LB, optimizer='wls')
+                       lambda_lb=data.lambda_lb, optimizer='wls')
     f_fit = fm.fit(S)
 
     d_par = f_fit.dpar

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -44,7 +44,7 @@ def test_forecast_positive_constrain():
     fm = ForecastModel(data.gtab,
                        sh_order=data.sh_order,
                        lambda_lb=data.lambda_lb,
-                       optimizer='pos',
+                       optimizer='POS',
                        sphere=data.sphere)
     f_fit = fm.fit(data.S)
 
@@ -59,13 +59,13 @@ def test_forecast_positive_constrain():
 
 def test_forecast_csd():
     sphere = get_sphere('repulsion100')
-    fm = ForecastModel(data.gtab, optimizer='csd',
+    fm = ForecastModel(data.gtab, optimizer='CSD',
                        sphere=data.sphere, lambda_csd=data.lambda_csd)
     f_fit = fm.fit(data.S)
     fodf_csd = f_fit.odf(sphere, clip_negative=False)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb, optimizer='wls')
+                       lambda_lb=data.lambda_lb, optimizer='WLS')
     f_fit = fm.fit(data.S)
     fodf_wls = f_fit.odf(sphere, clip_negative=False)
 
@@ -76,7 +76,7 @@ def test_forecast_csd():
 def test_forecast_odf():
     # check FORECAST fODF at different SH order
     fm = ForecastModel(data.gtab, sh_order=4,
-                       optimizer='csd', sphere=data.sphere)
+                       optimizer='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     sphere = get_sphere('repulsion724')
     fodf = f_fit.odf(sphere)
@@ -86,7 +86,7 @@ def test_forecast_odf():
         angular_similarity(directions, data.sticks), 2, 1)
 
     fm = ForecastModel(data.gtab, sh_order=6,
-                       optimizer='csd', sphere=data.sphere)
+                       optimizer='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -95,7 +95,7 @@ def test_forecast_odf():
         angular_similarity(directions, data.sticks), 2, 1)
 
     fm = ForecastModel(data.gtab, sh_order=8,
-                       optimizer='csd', sphere=data.sphere)
+                       optimizer='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -105,7 +105,7 @@ def test_forecast_odf():
 
     # stronger regularization is required for high order SH
     fm = ForecastModel(data.gtab, sh_order=10,
-                       optimizer='csd', sphere=sphere.vertices)
+                       optimizer='CSD', sphere=sphere.vertices)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -114,7 +114,7 @@ def test_forecast_odf():
         angular_similarity(directions, data.sticks), 2, 1)
 
     fm = ForecastModel(data.gtab, sh_order=12,
-                       optimizer='csd', sphere=sphere.vertices)
+                       optimizer='CSD', sphere=sphere.vertices)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -126,7 +126,7 @@ def test_forecast_odf():
 def test_forecast_indices():
     # check anisotropic tensor
     fm = ForecastModel(data.gtab, sh_order=2,
-                       lambda_lb=data.lambda_lb, optimizer='wls')
+                       lambda_lb=data.lambda_lb, optimizer='WLS')
     f_fit = fm.fit(data.S)
 
     d_par = f_fit.dpar
@@ -151,7 +151,7 @@ def test_forecast_indices():
         fractions=[50, 50], snr=None)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb, optimizer='wls')
+                       lambda_lb=data.lambda_lb, optimizer='WLS')
     f_fit = fm.fit(S)
 
     d_par = f_fit.dpar
@@ -166,7 +166,7 @@ def test_forecast_indices():
 def test_forecast_predict():
     # check anisotropic tensor
     fm = ForecastModel(data.gtab, sh_order=8,
-                       optimizer='csd', sphere=data.sphere)
+                       optimizer='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
 
     S = f_fit.predict(S0=1.0)
@@ -197,7 +197,7 @@ def test_multivox_forecast():
         fractions=[50, 50], snr=None)
 
     fm = ForecastModel(data.gtab, sh_order=8,
-                       optimizer='csd', sphere=data.sphere)
+                       optimizer='CSD', sphere=data.sphere)
     f_fit = fm.fit(S)
 
     S_predict = f_fit.predict()

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -173,7 +173,7 @@ def test_forecast_predict():
 
     mse = np.sum((S-data.S/100.0)**2) / len(S)
 
-    assert_almost_equal(mse, 0.0, 4)
+    assert_almost_equal(mse, 0.0, 3)
 
 
 def test_multivox_forecast():
@@ -196,8 +196,8 @@ def test_multivox_forecast():
         gtab, mevals, S0=1.0, angles=angl3,
         fractions=[50, 50], snr=None)
 
-    fm = ForecastModel(data.gtab, sh_order=8,
-                       optimizer='CSD', sphere=data.sphere)
+    fm = ForecastModel(gtab, sh_order=8,
+                       optimizer='CSD')
     f_fit = fm.fit(S)
 
     S_predict = f_fit.predict()
@@ -205,13 +205,13 @@ def test_multivox_forecast():
     assert_equal(S_predict.shape, S.shape)
 
     mse1 = np.sum((S_predict[0, 0, 0]-S[0, 0, 0])**2) / len(gtab.bvals)
-    assert_almost_equal(mse1, 0.0, 4)
+    assert_almost_equal(mse1, 0.0, 3)
 
     mse2 = np.sum((S_predict[1, 0, 0]-S[1, 0, 0])**2) / len(gtab.bvals)
-    assert_almost_equal(mse2, 0.0, 4)
+    assert_almost_equal(mse2, 0.0, 3)
 
     mse3 = np.sum((S_predict[2, 0, 0]-S[2, 0, 0])**2) / len(gtab.bvals)
-    assert_almost_equal(mse3, 0.0, 4)
+    assert_almost_equal(mse3, 0.0, 3)
 
 if __name__ == '__main__':
     run_module_suite()

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -1,0 +1,167 @@
+# Tests for FORECAST fitting and metrics
+
+import numpy as np
+
+from dipy.data import get_sphere, get_3shell_gtab
+from dipy.reconst.forecast import ForecastModel
+from dipy.sims.voxel import MultiTensor
+
+from numpy.testing import (assert_almost_equal,
+                           assert_equal,
+                           run_module_suite,
+                           dec)
+from dipy.direction.peaks import peak_directions
+from dipy.core.sphere_stats import angular_similarity
+from dipy.utils.optpkg import optional_package
+cvxpy, have_cvxpy, _ = optional_package("cvxpy")
+
+needs_cvxpy = dec.skipif(not have_cvxpy)
+
+
+# Object to hold module global data
+class _C(object):
+    pass
+data = _C()
+
+
+def setup():
+    data.gtab = get_3shell_gtab()
+    data.mevals = np.array(([0.0017, 0.0003, 0.0003],
+                            [0.0017, 0.0003, 0.0003]))
+    data.angl = [(0, 0), (60, 0)]
+    data.S, data.sticks = MultiTensor(
+        data.gtab, data.mevals, S0=100.0, angles=data.angl,
+        fractions=[50, 50], snr=None)
+    data.sh_order = 6
+    data.lambda_LB = 1e-8
+    data.lambda_csd = 1.0
+    sphere = get_sphere('repulsion100')
+    data.sphere = sphere.vertices[0:int(sphere.vertices.shape[0]/2), :]
+
+
+@needs_cvxpy
+def test_forecast_positive_constrain():
+    fm = ForecastModel(data.gtab,
+                       sh_order=data.sh_order,
+                       lambda_LB=data.lambda_LB,
+                       optimizer='pos',
+                       sphere=data.sphere)
+    f_fit = fm.fit(data.S)
+
+    sphere = get_sphere('repulsion100')
+    fodf = f_fit.odf(sphere)
+    assert_equal(fodf[fodf < 0].sum(), 0)
+
+    coeff = f_fit.sh_coeff
+    c0 = np.sqrt(1.0/(4*np.pi))
+    assert_almost_equal(coeff[0], c0, 10)
+
+
+def test_forecast_csd():
+    sphere = get_sphere('repulsion100')
+    fm = ForecastModel(data.gtab, optimizer='csd',
+                       sphere=data.sphere, lambda_csd=data.lambda_csd)
+    f_fit = fm.fit(data.S)
+    fodf_csd = f_fit.odf(sphere)
+
+    fm = ForecastModel(data.gtab, sh_order=data.sh_order,
+                       lambda_LB=data.lambda_LB, optimizer='wls')
+    f_fit = fm.fit(data.S)
+    fodf_wls = f_fit.odf(sphere)
+
+    value = fodf_wls[fodf_wls < 0].sum() < fodf_csd[fodf_csd < 0].sum()
+    assert_equal(value, 1)
+
+
+def test_forecast_odf():
+    # check FORECAST fODF at different SH order
+    fm = ForecastModel(data.gtab, sh_order=4,
+                       optimizer='csd', sphere=data.sphere)
+    f_fit = fm.fit(data.S)
+    sphere = get_sphere('repulsion724')
+    fodf = f_fit.odf(sphere)
+    directions, _, _ = peak_directions(fodf, sphere, .35, 25)
+    assert_equal(len(directions), 2)
+    assert_almost_equal(
+        angular_similarity(directions, data.sticks), 2, 1)
+
+    fm = ForecastModel(data.gtab, sh_order=6,
+                       optimizer='csd', sphere=data.sphere)
+    f_fit = fm.fit(data.S)
+    fodf = f_fit.odf(sphere)
+    directions, _, _ = peak_directions(fodf, sphere, .35, 25)
+    assert_equal(len(directions), 2)
+    assert_almost_equal(
+        angular_similarity(directions, data.sticks), 2, 1)
+
+    fm = ForecastModel(data.gtab, sh_order=8,
+                       optimizer='csd', sphere=data.sphere)
+    f_fit = fm.fit(data.S)
+    fodf = f_fit.odf(sphere)
+    directions, _, _ = peak_directions(fodf, sphere, .35, 25)
+    assert_equal(len(directions), 2)
+    assert_almost_equal(
+        angular_similarity(directions, data.sticks), 2, 1)
+
+    # stronger regularization is required for high order SH
+    fm = ForecastModel(data.gtab, sh_order=10,
+                       optimizer='csd', sphere=sphere.vertices)
+    f_fit = fm.fit(data.S)
+    fodf = f_fit.odf(sphere)
+    directions, _, _ = peak_directions(fodf, sphere, .35, 25)
+    assert_equal(len(directions), 2)
+    assert_almost_equal(
+        angular_similarity(directions, data.sticks), 2, 1)
+
+    fm = ForecastModel(data.gtab, sh_order=12,
+                       optimizer='csd', sphere=sphere.vertices)
+    f_fit = fm.fit(data.S)
+    fodf = f_fit.odf(sphere)
+    directions, _, _ = peak_directions(fodf, sphere, .35, 25)
+    assert_equal(len(directions), 2)
+    assert_almost_equal(
+        angular_similarity(directions, data.sticks), 2, 1)
+
+
+def test_forecast_indices():
+    # check anisotropic tensor
+    fm = ForecastModel(data.gtab, sh_order=2,
+                       lambda_LB=data.lambda_LB, optimizer='wls')
+    f_fit = fm.fit(data.S)
+
+    d_par = f_fit.dpar
+    d_perp = f_fit.dperp
+
+    assert_almost_equal(d_par, data.mevals[0, 0], 5)
+    assert_almost_equal(d_perp, data.mevals[0, 1], 5)
+
+    gt_fa = np.sqrt(0.5 * (2*(data.mevals[0, 0] - data.mevals[0, 1])**2) / (
+        data.mevals[0, 0]**2 + 2*data.mevals[0, 1]**2))
+    gt_md = (data.mevals[0, 0] + 2*data.mevals[0, 1])/3.0
+
+    assert_almost_equal(f_fit.fractional_anisotropy(), gt_fa, 2)
+    assert_almost_equal(f_fit.mean_diffusivity(), gt_md, 5)
+
+    # check isotropic tensor
+    mevals = np.array(([0.003, 0.003, 0.003],
+                       [0.003, 0.003, 0.003]))
+    data.angl = [(0, 0), (60, 0)]
+    S, sticks = MultiTensor(
+        data.gtab, mevals, S0=100.0, angles=data.angl,
+        fractions=[50, 50], snr=None)
+
+    fm = ForecastModel(data.gtab, sh_order=data.sh_order,
+                       lambda_LB=data.lambda_LB, optimizer='wls')
+    f_fit = fm.fit(S)
+
+    d_par = f_fit.dpar
+    d_perp = f_fit.dperp
+
+    assert_almost_equal(d_par, 3e-03, 5)
+    assert_almost_equal(d_perp, 3e-03, 5)
+    assert_almost_equal(f_fit.fractional_anisotropy(), 0.0, 5)
+    assert_almost_equal(f_fit.mean_diffusivity(), 3e-03, 10)
+
+
+if __name__ == '__main__':
+    run_module_suite()

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -44,7 +44,7 @@ def test_forecast_positive_constrain():
     fm = ForecastModel(data.gtab,
                        sh_order=data.sh_order,
                        lambda_lb=data.lambda_lb,
-                       optimizer='POS',
+                       dec_alg='POS',
                        sphere=data.sphere)
     f_fit = fm.fit(data.S)
 
@@ -59,13 +59,13 @@ def test_forecast_positive_constrain():
 
 def test_forecast_csd():
     sphere = get_sphere('repulsion100')
-    fm = ForecastModel(data.gtab, optimizer='CSD',
+    fm = ForecastModel(data.gtab, dec_alg='CSD',
                        sphere=data.sphere, lambda_csd=data.lambda_csd)
     f_fit = fm.fit(data.S)
     fodf_csd = f_fit.odf(sphere, clip_negative=False)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb, optimizer='WLS')
+                       lambda_lb=data.lambda_lb, dec_alg='WLS')
     f_fit = fm.fit(data.S)
     fodf_wls = f_fit.odf(sphere, clip_negative=False)
 
@@ -76,7 +76,7 @@ def test_forecast_csd():
 def test_forecast_odf():
     # check FORECAST fODF at different SH order
     fm = ForecastModel(data.gtab, sh_order=4,
-                       optimizer='CSD', sphere=data.sphere)
+                       dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     sphere = get_sphere('repulsion724')
     fodf = f_fit.odf(sphere)
@@ -86,7 +86,7 @@ def test_forecast_odf():
         angular_similarity(directions, data.sticks), 2, 1)
 
     fm = ForecastModel(data.gtab, sh_order=6,
-                       optimizer='CSD', sphere=data.sphere)
+                       dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -95,7 +95,7 @@ def test_forecast_odf():
         angular_similarity(directions, data.sticks), 2, 1)
 
     fm = ForecastModel(data.gtab, sh_order=8,
-                       optimizer='CSD', sphere=data.sphere)
+                       dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -105,7 +105,7 @@ def test_forecast_odf():
 
     # stronger regularization is required for high order SH
     fm = ForecastModel(data.gtab, sh_order=10,
-                       optimizer='CSD', sphere=sphere.vertices)
+                       dec_alg='CSD', sphere=sphere.vertices)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -114,7 +114,7 @@ def test_forecast_odf():
         angular_similarity(directions, data.sticks), 2, 1)
 
     fm = ForecastModel(data.gtab, sh_order=12,
-                       optimizer='CSD', sphere=sphere.vertices)
+                       dec_alg='CSD', sphere=sphere.vertices)
     f_fit = fm.fit(data.S)
     fodf = f_fit.odf(sphere)
     directions, _, _ = peak_directions(fodf, sphere, .35, 25)
@@ -126,7 +126,7 @@ def test_forecast_odf():
 def test_forecast_indices():
     # check anisotropic tensor
     fm = ForecastModel(data.gtab, sh_order=2,
-                       lambda_lb=data.lambda_lb, optimizer='WLS')
+                       lambda_lb=data.lambda_lb, dec_alg='WLS')
     f_fit = fm.fit(data.S)
 
     d_par = f_fit.dpar
@@ -151,7 +151,7 @@ def test_forecast_indices():
         fractions=[50, 50], snr=None)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
-                       lambda_lb=data.lambda_lb, optimizer='WLS')
+                       lambda_lb=data.lambda_lb, dec_alg='WLS')
     f_fit = fm.fit(S)
 
     d_par = f_fit.dpar
@@ -166,7 +166,7 @@ def test_forecast_indices():
 def test_forecast_predict():
     # check anisotropic tensor
     fm = ForecastModel(data.gtab, sh_order=8,
-                       optimizer='CSD', sphere=data.sphere)
+                       dec_alg='CSD', sphere=data.sphere)
     f_fit = fm.fit(data.S)
 
     S = f_fit.predict(S0=1.0)
@@ -197,7 +197,7 @@ def test_multivox_forecast():
         fractions=[50, 50], snr=None)
 
     fm = ForecastModel(gtab, sh_order=8,
-                       optimizer='CSD')
+                       dec_alg='CSD')
     f_fit = fm.fit(S)
 
     S_predict = f_fit.predict()

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -36,7 +36,7 @@ sherbrooke_3shell has the x axis of the gradients flipped with respect to
 Dipy convention. We fix this by flipping the bvecs x axis 
 """
 
-bvecs_corrected = gtab.bvecs * np.array([-1,1,1])
+bvecs_corrected = gtab.bvecs * np.array([-1, 1, 1])
 gtab_corrected = gradient_table(gtab.bvals, bvecs_corrected)
 
 """
@@ -60,9 +60,10 @@ data_b0 = data[..., 0]
 
 sigma = estimate_sigma(data_b0, N=4)
 
-denoised_b0 = nlmeans(data_b0, sigma=sigma, mask=mask, patch_radius=1, block_radius=3, rician=False)
+denoised_b0 = nlmeans(data_b0, sigma=sigma, mask=mask,
+                      patch_radius=1, block_radius=3, rician=False)
 
-data[...,0] = denoised_b0
+data[..., 0] = denoised_b0
 
 """
 Let us consider only a single slice for the FORECAST fitting	
@@ -72,7 +73,7 @@ Let us consider only a single slice for the FORECAST fitting
 # mask_small = mask[:, :, axial_middle]
 
 data_small = data[26:100, 64:65, :]
-mask_small = mask[26:100, 64:65, :] 
+mask_small = mask[26:100, 64:65, :]
 
 """
 Instantiate the FORECAST Model.
@@ -109,21 +110,25 @@ Show the indices and save them in FORECAST_indices.png.
 fig = plt.figure(figsize=(6, 6))
 ax1 = fig.add_subplot(2, 2, 1, title='parallel diffusivity')
 ax1.set_axis_off()
-ind = ax1.imshow(d_par[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+ind = ax1.imshow(d_par[:, 0, :].T, interpolation='nearest',
+                 origin='lower', cmap=plt.cm.gray)
 plt.colorbar(ind, shrink=0.6)
 ax2 = fig.add_subplot(2, 2, 2, title='perpendicular diffusivity')
 ax2.set_axis_off()
-ind = ax2.imshow(d_perp[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+ind = ax2.imshow(d_perp[:, 0, :].T, interpolation='nearest',
+                 origin='lower', cmap=plt.cm.gray)
 plt.colorbar(ind, shrink=0.6)
 ax3 = fig.add_subplot(2, 2, 3, title='fractional anisotropy')
 ax3.set_axis_off()
-ind = ax3.imshow(fa[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+ind = ax3.imshow(fa[:, 0, :].T, interpolation='nearest',
+                 origin='lower', cmap=plt.cm.gray)
 plt.colorbar(ind, shrink=0.6)
 ax4 = fig.add_subplot(2, 2, 4, title='mean diffusivity')
 ax4.set_axis_off()
-ind = ax4.imshow(md[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+ind = ax4.imshow(md[:, 0, :].T, interpolation='nearest',
+                 origin='lower', cmap=plt.cm.gray)
 plt.colorbar(ind, shrink=0.6)
-plt.savefig('FORECAST_indices.png')
+plt.savefig('FORECAST_indices.png', dpi=300, bbox_inches='tight')
 
 """
 .. figure:: FORECAST_indices.png
@@ -153,12 +158,11 @@ Display a part of the fODFs
 
 from dipy.viz import fvtk
 r = fvtk.ren()
-sfu = fvtk.sphere_funcs(odf[40:60,:,30:45], sphere, colormap='jet')
+sfu = fvtk.sphere_funcs(odf[40:60, :, 30:45], sphere, colormap='jet')
 sfu.RotateX(-90)
 fvtk.add(r, sfu)
-fvtk.show(r)
-fvtk.record(r, n_frames=1, out_path='fODFs.png', size=(600, 600), 
-			magnification=4)
+fvtk.record(r, n_frames=1, out_path='fODFs.png', size=(600, 600),
+            magnification=4)
 
 """
 .. figure:: fODFs.png

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -38,13 +38,13 @@ mask_small = data_small[..., 0] > 1000
 """
 Instantiate the FORECAST Model.
 
-sh_order is the spherical harmonics order used for the fODF.
+"sh_order" is the spherical harmonics order used for the fODF.
 
-optimizer is the algorithm used for the FORECAST basis fitting, in this case
+dec_alg is the spherical deconvolution algorithm used for the FORECAST basis fitting, in this case
 we used the Constrained Spherical Deconvolution (CSD) algorithm.
 """
 
-fm = ForecastModel(gtab, sh_order=6, optimizer='CSD')
+fm = ForecastModel(gtab, sh_order=6, dec_alg='CSD')
 
 """
 Fit the FORECAST to the data

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -98,7 +98,6 @@ plt.savefig('FORECAST_indices.png', dpi=300, bbox_inches='tight')
 
 """
 
-
 """
 Load an odf reconstruction sphere
 """

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -9,16 +9,11 @@ axially symmetric tensor and the fODF using the FORECAST model from
 
 First import the necessary modules:
 """
-import numpy as np
+
 import matplotlib.pyplot as plt
-
 from dipy.reconst.forecast import ForecastModel
-from dipy.reconst.shm import sh_to_sf
 from dipy.viz import fvtk
-# from dipy.data import fetch_sherbrooke_3shell, read_sherbrooke_3shell, get_sphere
 from dipy.data import fetch_cenir_multib, read_cenir_multib, get_sphere
-from dipy.core.gradients import gradient_table
-
 
 """
 Download and read the data for this tutorial.
@@ -37,7 +32,7 @@ data = img.get_data()
 Let us consider only a single slice for the FORECAST fitting	
 """
 
-data_small = data[18:87,51:52,10:70]
+data_small = data[18:87, 51:52, 10:70]
 mask_small = data_small[..., 0] > 1000
 
 """
@@ -47,9 +42,9 @@ sh_order is the spherical harmonics order used for the fODF.
 
 optimizer is the algorithm used for the FORECAST basis fitting, in this case
 we used the Constrained Spherical Deconvolution (CSD) algorithm.
-
 """
-fm = ForecastModel(gtab, sh_order=8, optimizer='csd')
+
+fm = ForecastModel(gtab, sh_order=6, optimizer='csd')
 
 """
 Fit the FORECAST to the data
@@ -121,7 +116,6 @@ print('fODF.shape (%d, %d, %d, %d)' % odf.shape)
 Display a part of the fODFs
 """
 
-from dipy.viz import fvtk
 r = fvtk.ren()
 sfu = fvtk.sphere_funcs(odf[16:36, :, 30:45], sphere, colormap='jet')
 sfu.RotateX(-90)

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -44,7 +44,7 @@ optimizer is the algorithm used for the FORECAST basis fitting, in this case
 we used the Constrained Spherical Deconvolution (CSD) algorithm.
 """
 
-fm = ForecastModel(gtab, sh_order=6, optimizer='csd')
+fm = ForecastModel(gtab, sh_order=6, optimizer='CSD')
 
 """
 Fit the FORECAST to the data

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -1,0 +1,138 @@
+"""
+==============================================================
+Crossing invariant fiber response function with FORECAST model
+==============================================================
+
+We show how to obtain a voxel specific response function in the form of
+axially symmetric tensor and the fODF using the FORECAST model.
+
+First import the necessary modules:
+"""
+
+from dipy.reconst.forecast import ForecastModel
+from dipy.reconst.shm import sh_to_sf
+from dipy.viz import fvtk
+from dipy.data import fetch_sherbrooke_3shell, read_sherbrooke_3shell, get_sphere
+from dipy.core.gradients import gradient_table
+
+"""
+Download and read the data for this tutorial.
+
+fetch_sherbrooke_3shell() provides data acquired using three shells at
+b-values 1000, 2000, and 3500.
+"""
+
+fetch_sherbrooke_3shell()
+img, gtab = read_sherbrooke_3shell()
+data = img.get_data()
+
+data_small = data[26:100, 64, :]
+
+print('data.shape (%d, %d, %d, %d)' % data.shape)
+
+"""
+Instantiate the FORECAST Model.
+
+sh_order is the spherical harmonics order used for the fODF.
+
+optimizer is the algorithm used for the FORECAST basis fitting, in this case
+we used the Constrained Spherical Deconvolution (CSD) algorithm.
+
+"""
+fm = ForecastModel(gtab, sh_order=8, optimizer='csd')
+
+"""
+Fit the FORECAST to the data
+"""
+
+f_fit = fm.fit(data_small)
+
+"""
+Calculate the crossing invariant tensor indices: the parallel diffusivity,
+the perpendicular diffusivity, the fractional anisotropy and the mean
+diffusivity.
+"""
+
+d_par = f_fit.dpar
+d_perp = f_fit.dperp
+fa = f_fit.fractional_anisotropy()
+md = f_fit.mean_diffusivity()
+
+"""
+Show the calculated indices
+"""
+
+
+"""
+Show the indices and save them in FORECAST_indices.png.
+"""
+
+fig = plt.figure(figsize=(6, 6))
+ax1 = fig.add_subplot(2, 2, 1, title='parallel diffusivity')
+ax1.set_axis_off()
+ind = ax1.imshow(d_par.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind)
+ax2 = fig.add_subplot(2, 2, 2, title='perpendicular diffusivity')
+ax2.set_axis_off()
+ind = ax2.imshow(d_perp.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind)
+ax3 = fig.add_subplot(2, 2, 3, title='fractional anisotropy')
+ax3.set_axis_off()
+ind = ax3.imshow(fa.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind)
+ax4 = fig.add_subplot(2, 2, 4, title='mean diffusivity')
+ax4.set_axis_off()
+ind = ax4.imshow(md.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind)
+plt.savefig('FORECAST_indices.png')
+
+
+"""
+.. figure:: FORECAST_indices.png
+   :align: center
+
+   **FORECAST scalar indices**.
+
+"""
+
+
+# """
+# Load an odf reconstruction sphere
+# """
+
+# sphere = get_sphere('symmetric724')
+
+# """
+# Compute the ODFs
+# """
+
+# odf = asmfit.odf(sphere)
+# print('odf.shape (%d, %d, %d)' % odf.shape)
+
+# """
+# Display the ODFs
+# """
+
+# r = fvtk.ren()
+# sfu = fvtk.sphere_funcs(odf[:, None, :], sphere, colormap='jet')
+# sfu.RotateX(-90)
+# fvtk.add(r, sfu)
+# fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
+
+"""
+.. figure:: odfs.png
+   :align: center
+
+   **Orientation distribution functions**.
+   
+.. [Merlet2013] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
+				estimation via Compressive Sensing in diffusion MRI", Medical
+				Image Analysis, 2013.
+
+.. [Cheng2011] Cheng J. et. al, "Theoretical Analysis and Pratical Insights
+			   on EAP Estimation via Unified HARDI Framework", MICCAI
+			   workshop on Computational Diffusion MRI, 2011.
+
+.. include:: ../links_names.inc
+
+"""

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -4,10 +4,13 @@ Crossing invariant fiber response function with FORECAST model
 ==============================================================
 
 We show how to obtain a voxel specific response function in the form of
-axially symmetric tensor and the fODF using the FORECAST model.
+axially symmetric tensor and the fODF using the FORECAST model from
+[Anderson2005]_ , [Kaden2016]_ and [Zucchelli2017]_.
 
 First import the necessary modules:
 """
+import numpy as np
+import matplotlib.pyplot as plt
 
 from dipy.reconst.forecast import ForecastModel
 from dipy.reconst.shm import sh_to_sf
@@ -26,9 +29,50 @@ fetch_sherbrooke_3shell()
 img, gtab = read_sherbrooke_3shell()
 data = img.get_data()
 
-data_small = data[26:100, 64, :]
-
 print('data.shape (%d, %d, %d, %d)' % data.shape)
+
+"""
+sherbrooke_3shell has the x axis of the gradients flipped with respect to
+Dipy convention. We fix this by flipping the bvecs x axis 
+"""
+
+bvecs_corrected = gtab.bvecs * np.array([-1,1,1])
+gtab_corrected = gradient_table(gtab.bvals, bvecs_corrected)
+
+"""
+First, let us mask the data
+"""
+
+from dipy.segment.mask import median_otsu
+data_masked, mask = median_otsu(data, 2, 1)
+
+"""
+sherbrooke_3shell contains only one b0 image, in these cases it is always better
+to denoise the b0 image before processing the data.
+For more information about nlmeans denoising check the relative example in the
+gallery.
+"""
+
+from dipy.denoise.nlmeans import nlmeans
+from dipy.denoise.noise_estimate import estimate_sigma
+
+data_b0 = data[..., 0]
+
+sigma = estimate_sigma(data_b0, N=4)
+
+denoised_b0 = nlmeans(data_b0, sigma=sigma, mask=mask, patch_radius=1, block_radius=3, rician=False)
+
+data[...,0] = denoised_b0
+
+"""
+Let us consider only a single slice for the FORECAST fitting	
+"""
+# axial_middle = data.shape[2] // 2
+# data_small = data[:, :, axial_middle]
+# mask_small = mask[:, :, axial_middle]
+
+data_small = data[26:100, 64:65, :]
+mask_small = mask[26:100, 64:65, :] 
 
 """
 Instantiate the FORECAST Model.
@@ -39,16 +83,16 @@ optimizer is the algorithm used for the FORECAST basis fitting, in this case
 we used the Constrained Spherical Deconvolution (CSD) algorithm.
 
 """
-fm = ForecastModel(gtab, sh_order=8, optimizer='csd')
+fm = ForecastModel(gtab_corrected, sh_order=6, optimizer='csd')
 
 """
 Fit the FORECAST to the data
 """
 
-f_fit = fm.fit(data_small)
+f_fit = fm.fit(data_small, mask_small)
 
 """
-Calculate the crossing invariant tensor indices: the parallel diffusivity,
+Calculate the crossing invariant tensor indices [Kaden2016]_ : the parallel diffusivity,
 the perpendicular diffusivity, the fractional anisotropy and the mean
 diffusivity.
 """
@@ -59,33 +103,27 @@ fa = f_fit.fractional_anisotropy()
 md = f_fit.mean_diffusivity()
 
 """
-Show the calculated indices
-"""
-
-
-"""
 Show the indices and save them in FORECAST_indices.png.
 """
 
 fig = plt.figure(figsize=(6, 6))
 ax1 = fig.add_subplot(2, 2, 1, title='parallel diffusivity')
 ax1.set_axis_off()
-ind = ax1.imshow(d_par.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
-plt.colorbar(ind)
+ind = ax1.imshow(d_par[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind, shrink=0.6)
 ax2 = fig.add_subplot(2, 2, 2, title='perpendicular diffusivity')
 ax2.set_axis_off()
-ind = ax2.imshow(d_perp.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
-plt.colorbar(ind)
+ind = ax2.imshow(d_perp[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind, shrink=0.6)
 ax3 = fig.add_subplot(2, 2, 3, title='fractional anisotropy')
 ax3.set_axis_off()
-ind = ax3.imshow(fa.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
-plt.colorbar(ind)
+ind = ax3.imshow(fa[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind, shrink=0.6)
 ax4 = fig.add_subplot(2, 2, 4, title='mean diffusivity')
 ax4.set_axis_off()
-ind = ax4.imshow(md.T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
-plt.colorbar(ind)
+ind = ax4.imshow(md[:,0,:].T, interpolation='nearest', origin='lower', cmap = plt.cm.gray)
+plt.colorbar(ind, shrink=0.6)
 plt.savefig('FORECAST_indices.png')
-
 
 """
 .. figure:: FORECAST_indices.png
@@ -96,43 +134,49 @@ plt.savefig('FORECAST_indices.png')
 """
 
 
-# """
-# Load an odf reconstruction sphere
-# """
+"""
+Load an odf reconstruction sphere
+"""
 
-# sphere = get_sphere('symmetric724')
-
-# """
-# Compute the ODFs
-# """
-
-# odf = asmfit.odf(sphere)
-# print('odf.shape (%d, %d, %d)' % odf.shape)
-
-# """
-# Display the ODFs
-# """
-
-# r = fvtk.ren()
-# sfu = fvtk.sphere_funcs(odf[:, None, :], sphere, colormap='jet')
-# sfu.RotateX(-90)
-# fvtk.add(r, sfu)
-# fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
+sphere = get_sphere('symmetric724')
 
 """
-.. figure:: odfs.png
+Compute the fODFs. 
+"""
+
+odf = f_fit.odf(sphere)
+print('fODF.shape (%d, %d, %d, %d)' % odf.shape)
+
+"""
+Display a part of the fODFs
+"""
+
+from dipy.viz import fvtk
+r = fvtk.ren()
+sfu = fvtk.sphere_funcs(odf[40:60,:,30:45], sphere, colormap='jet')
+sfu.RotateX(-90)
+fvtk.add(r, sfu)
+fvtk.show(r)
+fvtk.record(r, n_frames=1, out_path='fODFs.png', size=(600, 600), 
+			magnification=4)
+
+"""
+.. figure:: fODFs.png
    :align: center
 
-   **Orientation distribution functions**.
+   **Fiber Orientation Distribution Functions, in a small ROI of the brain**.
    
-.. [Merlet2013] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
-				estimation via Compressive Sensing in diffusion MRI", Medical
-				Image Analysis, 2013.
+.. [Anderson2005] Anderson A. W., "Measurement of Fiber Orientation Distributions
+       Using High Angular Resolution Diffusion Imaging", Magnetic
+       Resonance in Medicine, 2005.
 
-.. [Cheng2011] Cheng J. et. al, "Theoretical Analysis and Pratical Insights
-			   on EAP Estimation via Unified HARDI Framework", MICCAI
-			   workshop on Computational Diffusion MRI, 2011.
+.. [Kaden2016] Kaden E. et. al, "Quantitative Mapping of the Per-Axon Diffusion 
+       Coefficients in Brain White Matter", Magnetic Resonance in 
+       Medicine, 2016.
 
+.. [Zucchelli2017] Zucchelli E. et. al, "A generalized SMT-based framework for
+       Diffusion MRI microstructural model estimation", MICCAI Workshop
+       on Computational DIFFUSION MRI (CDMRI), 2017.
 .. include:: ../links_names.inc
 
 """

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -12,7 +12,7 @@ First import the necessary modules:
 
 import matplotlib.pyplot as plt
 from dipy.reconst.forecast import ForecastModel
-from dipy.viz import fvtk
+from dipy.viz import actor, window
 from dipy.data import fetch_cenir_multib, read_cenir_multib, get_sphere
 
 """
@@ -29,7 +29,7 @@ img, gtab = read_cenir_multib(bvals)
 data = img.get_data()
 
 """
-Let us consider only a single slice for the FORECAST fitting	
+Let us consider only a single slice for the FORECAST fitting  
 """
 
 data_small = data[18:87, 51:52, 10:70]
@@ -116,12 +116,13 @@ print('fODF.shape (%d, %d, %d, %d)' % odf.shape)
 Display a part of the fODFs
 """
 
-r = fvtk.ren()
-sfu = fvtk.sphere_funcs(odf[16:36, :, 30:45], sphere, colormap='jet')
-sfu.RotateX(-90)
-fvtk.add(r, sfu)
-fvtk.record(r, n_frames=1, out_path='fODFs.png', size=(600, 600),
-            magnification=4)
+odf_actor = actor.odf_slicer(odf[16:36, :, 30:45], sphere=sphere,
+                             colormap='jet', scale=0.6)
+odf_actor.display(y=0)
+odf_actor.RotateX(-90)
+ren = window.Renderer()
+ren.add(odf_actor)
+window.record(ren, out_path='fODFs.png', size=(600, 600), magnification=4)
 
 """
 .. figure:: fODFs.png

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -5,6 +5,7 @@
  reconst_csa.py
  reconst_csd_parallel.py
  reconst_csd.py
+ reconst_forecast.py
  reconst_dki.py
  reconst_dsi_metrics.py
  reconst_dsi.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -60,6 +60,11 @@ Constrained Spherical Deconvolution
 
 - :ref:`example_reconst_csd`
 
+Fiber ORientation Estimated using Continuous Axially Symmetric Tensors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :ref:`example_reconst_forecast`
+
 Simple Harmonic Oscillator based Reconstruction and Estimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Dear DIPY developers,
This pull request is made to add the FORECAST model to DIPY:
http://onlinelibrary.wiley.com/doi/10.1002/mrm.20667/full

FORECAST is a Spherical Deconvolution method that allows estimating voxel specific response function in the form of an axially symmetric tensor. From this tensor, FORECAST has been recently used for estimating crossing invariant diffusivities and fractional anisotropy in:
http://onlinelibrary.wiley.com/doi/10.1002/mrm.25734/full

I'm going to present the comparison between FORECAST and similar techniques at the 2017 MICCAI Computational Diffusion MRI workshop and this implementation is based on the one that I use for that work.

Best wishes,

Mauro