### PR TITLE
Catch a more specific warning in test_csdeconv

### DIFF
--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 from numpy.testing import (assert_, assert_equal, assert_almost_equal,
                            assert_array_almost_equal, run_module_suite,
-                           assert_array_equal)
+                           assert_array_equal, assert_warns)
 from dipy.data import get_sphere, get_data, default_sphere, small_sphere
 from dipy.sims.voxel import (multi_tensor,
                              single_tensor,
@@ -224,13 +224,11 @@ def test_csdeconv():
     assert_equal(directions.shape[0], 2)
     assert_equal(directions2.shape[0], 2)
 
-    with warnings.catch_warnings(record=True) as w:
-        ConstrainedSphericalDeconvModel(gtab, response, sh_order=10)
-        assert_equal(len(w) > 0, True)
+    assert_warns(UserWarning, ConstrainedSphericalDeconvModel, gtab, response, sh_order=10)
 
     with warnings.catch_warnings(record=True) as w:
         ConstrainedSphericalDeconvModel(gtab, response, sh_order=8)
-        assert_equal(len(w) > 0, False)
+        assert_equal(len([local_warn for local_warn in w if issubclass(local_warn.category, UserWarning)]) > 0, False)
 
     mevecs = []
     for s in sticks:


### PR DESCRIPTION
The goal of this PR is to fix #1323.

Like @arokem said, the test was catching too many warnings. In this case, the test was catching this : 

`FutureWarning: 'rcond' parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.
To use the future default and silence this warning we advise to pass 'rcond=None', to keep using the old, explicitly pass 'rcond=-1'. `