### PR TITLE
BUG: Address small_delta vs. big_delta flipped parameters.

### DIFF
--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -62,8 +62,8 @@ img, gtab = read_cenir_multib(bvals)
 big_delta = 0.0365  # seconds
 small_delta = 0.0157  # seconds
 gtab = gradient_table(bvals=gtab.bvals, bvecs=gtab.bvecs,
-                      small_delta=big_delta,
-                      big_delta=small_delta)
+                      big_delta=big_delta,
+                      small_delta=small_delta)
 data = img.get_data()
 data_small = data[40:65, 50:51, 35:60]
 


### PR DESCRIPTION
Fix the `small_delta` and `big_delta` parameters of the `reconst_mapmri`
example being flipped.