### PR TITLE
ENH: Add Travis badge to README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
  DIPY
 ======
 
+.. image:: https://travis-ci.org/nipy/dipy.svg?branch=master
+  :target: https://travis-ci.org/nipy/dipy
+
 .. image:: https://codecov.io/gh/nipy/dipy/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/nipy/dipy
 


### PR DESCRIPTION
Add the Travis CI badge to the `README.rst` file so that we can visualize
the health of the master branch of DIPY.