### PR TITLE
DOC: Format README.rst file code blocks.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,11 +46,11 @@ You can find our sources and single-click downloads:
 Installing DIPY
 ===============
 
-DIPY can be installed using `pip`:
+DIPY can be installed using `pip`::
 
     pip install dipy
 
-or using `conda`:
+or using `conda`::
 
     conda install -c conda-forge dipy vtk
 


### PR DESCRIPTION
Use the reST syntax to highlight code blocks in `README.rst` when describing
the DIPY installation commands.