### PR TITLE
Replacing fvtk by the new viz API

### DIFF
--- a/dipy/sims/phantom.py
+++ b/dipy/sims/phantom.py
@@ -244,7 +244,8 @@ if __name__ == "__main__":
 
     # """
 
-    # r=fvtk.ren()
-    # fvtk.add(r,fvtk.volume(vol234[...,0]))
-    # fvtk.show(r)
+    # from dipy.viz import window, actor
+    # ren = window.Renderer()
+    # ren.add(actor.volume(vol234[...,0]))
+    # window.show(r)
     # vol234n=add_rician_noise(vol234,20)

--- a/dipy/tracking/tests/test_distances.py
+++ b/dipy/tracking/tests/test_distances.py
@@ -64,7 +64,7 @@ def test_LSCv2():
     from dipy.data import get_data
     from nibabel import trackvis as tv
     try:
-        from dipy.viz import fvtk
+        from dipy.viz import window, actor
     except ImportError as e:
         raise nose.plugins.skip.SkipTest(
             'Fails to import dipy.viz due to %s' % str(e))
@@ -80,15 +80,15 @@ def test_LSCv2():
 
     """
 
-    r = fvtk.ren()
+    r = window.Renderer()
     colors = np.zeros((len(C), 3))
     for c in C:
         color = np.random.rand(3)
         for i in C[c]['indices']:
-            fvtk.add(r, fvtk.line(T3[i], color))
+            r.add(actor.line(T3[i], color))
         colors[c] = color
-    fvtk.show(r)
-    fvtk.clear(r)
+    window.show(r)
+    window.clear(r)
     skeleton = []
 
     def width(w):
@@ -102,12 +102,12 @@ def test_LSCv2():
         bundle = [T3[i] for i in C[c]['indices']]
         si,s = pf.most_similar_track_mam(bundle, 'avg')
         skeleton.append(bundle[si])
-        fvtk.label(r,text = str(len(bundle)), pos=(bundle[si][-1]),
-                   scale=(2, 2, 2))
-        fvtk.add(r, fvtk.line(skeleton, colors, opacity=1,
-                              linewidth = width(len(bundle)/10.)))
+        actor.label(r,text = str(len(bundle)), pos=(bundle[si][-1]),
+                    scale=(2, 2, 2))
+        r.add(actor.line(skeleton, colors, opacity=1,
+                         linewidth = width(len(bundle)/10.)))
 
-    fvtk.show(r)
+    window.show(r)
 
     """
 

--- a/dipy/tracking/tests/test_fbc.py
+++ b/dipy/tracking/tests/test_fbc.py
@@ -1,9 +1,6 @@
 from dipy.denoise.enhancement_kernel import EnhancementKernel
 from dipy.tracking.fbcmeasures import FBCMeasures
 
-from dipy.viz import fvtk
-from dipy.viz.colormap import line_colors
-from dipy.viz import window, actor
 
 from dipy.core.sphere import Sphere
 

--- a/dipy/tracking/tests/test_metrics.py
+++ b/dipy/tracking/tests/test_metrics.py
@@ -152,11 +152,11 @@ def test_downsample():
     Td = [tm.downsample(s[0], pts) for s in streams]
     T = [s[0] for s in streams]
 
-    from dipy.viz import fvtk
-    r = fvtk.ren()
-    fvtk.add(r, fvtk.line(T, fvtk.red))
-    fvtk.add(r, fvtk.line(Td, fvtk.green))
-    fvtk.show(r)
+    from dipy.viz import window, actor
+    ren = window.Renderer()
+    ren.add(actor.line(T, window.red))
+    ren.add(actor.line(Td, window.green))
+    window.show(ren)
     """
 
 

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -36,7 +36,7 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
         If None then the values will be interpolated from (data.min(),
         data.max()) to (0, 255). Otherwise from (value_range[0],
         value_range[1]) to (0, 255).
-    opacity : float
+    opacity : float, optional
         Opacity of 0 means completely transparent and 1 completely visible.
     lookup_colormap : vtkLookupTable
         If None (default) then a grayscale map is created.
@@ -133,14 +133,6 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
     image_resliced.SetInterpolationModeToLinear()
     image_resliced.Update()
 
-    if nb_components == 1:
-        if lookup_colormap is None:
-            # Create a black/white lookup table.
-            lut = colormap_lookup_table((0, 255), (0, 0), (0, 0), (0, 1))
-        else:
-            lut = lookup_colormap
-
-    x1, x2, y1, y2, z1, z2 = im.GetExtent()
     ex1, ex2, ey1, ey2, ez1, ez2 = image_resliced.GetOutput().GetExtent()
 
     class ImageActor(vtk.vtkImageActor):
@@ -195,6 +187,11 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
 
     image_actor = ImageActor()
     if nb_components == 1:
+        lut = lookup_colormap
+        if lookup_colormap is None:
+            # Create a black/white lookup table.
+            lut = colormap_lookup_table((0, 255), (0, 0), (0, 0), (0, 1))
+
         plane_colors = vtk.vtkImageMapToColors()
         plane_colors.SetLookupTable(lut)
         plane_colors.SetInputConnection(image_resliced.GetOutputPort())
@@ -362,7 +359,7 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
         colormap are interpolated automatically using trilinear interpolation.
 
     opacity : float
-        Default is 1.
+        Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
     linewidth : float
         Default is 0.01.
     tube_sides : int
@@ -506,7 +503,7 @@ def line(lines, colors=None, opacity=1, linewidth=1,
         colormap are interpolated automatically using trilinear interpolation.
 
     opacity : float, optional
-        Default is 1.
+        Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
 
     linewidth : float, optional
         Line thickness. Default is 1.
@@ -616,8 +613,8 @@ def scalar_bar(lookup_table=None, title=" "):
 
 
 def _arrow(pos=(0, 0, 0), color=(1, 0, 0), scale=(1, 1, 1), opacity=1):
-    ''' Internal function for generating arrow actors.
-    '''
+    """ Internal function for generating arrow actors.
+    """
     arrow = vtk.vtkArrowSource()
     # arrow.SetTipLength(length)
 
@@ -653,6 +650,8 @@ def axes(scale=(1, 1, 1), colorx=(1, 0, 0), colory=(0, 1, 0), colorz=(0, 0, 1),
         y-axis color. Default green (0, 1, 0).
     colorz : tuple (3,)
         z-axis color. Default blue (0, 0, 1).
+    opacity : float, optional
+        Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
 
     Returns
     -------
@@ -696,7 +695,7 @@ def odf_slicer(odfs, affine=None, mask=None, sphere=None, scale=2.2,
     radial_scale : bool
         Scale sphere points according to odf values.
     opacity : float
-        Takes values from 0 (fully transparent) to 1 (opaque)
+        Takes values from 0 (fully transparent) to 1 (opaque). Default is 1.
     colormap : None or str
         If None then white color is used. Otherwise the name of colormap is
         given. Matplotlib colormaps are supported (e.g., 'inferno').
@@ -878,7 +877,7 @@ def _makeNd(array, ndim):
 
 
 def peak_slicer(peaks_dirs, peaks_values=None, mask=None, affine=None,
-                colors=(1, 0, 0), opacity=1, linewidth=1,
+                colors=(1, 0, 0), opacity=1., linewidth=1,
                 lod=False, lod_points=10 ** 4, lod_points_size=3):
     """ Visualize peak directions as given from ``peaks_from_model``
 
@@ -890,13 +889,16 @@ def peak_slicer(peaks_dirs, peaks_values=None, mask=None, affine=None,
     peaks_values : ndarray
         Peak values. The shape of the array can be (M, ) or (X, M) or
         (X, Y, M) or (X, Y, Z, M)
-
+    affine : array
+        4x4 transformation array from native coordinates to world coordinates
+    mask : ndarray
+        3D mask
     colors : tuple or None
         Default red color. If None then every peak gets an orientation color
         in similarity to a DEC map.
 
     opacity : float, optional
-        Default is 1.
+        Takes values from 0 (fully transparent) to 1 (opaque)
 
     linewidth : float, optional
         Line thickness. Default is 1.
@@ -997,7 +999,8 @@ def dots(points, color=(1, 0, 0), opacity=1, dot_size=5):
     ----------
     points : ndarray, (N, 3)
     color : tuple (3,)
-    opacity : float
+    opacity : float, optional
+        Takes values from 0 (fully transparent) to 1 (opaque)
     dot_size : int
 
     Returns
@@ -1051,7 +1054,7 @@ def dots(points, color=(1, 0, 0), opacity=1, dot_size=5):
     return aPolyVertexActor
 
 
-def point(points, colors, opacity=1, point_radius=0.1, theta=8, phi=8):
+def point(points, colors, opacity=1., point_radius=0.1, theta=8, phi=8):
     """ Visualize points as sphere glyphs
 
     Parameters
@@ -1061,6 +1064,8 @@ def point(points, colors, opacity=1, point_radius=0.1, theta=8, phi=8):
     point_radius : float
     theta : int
     phi : int
+    opacity : float, optional
+        Takes values from 0 (fully transparent) to 1 (opaque)
 
     Returns
     -------

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -1153,10 +1153,10 @@ def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     Examples
     --------
     >>> from dipy.viz import window, actor
-    >>> r = window.Renderer()
-    >>> l = actor.label(r)
+    >>> ren = window.Renderer()
+    >>> l = actor.label(ren)
     >>> ren.add(l)
-    >>> #window.show(r)
+    >>> #window.show(ren)
     """
 
     atext = vtk.vtkVectorText()

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -1355,7 +1355,7 @@ def label(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     --------
     >>> from dipy.viz import window, actor
     >>> ren = window.Renderer()
-    >>> l = actor.label('Hello')
+    >>> l = actor.label(text='Hello')
     >>> ren.add(l)
     >>> #window.show(ren)
     """

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -896,7 +896,7 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
         eigenvalues
     evecs : (3, 3) or (X, 3, 3) or (X, Y, 3, 3) or (X, Y, Z, 3, 3) ndarray
         eigenvectors
-    affine : array-
+    affine : array
         4x4 transformation array from native coordinates to world coordinates*
     mask : ndarray
         3D mask
@@ -963,7 +963,7 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
 
 def _tensor_slicer_mapper(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
                           norm=True, opacity=1., scalar_colors=None):
-    """ Helper function for slicing spherical fields
+    """ Helper function for slicing tensor fields
 
     Parameters
     ----------
@@ -1329,7 +1329,7 @@ def point(points, colors, opacity=1., point_radius=0.1, theta=8, phi=8):
     return actor
 
 
-def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
+def label(text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
           color=(1, 1, 1)):
     """ Create a label actor.
 
@@ -1337,8 +1337,6 @@ def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
 
     Parameters
     ----------
-    ren : vtkRenderer() object
-       Renderer as returned by ``ren()``.
     text : str
         Text for the label.
     pos : (3,) array_like, optional
@@ -1357,7 +1355,7 @@ def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
     --------
     >>> from dipy.viz import window, actor
     >>> ren = window.Renderer()
-    >>> l = actor.label(ren)
+    >>> l = actor.label('Hello')
     >>> ren.add(l)
     >>> #window.show(ren)
     """
@@ -1377,8 +1375,5 @@ def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
 
     texta.GetProperty().SetColor(color)
     texta.SetPosition(pos)
-
-    ren.AddActor(texta)
-    texta.SetCamera(ren.GetActiveCamera())
 
     return texta

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -916,7 +916,7 @@ def peak_slicer(peaks_dirs, peaks_values=None, mask=None, affine=None,
 
     See Also
     --------
-    dipy.viz.fvtk.sphere_funcs
+    dipy.viz.actor.odf_slicer
 
     """
     peaks_dirs = np.asarray(peaks_dirs)
@@ -988,3 +988,194 @@ def peak_slicer(peaks_dirs, peaks_values=None, mask=None, affine=None,
                               int(np.floor(szz / 2)), int(np.floor(szz / 2)))
 
     return peak_actor
+
+
+def dots(points, color=(1, 0, 0), opacity=1, dot_size=5):
+    """ Create one or more 3d points
+
+    Parameters
+    ----------
+    points : ndarray, (N, 3)
+    color : tuple (3,)
+    opacity : float
+    dot_size : int
+
+    Returns
+    --------
+    vtkActor
+
+    See Also
+    ---------
+    dipy.viz.actor.point
+
+    """
+
+    if points.ndim == 2:
+        points_no = points.shape[0]
+    else:
+        points_no = 1
+
+    polyVertexPoints = vtk.vtkPoints()
+    polyVertexPoints.SetNumberOfPoints(points_no)
+    aPolyVertex = vtk.vtkPolyVertex()
+    aPolyVertex.GetPointIds().SetNumberOfIds(points_no)
+
+    cnt = 0
+    if points.ndim > 1:
+        for point in points:
+            polyVertexPoints.InsertPoint(cnt, point[0], point[1], point[2])
+            aPolyVertex.GetPointIds().SetId(cnt, cnt)
+            cnt += 1
+    else:
+        polyVertexPoints.InsertPoint(cnt, points[0], points[1], points[2])
+        aPolyVertex.GetPointIds().SetId(cnt, cnt)
+        cnt += 1
+
+    aPolyVertexGrid = vtk.vtkUnstructuredGrid()
+    aPolyVertexGrid.Allocate(1, 1)
+    aPolyVertexGrid.InsertNextCell(aPolyVertex.GetCellType(),
+                                   aPolyVertex.GetPointIds())
+
+    aPolyVertexGrid.SetPoints(polyVertexPoints)
+    aPolyVertexMapper = vtk.vtkDataSetMapper()
+    if major_version <= 5:
+        aPolyVertexMapper.SetInput(aPolyVertexGrid)
+    else:
+        aPolyVertexMapper.SetInputData(aPolyVertexGrid)
+    aPolyVertexActor = vtk.vtkActor()
+    aPolyVertexActor.SetMapper(aPolyVertexMapper)
+
+    aPolyVertexActor.GetProperty().SetColor(color)
+    aPolyVertexActor.GetProperty().SetOpacity(opacity)
+    aPolyVertexActor.GetProperty().SetPointSize(dot_size)
+    return aPolyVertexActor
+
+
+def point(points, colors, opacity=1, point_radius=0.1, theta=8, phi=8):
+    """ Visualize points as sphere glyphs
+
+    Parameters
+    ----------
+    points : ndarray, shape (N, 3)
+    colors : ndarray (N,3) or tuple (3,)
+    point_radius : float
+    theta : int
+    phi : int
+
+    Returns
+    -------
+    vtkActor
+
+    Examples
+    --------
+    >>> from dipy.viz import window, actor
+    >>> ren = window.Renderer()
+    >>> pts = np.random.rand(5, 3)
+    >>> point_actor = actor.point(pts, window.colors.coral)
+    >>> ren.add(point_actor)
+    >>> #window.show(ren)
+    """
+
+    if np.array(colors).ndim == 1:
+        # return dots(points,colors,opacity)
+        colors = np.tile(colors, (len(points), 1))
+
+    scalars = vtk.vtkUnsignedCharArray()
+    scalars.SetNumberOfComponents(3)
+
+    pts = vtk.vtkPoints()
+    cnt_colors = 0
+
+    for p in points:
+
+        pts.InsertNextPoint(p[0], p[1], p[2])
+        scalars.InsertNextTuple3(
+            round(255 * colors[cnt_colors][0]),
+            round(255 * colors[cnt_colors][1]),
+            round(255 * colors[cnt_colors][2]))
+        cnt_colors += 1
+
+    src = vtk.vtkSphereSource()
+    src.SetRadius(point_radius)
+    src.SetThetaResolution(theta)
+    src.SetPhiResolution(phi)
+
+    polyData = vtk.vtkPolyData()
+    polyData.SetPoints(pts)
+    polyData.GetPointData().SetScalars(scalars)
+
+    glyph = vtk.vtkGlyph3D()
+    glyph.SetSourceConnection(src.GetOutputPort())
+    if major_version <= 5:
+        glyph.SetInput(polyData)
+    else:
+        glyph.SetInputData(polyData)
+    glyph.SetColorModeToColorByScalar()
+    glyph.SetScaleModeToDataScalingOff()
+    glyph.Update()
+
+    mapper = vtk.vtkPolyDataMapper()
+    if major_version <= 5:
+        mapper.SetInput(glyph.GetOutput())
+    else:
+        mapper.SetInputData(glyph.GetOutput())
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    actor.GetProperty().SetOpacity(opacity)
+
+    return actor
+
+
+def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
+          color=(1, 1, 1)):
+    """ Create a label actor.
+
+    This actor will always face the camera
+
+    Parameters
+    ----------
+    ren : vtkRenderer() object
+       Renderer as returned by ``ren()``.
+    text : str
+        Text for the label.
+    pos : (3,) array_like, optional
+        Left down position of the label.
+    scale : (3,) array_like
+        Changes the size of the label.
+    color : (3,) array_like
+        Label color as ``(r,g,b)`` tuple.
+
+    Returns
+    -------
+    l : vtkActor object
+        Label.
+
+    Examples
+    --------
+    >>> from dipy.viz import window, actor
+    >>> r = window.Renderer()
+    >>> l = actor.label(r)
+    >>> ren.add(l)
+    >>> #window.show(r)
+    """
+
+    atext = vtk.vtkVectorText()
+    atext.SetText(text)
+
+    textm = vtk.vtkPolyDataMapper()
+    if major_version <= 5:
+        textm.SetInput(atext.GetOutput())
+    else:
+        textm.SetInputData(atext.GetOutput())
+
+    texta = vtk.vtkFollower()
+    texta.SetMapper(textm)
+    texta.SetScale(scale)
+
+    texta.GetProperty().SetColor(color)
+    texta.SetPosition(pos)
+
+    ren.AddActor(texta)
+    texta.SetCamera(ren.GetActiveCamera())
+
+    return texta

--- a/dipy/viz/colormap.py
+++ b/dipy/viz/colormap.py
@@ -241,7 +241,7 @@ def orient2rgb(v):
 
 
 def line_colors(streamlines, cmap='rgb_standard'):
-    """ Create colors for streamlines to be used in fvtk.line
+    """ Create colors for streamlines to be used in actor.line
 
     Parameters
     ----------

--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -69,7 +69,7 @@ if have_vtk:
 
     from dipy.viz.window import (ren, renderer, add, clear, rm, rm_all,
                                  show, record, snapshot)
-    from dipy.viz.actor import line, streamtube, slicer, axes, dots, label, point
+    from dipy.viz.actor import line, streamtube, slicer, axes, dots, point
 
     try:
         if major_version < 7:
@@ -829,6 +829,56 @@ def tensor(evals, evecs, scalar_colors=None,
     actor.SetMapper(mapper)
 
     return actor
+
+
+def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
+          color=(1, 1, 1)):
+    """ Create a label actor.
+    This actor will always face the camera
+    Parameters
+    ----------
+    ren : vtkRenderer() object
+       Renderer as returned by ``ren()``.
+    text : str
+        Text for the label.
+    pos : (3,) array_like, optional
+        Left down position of the label.
+    scale : (3,) array_like
+        Changes the size of the label.
+    color : (3,) array_like
+        Label color as ``(r,g,b)`` tuple.
+    Returns
+    -------
+    l : vtkActor object
+        Label.
+    Examples
+    --------
+    >>> from dipy.viz import fvtk
+    >>> r=fvtk.ren()
+    >>> l=fvtk.label(r)
+    >>> fvtk.add(r,l)
+    >>> #fvtk.show(r)
+    """
+    atext = vtk.vtkVectorText()
+    atext.SetText(text)
+
+    textm = vtk.vtkPolyDataMapper()
+    if major_version <= 5:
+        textm.SetInput(atext.GetOutput())
+    else:
+        textm.SetInputData(atext.GetOutput())
+
+    texta = vtk.vtkFollower()
+    texta.SetMapper(textm)
+    texta.SetScale(scale)
+
+    texta.GetProperty().SetColor(color)
+    texta.SetPosition(pos)
+
+    ren.AddActor(texta)
+    texta.SetCamera(ren.GetActiveCamera())
+
+    return texta
 
 
 def camera(ren, pos=None, focal=None, viewup=None, verbose=True):

--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -69,7 +69,7 @@ if have_vtk:
 
     from dipy.viz.window import (ren, renderer, add, clear, rm, rm_all,
                                  show, record, snapshot)
-    from dipy.viz.actor import line, streamtube, slicer, axes
+    from dipy.viz.actor import line, streamtube, slicer, axes, dots, label, point
 
     try:
         if major_version < 7:
@@ -85,194 +85,12 @@ else:
                                         'Python VTK is not installed')
 
 
-def dots(points, color=(1, 0, 0), opacity=1, dot_size=5):
-    """ Create one or more 3d points
 
-    Parameters
-    ----------
-    points : ndarray, (N, 3)
-    color : tuple (3,)
-    opacity : float
-    dot_size : int
-
-    Returns
-    --------
-    vtkActor
-
-    See Also
-    ---------
-    dipy.viz.fvtk.point
-
-    """
-
-    if points.ndim == 2:
-        points_no = points.shape[0]
-    else:
-        points_no = 1
-
-    polyVertexPoints = vtk.vtkPoints()
-    polyVertexPoints.SetNumberOfPoints(points_no)
-    aPolyVertex = vtk.vtkPolyVertex()
-    aPolyVertex.GetPointIds().SetNumberOfIds(points_no)
-
-    cnt = 0
-    if points.ndim > 1:
-        for point in points:
-            polyVertexPoints.InsertPoint(cnt, point[0], point[1], point[2])
-            aPolyVertex.GetPointIds().SetId(cnt, cnt)
-            cnt += 1
-    else:
-        polyVertexPoints.InsertPoint(cnt, points[0], points[1], points[2])
-        aPolyVertex.GetPointIds().SetId(cnt, cnt)
-        cnt += 1
-
-    aPolyVertexGrid = vtk.vtkUnstructuredGrid()
-    aPolyVertexGrid.Allocate(1, 1)
-    aPolyVertexGrid.InsertNextCell(aPolyVertex.GetCellType(),
-                                   aPolyVertex.GetPointIds())
-
-    aPolyVertexGrid.SetPoints(polyVertexPoints)
-    aPolyVertexMapper = vtk.vtkDataSetMapper()
-    if major_version <= 5:
-        aPolyVertexMapper.SetInput(aPolyVertexGrid)
-    else:
-        aPolyVertexMapper.SetInputData(aPolyVertexGrid)
-    aPolyVertexActor = vtk.vtkActor()
-    aPolyVertexActor.SetMapper(aPolyVertexMapper)
-
-    aPolyVertexActor.GetProperty().SetColor(color)
-    aPolyVertexActor.GetProperty().SetOpacity(opacity)
-    aPolyVertexActor.GetProperty().SetPointSize(dot_size)
-    return aPolyVertexActor
-
-
-def point(points, colors, opacity=1, point_radius=0.1, theta=8, phi=8):
-    """ Visualize points as sphere glyphs
-
-    Parameters
-    ----------
-    points : ndarray, shape (N, 3)
-    colors : ndarray (N,3) or tuple (3,)
-    point_radius : float
-    theta : int
-    phi : int
-
-    Returns
-    -------
-    vtkActor
-
-    Examples
-    --------
-    >>> from dipy.viz import fvtk
-    >>> ren = fvtk.ren()
-    >>> pts = np.random.rand(5, 3)
-    >>> point_actor = fvtk.point(pts, fvtk.colors.coral)
-    >>> fvtk.add(ren, point_actor)
-    >>> #fvtk.show(ren)
-    """
-
-    if np.array(colors).ndim == 1:
-        # return dots(points,colors,opacity)
-        colors = np.tile(colors, (len(points), 1))
-
-    scalars = vtk.vtkUnsignedCharArray()
-    scalars.SetNumberOfComponents(3)
-
-    pts = vtk.vtkPoints()
-    cnt_colors = 0
-
-    for p in points:
-
-        pts.InsertNextPoint(p[0], p[1], p[2])
-        scalars.InsertNextTuple3(
-            round(255 * colors[cnt_colors][0]),
-            round(255 * colors[cnt_colors][1]),
-            round(255 * colors[cnt_colors][2]))
-        cnt_colors += 1
-
-    src = vtk.vtkSphereSource()
-    src.SetRadius(point_radius)
-    src.SetThetaResolution(theta)
-    src.SetPhiResolution(phi)
-
-    polyData = vtk.vtkPolyData()
-    polyData.SetPoints(pts)
-    polyData.GetPointData().SetScalars(scalars)
-
-    glyph = vtk.vtkGlyph3D()
-    glyph.SetSourceConnection(src.GetOutputPort())
-    if major_version <= 5:
-        glyph.SetInput(polyData)
-    else:
-        glyph.SetInputData(polyData)
-    glyph.SetColorModeToColorByScalar()
-    glyph.SetScaleModeToDataScalingOff()
-    glyph.Update()
-
-    mapper = vtk.vtkPolyDataMapper()
-    if major_version <= 5:
-        mapper.SetInput(glyph.GetOutput())
-    else:
-        mapper.SetInputData(glyph.GetOutput())
-    actor = vtk.vtkActor()
-    actor.SetMapper(mapper)
-    actor.GetProperty().SetOpacity(opacity)
-
-    return actor
-
-
-def label(ren, text='Origin', pos=(0, 0, 0), scale=(0.2, 0.2, 0.2),
-          color=(1, 1, 1)):
-    ''' Create a label actor.
-
-    This actor will always face the camera
-
-    Parameters
-    ----------
-    ren : vtkRenderer() object
-       Renderer as returned by ``ren()``.
-    text : str
-        Text for the label.
-    pos : (3,) array_like, optional
-        Left down position of the label.
-    scale : (3,) array_like
-        Changes the size of the label.
-    color : (3,) array_like
-        Label color as ``(r,g,b)`` tuple.
-
-    Returns
-    -------
-    l : vtkActor object
-        Label.
-
-    Examples
-    --------
-    >>> from dipy.viz import fvtk
-    >>> r=fvtk.ren()
-    >>> l=fvtk.label(r)
-    >>> fvtk.add(r,l)
-    >>> #fvtk.show(r)
-    '''
-    atext = vtk.vtkVectorText()
-    atext.SetText(text)
-
-    textm = vtk.vtkPolyDataMapper()
-    if major_version <= 5:
-        textm.SetInput(atext.GetOutput())
-    else:
-        textm.SetInputData(atext.GetOutput())
-
-    texta = vtk.vtkFollower()
-    texta.SetMapper(textm)
-    texta.SetScale(scale)
-
-    texta.GetProperty().SetColor(color)
-    texta.SetPosition(pos)
-
-    ren.AddActor(texta)
-    texta.SetCamera(ren.GetActiveCamera())
-
-    return texta
+deprecation_msg = ("Module 'dipy.viz.fvtk' is deprecated as of version"
+                   " 0.13 of dipy and will be removed in a future version."
+                   " Please, instead use module 'dipy.viz.window' or "
+                   " 'dipy.viz.actor'.")
+warn(DeprecationWarning(deprecation_msg))
 
 
 def volume(vol, voxsz=(1.0, 1.0, 1.0), affine=None, center_origin=1,

--- a/dipy/viz/fvtk.py
+++ b/dipy/viz/fvtk.py
@@ -87,7 +87,7 @@ else:
 
 
 deprecation_msg = ("Module 'dipy.viz.fvtk' is deprecated as of version"
-                   " 0.13 of dipy and will be removed in a future version."
+                   " 0.14 of dipy and will be removed in a future version."
                    " Please, instead use module 'dipy.viz.window' or "
                    " 'dipy.viz.actor'.")
 warn(DeprecationWarning(deprecation_msg))

--- a/dipy/viz/tests/test_actors.py
+++ b/dipy/viz/tests/test_actors.py
@@ -580,9 +580,6 @@ def test_tensor_slicer(interactive=False):
     affine = np.eye(4)
     renderer = window.Renderer()
 
-    # mask = np.ones(mevals.shape[:3])
-    # mask[:4, :4, :4] = 0
-
     tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine,
                                        sphere=sphere,  scale=.3)
     I, J, K = mevals.shape[:3]
@@ -594,7 +591,108 @@ def test_tensor_slicer(interactive=False):
     tensor_actor.GetProperty().SetOpacity(1.0)
     if interactive:
         window.show(renderer, reset_camera=False)
-    tensor_actor.display_extent(0, 2, 0, J, 0, K)
+
+    npt.assert_equal(renderer.GetActors().GetNumberOfItems(), 1)
+
+    # Test extent
+    big_extent = renderer.GetActors().GetLastActor().GetBounds()
+    big_extent_x = abs(big_extent[1] - big_extent[0])
+    tensor_actor.display(x=2)
+
+    if interactive:
+        window.show(renderer, reset_camera=False)
+
+    small_extent = renderer.GetActors().GetLastActor().GetBounds()
+    small_extent_x = abs(small_extent[1] - small_extent[0])
+    npt.assert_equal(big_extent_x > small_extent_x, True)
+
+    # Test empty mask
+    empty_actor = actor.tensor_slicer(mevals, mevecs, affine=affine,
+                                      mask=np.zeros(mevals.shape[:3]),
+                                      sphere=sphere,  scale=.3)
+    npt.assert_equal(empty_actor.GetMapper(), None)
+
+    # Test mask
+    mask = np.ones(mevals.shape[:3])
+    mask[:2, :3, :3] = 0
+    tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine, mask=mask,
+                                       sphere=sphere,  scale=.3)
+    renderer.clear()
+    renderer.add(tensor_actor)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    if interactive:
+        window.show(renderer, reset_camera=False)
+
+    mask_extent = renderer.GetActors().GetLastActor().GetBounds()
+    mask_extent_x = abs(mask_extent[1] - mask_extent[0])
+    npt.assert_equal(big_extent_x > mask_extent_x, True)
+
+
+@npt.dec.skipif(not run_test)
+@xvfb_it
+def test_dots(interactive=False):
+    points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0]])
+
+    dots_actor = actor.dots(points, color=(0, 255, 0))
+
+    renderer = window.Renderer()
+    renderer.add(dots_actor)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    if interactive:
+        window.show(renderer, reset_camera=False)
+
+    npt.assert_equal(renderer.GetActors().GetNumberOfItems(), 1)
+
+    extent = renderer.GetActors().GetLastActor().GetBounds()
+    npt.assert_equal(extent, (0.0, 1.0, 0.0, 1.0, 0.0, 0.0))
+
+    arr = window.snapshot(renderer)
+    report = window.analyze_snapshot(arr,
+                                     colors=(0, 255, 0))
+    npt.assert_equal(report.objects, 3)
+
+
+@npt.dec.skipif(not run_test)
+@xvfb_it
+def test_points(interactive=False):
+    points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0]])
+    colors = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    points_actor = actor.point(points,  colors)
+
+    renderer = window.Renderer()
+    renderer.add(points_actor)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    if interactive:
+        window.show(renderer, reset_camera=False)
+
+    npt.assert_equal(renderer.GetActors().GetNumberOfItems(), 1)
+
+    arr = window.snapshot(renderer)
+    report = window.analyze_snapshot(arr,
+                                     colors=colors)
+    npt.assert_equal(report.objects, 3)
+
+
+@npt.dec.skipif(not run_test)
+@xvfb_it
+def test_labels(interactive=False):
+
+    text_actor = actor.label("Hello")
+
+    renderer = window.Renderer()
+    renderer.add(text_actor)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    if interactive:
+        window.show(renderer, reset_camera=False)
 
     npt.assert_equal(renderer.GetActors().GetNumberOfItems(), 1)
 

--- a/dipy/viz/tests/test_actors.py
+++ b/dipy/viz/tests/test_actors.py
@@ -560,5 +560,44 @@ def test_peak_slicer(interactive=False):
     npt.assert_equal(report.actors_classnames, ex)
 
 
+@npt.dec.skipif(not run_test)
+@xvfb_it
+def test_tensor_slicer(interactive=False):
+
+    evals = np.array([1.4, .35, .35]) * 10 ** (-3)
+    evecs = np.eye(3)
+
+    mevals = np.zeros((3, 2, 4, 3))
+    mevecs = np.zeros((3, 2, 4, 3, 3))
+
+    mevals[..., :] = evals
+    mevecs[..., :, :] = evecs
+
+    from dipy.data import get_sphere
+
+    sphere = get_sphere('symmetric724')
+
+    affine = np.eye(4)
+    renderer = window.Renderer()
+
+    # mask = np.ones(mevals.shape[:3])
+    # mask[:4, :4, :4] = 0
+
+    tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine,
+                                       sphere=sphere,  scale=.3)
+    I, J, K = mevals.shape[:3]
+    renderer.add(tensor_actor)
+    renderer.reset_camera()
+    renderer.reset_clipping_range()
+
+    tensor_actor.display_extent(0, 1, 0, J, 0, K)
+    tensor_actor.GetProperty().SetOpacity(1.0)
+    if interactive:
+        window.show(renderer, reset_camera=False)
+    tensor_actor.display_extent(0, 2, 0, J, 0, K)
+
+    npt.assert_equal(renderer.GetActors().GetNumberOfItems(), 1)
+
+
 if __name__ == "__main__":
     npt.run_module_suite()

--- a/dipy/viz/tests/test_widgets.py
+++ b/dipy/viz/tests/test_widgets.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 from os.path import join as pjoin
 
-from dipy.viz import actor, window, widget, fvtk
+from dipy.viz import actor, window, widget
 from dipy.data import DATA_DIR
 from dipy.data import fetch_viz_icons, read_viz_icons
 import numpy.testing as npt
@@ -148,7 +148,7 @@ def test_text_widget():
     interactive = False
 
     renderer = window.Renderer()
-    axes = fvtk.axes()
+    axes = actor.axes()
     window.add(renderer, axes)
     renderer.ResetCamera()
 

--- a/dipy/viz/window.py
+++ b/dipy/viz/window.py
@@ -231,7 +231,7 @@ def renderer(background=None):
     >>> r = window.Renderer()
     >>> lines=[np.random.rand(10,3)]
     >>> c=actor.line(lines, window.colors.red)
-    >>> r.add(r,c)
+    >>> r.add(c)
     >>> #window.show(r)
     """
 
@@ -635,7 +635,7 @@ def show(ren, title='DIPY', size=(300, 300),
     >>> colors=np.array([[0.2,0.2,0.2],[0.8,0.8,0.8]])
     >>> c=actor.line(lines,colors)
     >>> r.add(c)
-    >>> l=window.label(r)
+    >>> l=actor.label(r)
     >>> r.add(l)
     >>> #window.show(r)
 

--- a/dipy/viz/window.py
+++ b/dipy/viz/window.py
@@ -635,7 +635,7 @@ def show(ren, title='DIPY', size=(300, 300),
     >>> colors=np.array([[0.2,0.2,0.2],[0.8,0.8,0.8]])
     >>> c=actor.line(lines,colors)
     >>> r.add(c)
-    >>> l=actor.label(r)
+    >>> l=actor.label(text="Hello")
     >>> r.add(l)
     >>> #window.show(r)
 

--- a/dipy/viz/window.py
+++ b/dipy/viz/window.py
@@ -226,13 +226,13 @@ def renderer(background=None):
 
     Examples
     --------
-    >>> from dipy.viz import fvtk
+    >>> from dipy.viz import window, actor
     >>> import numpy as np
-    >>> r=fvtk.ren()
+    >>> r = window.Renderer()
     >>> lines=[np.random.rand(10,3)]
-    >>> c=fvtk.line(lines, fvtk.colors.red)
-    >>> fvtk.add(r,c)
-    >>> #fvtk.show(r)
+    >>> c=actor.line(lines, window.colors.red)
+    >>> r.add(r,c)
+    >>> #window.show(r)
     """
 
     deprecation_msg = ("Method 'dipy.viz.window.renderer' is deprecated, instead"
@@ -629,15 +629,15 @@ def show(ren, title='DIPY', size=(300, 300),
     Examples
     ----------
     >>> import numpy as np
-    >>> from dipy.viz import fvtk
-    >>> r=fvtk.ren()
+    >>> from dipy.viz import window, actor
+    >>> r = window.Renderer()
     >>> lines=[np.random.rand(10,3),np.random.rand(20,3)]
     >>> colors=np.array([[0.2,0.2,0.2],[0.8,0.8,0.8]])
-    >>> c=fvtk.line(lines,colors)
-    >>> fvtk.add(r,c)
-    >>> l=fvtk.label(r)
-    >>> fvtk.add(r,l)
-    >>> #fvtk.show(r)
+    >>> c=actor.line(lines,colors)
+    >>> r.add(c)
+    >>> l=window.label(r)
+    >>> r.add(l)
+    >>> #window.show(r)
 
     See also
     ---------
@@ -693,12 +693,12 @@ def record(ren=None, cam_pos=None, cam_focal=None, cam_view=None,
 
     Examples
     ---------
-    >>> from dipy.viz import fvtk
-    >>> r=fvtk.ren()
-    >>> a=fvtk.axes()
-    >>> fvtk.add(r,a)
-    >>> #uncomment below to record
-    >>> #fvtk.record(r)
+    >>> from dipy.viz import window, actor
+    >>> ren = window.Renderer()
+    >>> a = actor.axes()
+    >>> ren.add(a)
+    >>> # uncomment below to record
+    >>> # window.record(ren)
     >>> #check for new images in current directory
     """
 

--- a/doc/examples/bundle_registration.py
+++ b/doc/examples/bundle_registration.py
@@ -10,7 +10,7 @@ To show the concept we will use two pre-saved cingulum bundles. The algorithm
 used here is called Streamline-based Linear Registration (SLR) [Garyfallidis15]_.
 """
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from time import sleep
 from dipy.data import two_cingulum_bundles
 
@@ -48,25 +48,25 @@ After the optimization is finished we can apply the transformation to
 cb_subj2_aligned = srm.transform(cb_subj2)
 
 
-def show_both_bundles(bundles, colors=None, show=False, fname=None):
+def show_both_bundles(bundles, colors=None, show=True, fname=None):
 
-    ren = fvtk.ren()
+    ren = window.Renderer()
     ren.SetBackground(1., 1, 1)
     for (i, bundle) in enumerate(bundles):
         color = colors[i]
-        lines = fvtk.streamtube(bundle, color, linewidth=0.3)
-        lines.RotateX(-90)
-        lines.RotateZ(90)
-        fvtk.add(ren, lines)
+        lines_actor = actor.streamtube(bundle, color, linewidth=0.3)
+        lines_actor.RotateX(-90)
+        lines_actor.RotateZ(90)
+        ren.add(lines_actor)
     if show:
-        fvtk.show(ren)
+        window.show(ren)
     if fname is not None:
         sleep(1)
-        fvtk.record(ren, n_frames=1, out_path=fname, size=(900, 900))
+        window.record(ren, n_frames=1, out_path=fname, size=(900, 900))
 
 
 show_both_bundles([cb_subj1, cb_subj2],
-                  colors=[fvtk.colors.orange, fvtk.colors.red],
+                  colors=[window.colors.orange, window.colors.red],
                   fname='before_registration.png')
 
 """
@@ -77,7 +77,7 @@ show_both_bundles([cb_subj1, cb_subj2],
 """
 
 show_both_bundles([cb_subj1, cb_subj2_aligned],
-                  colors=[fvtk.colors.orange, fvtk.colors.red],
+                  colors=[window.colors.orange, window.colors.red],
                   fname='after_registration.png')
 
 """

--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -218,34 +218,40 @@ after the cleaning procedure via RFBC thresholding (see
 """
 
 # Visualize the results
-from dipy.viz import fvtk, actor
+from dipy.viz import window, actor
+
+# Enables/disables interactive visualization
+interactive = False
 
 # Create renderer
-ren = fvtk.ren()
+ren = window.Renderer()
 
 # Original lines colored by LFBC
 lineactor = actor.line(fbc_sl_orig, clrs_orig, linewidth=0.2)
-fvtk.add(ren, lineactor)
+ren.add(lineactor)
 
 # Horizontal (axial) slice of T1 data
-vol_actor1 = fvtk.slicer(t1_data, affine=affine)
-vol_actor1.display(None, None, 20)
-fvtk.add(ren, vol_actor1)
+vol_actor1 = actor.slicer(t1_data, affine=affine)
+vol_actor1.display(z=20)
+ren.add(vol_actor1)
 
 # Vertical (sagittal) slice of T1 data
-vol_actor2 = fvtk.slicer(t1_data, affine=affine)
-vol_actor2.display(35, None, None)
-fvtk.add(ren, vol_actor2)
+vol_actor2 = actor.slicer(t1_data, affine=affine)
+vol_actor2.display(x=35)
+ren.add(vol_actor2)
 
 # Show original fibers
-fvtk.camera(ren, pos=(-264, 285, 155), focal=(0, -14, 9), viewup=(0, 0, 1),
-            verbose=False)
-fvtk.record(ren, n_frames=1, out_path='OR_before.png', size=(900, 900))
+ren.set_camera(position=(-264, 285, 155), focal_point=(0, -14, 9), view_up=(0, 0, 1))
+window.record(ren, n_frames=1, out_path='OR_before.png', size=(900, 900))
+if interactive:
+    window.show(ren)
 
 # Show thresholded fibers
-fvtk.rm(ren, lineactor)
-fvtk.add(ren, actor.line(fbc_sl_thres, clrs_thres, linewidth=0.2))
-fvtk.record(ren, n_frames=1, out_path='OR_after.png', size=(900, 900))
+ren.rm(lineactor)
+ren.add(actor.line(fbc_sl_thres, clrs_thres, linewidth=0.2))
+window.record(ren, n_frames=1, out_path='OR_after.png', size=(900, 900))
+if interactive:
+    window.show(ren)
 
 """
 .. _optic_radiation_before_cleaning:

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -46,14 +46,21 @@ In ``hsph_updated`` we have the updated ``HemiSphere`` with the points nicely
 distributed on the hemisphere. Let's visualize them.
 """
 
-from dipy.viz import fvtk
-ren = fvtk.ren()
+from dipy.viz import window, actor
+
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
 ren.SetBackground(1, 1, 1)
-fvtk.add(ren, fvtk.point(hsph_initial.vertices, fvtk.colors.red, point_radius=0.05))
-fvtk.add(ren, fvtk.point(hsph_updated.vertices, fvtk.colors.green, point_radius=0.05))
+
+ren.add(actor.point(hsph_initial.vertices, window.colors.red, point_radius=0.05))
+ren.add(actor.point(hsph_updated.vertices, window.colors.green, point_radius=0.05))
 
 print('Saving illustration as initial_vs_updated.png')
-fvtk.record(ren, out_path='initial_vs_updated.png', size=(300, 300))
+window.record(ren, out_path='initial_vs_updated.png', size=(300, 300))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: initial_vs_updated.png
@@ -64,13 +71,15 @@ fvtk.record(ren, out_path='initial_vs_updated.png', size=(300, 300))
 We can also create a sphere from the hemisphere and show it in the following way.
 """
 
-sph = Sphere(xyz = np.vstack((hsph_updated.vertices, -hsph_updated.vertices)))
+sph = Sphere(xyz=np.vstack((hsph_updated.vertices, -hsph_updated.vertices)))
 
-fvtk.rm_all(ren)
-fvtk.add(ren, fvtk.point(sph.vertices, fvtk.colors.green, point_radius=0.05))
+window.rm_all(ren)
+ren.add(actor.point(sph.vertices, actor.colors.green, point_radius=0.05))
 
 print('Saving illustration as full_sphere.png')
-fvtk.record(ren, out_path='full_sphere.png', size=(300, 300))
+window.record(ren, out_path='full_sphere.png', size=(300, 300))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: full_sphere.png
@@ -156,23 +165,25 @@ Both b-values and b-vectors look correct. Let's now create the
 
 gtab = gradient_table(bvals, bvecs)
 
-fvtk.rm_all(ren)
+window.rm_all(ren)
 
 """
 We can also visualize the gradients. Let's color the first shell blue and
 the second shell cyan.
 """
 
-colors_b1000 = fvtk.colors.blue * np.ones(vertices.shape)
-colors_b2500 = fvtk.colors.cyan * np.ones(vertices.shape)
+colors_b1000 = window.colors.blue * np.ones(vertices.shape)
+colors_b2500 = window.colors.cyan * np.ones(vertices.shape)
 colors = np.vstack((colors_b1000, colors_b2500))
 colors = np.insert(colors, (0, colors.shape[0]), np.array([0, 0, 0]), axis=0)
 colors = np.ascontiguousarray(colors)
 
-fvtk.add(ren, fvtk.point(gtab.gradients, colors, point_radius=100))
+ren.add(actor.point(gtab.gradients, colors, point_radius=100))
 
 print('Saving illustration as gradients.png')
-fvtk.record(ren, out_path='gradients.png', size=(300, 300))
+window.record(ren, out_path='gradients.png', size=(300, 300))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: gradients.png

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -90,7 +90,7 @@ seeds = utils.seeds_from_mask(seed_mask, density=[2, 2, 2], affine=affine)
 
 """
 Finally, we can bring it all together using ``LocalTracking``. We will then
-display the resulting streamlines using the viz package.
+display the resulting streamlines using the ``dipy.viz`` package.
 """
 
 from dipy.tracking.local import LocalTracking
@@ -112,7 +112,7 @@ color = line_colors(streamlines)
 if window.have_vtk:
     streamlines_actor = actor.line(streamlines, line_colors(streamlines))
 
-    # Create the 3d display.
+    # Create the 3D display.
     r = window.Renderer()
     r.add(streamlines_actor)
 
@@ -199,7 +199,7 @@ streamlines = list(streamlines)
 if window.have_vtk:
     streamlines_actor = actor.line(streamlines, line_colors(streamlines))
 
-    # Create the 3d display.
+    # Create the 3D display.
     r = window.Renderer()
     r.add(streamlines_actor)
 

--- a/doc/examples/introduction_to_basic_tracking.py
+++ b/doc/examples/introduction_to_basic_tracking.py
@@ -90,12 +90,15 @@ seeds = utils.seeds_from_mask(seed_mask, density=[2, 2, 2], affine=affine)
 
 """
 Finally, we can bring it all together using ``LocalTracking``. We will then
-display the resulting streamlines using the ``fvtk`` module.
+display the resulting streamlines using the viz package.
 """
 
 from dipy.tracking.local import LocalTracking
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.viz.colormap import line_colors
+
+# Enables/disables interactive visualization
+interactive = False
 
 # Initialization of LocalTracking. The computation happens in the next step.
 streamlines = LocalTracking(csa_peaks, classifier, seeds, affine, step_size=.5)
@@ -106,17 +109,17 @@ streamlines = list(streamlines)
 # Prepare the display objects.
 color = line_colors(streamlines)
 
-if fvtk.have_vtk:
-    streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
+if window.have_vtk:
+    streamlines_actor = actor.line(streamlines, line_colors(streamlines))
 
-    # Create the 3D display.
-    r = fvtk.ren()
-    fvtk.add(r, streamlines_actor)
+    # Create the 3d display.
+    r = window.Renderer()
+    r.add(streamlines_actor)
 
     # Save still images for this static example. Or for interactivity use
-    # fvtk.show
-    fvtk.record(r, n_frames=1, out_path='deterministic.png',
-                size=(800, 800))
+    window.record(r, n_frames=1, out_path='deterministic.png', size=(800, 800))
+    if interactive:
+        window.show(r)
 
 """
 .. figure:: deterministic.png
@@ -193,19 +196,17 @@ streamlines = LocalTracking(prob_dg, classifier, seeds, affine,
 # Compute streamlines and store as a list.
 streamlines = list(streamlines)
 
-# Prepare the display objects.
-color = line_colors(streamlines)
+if window.have_vtk:
+    streamlines_actor = actor.line(streamlines, line_colors(streamlines))
 
-if fvtk.have_vtk:
-    streamlines_actor = fvtk.line(streamlines, line_colors(streamlines))
-
-    # Create the 3D display.
-    r = fvtk.ren()
-    fvtk.add(r, streamlines_actor)
+    # Create the 3d display.
+    r = window.Renderer()
+    r.add(streamlines_actor)
 
     # Save still images for this static example.
-    fvtk.record(r, n_frames=1, out_path='probabilistic.png',
-                size=(800, 800))
+    window.record(r, n_frames=1, out_path='probabilistic.png', size=(800, 800))
+    if interactive:
+        window.show(r)
 
 """
 .. figure:: probabilistic.png

--- a/doc/examples/kfold_xval.py
+++ b/doc/examples/kfold_xval.py
@@ -95,8 +95,8 @@ each sub-plot (blue=DTI, red=CSD).
 
 """
 
-fig, ax = plt.subplots(1,2)
-fig.set_size_inches([12,6])
+fig, ax = plt.subplots(1, 2)
+fig.set_size_inches([12, 6])
 ax[0].plot(cc_vox[~gtab.b0s_mask], dti_cc[~gtab.b0s_mask], 'o', color='b')
 ax[0].plot(cc_vox[~gtab.b0s_mask], csd_cc[~gtab.b0s_mask], 'o', color='r')
 ax[1].plot(cso_vox[~gtab.b0s_mask], dti_cso[~gtab.b0s_mask], 'o', color='b', label='DTI')
@@ -124,10 +124,10 @@ R-squared score:
 
 """
 
-cc_dti_r2=stats.pearsonr(cc_vox[~gtab.b0s_mask], dti_cc[~gtab.b0s_mask])[0]**2
-cc_csd_r2=stats.pearsonr(cc_vox[~gtab.b0s_mask], csd_cc[~gtab.b0s_mask])[0]**2
-cso_dti_r2=stats.pearsonr(cso_vox[~gtab.b0s_mask], dti_cso[~gtab.b0s_mask])[0]**2
-cso_csd_r2=stats.pearsonr(cso_vox[~gtab.b0s_mask], csd_cso[~gtab.b0s_mask])[0]**2
+cc_dti_r2 = stats.pearsonr(cc_vox[~gtab.b0s_mask], dti_cc[~gtab.b0s_mask])[0]**2
+cc_csd_r2 = stats.pearsonr(cc_vox[~gtab.b0s_mask], csd_cc[~gtab.b0s_mask])[0]**2
+cso_dti_r2 = stats.pearsonr(cso_vox[~gtab.b0s_mask], dti_cso[~gtab.b0s_mask])[0]**2
+cso_csd_r2 = stats.pearsonr(cso_vox[~gtab.b0s_mask], csd_cso[~gtab.b0s_mask])[0]**2
 
 print("Corpus callosum\n"
       "DTI R2 : %s\n"

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -58,15 +58,14 @@ anatomical structure of this brain:
 """
 
 from dipy.viz.colormap import line_colors
-from dipy.viz import window, actor, fvtk
+from dipy.viz import window, actor
 
 # Enables/disables interactive visualization
 interactive = False
 
 candidate_streamlines_actor = actor.streamtube(candidate_sl, line_colors(candidate_sl))
-cc_ROI_actor = fvtk.contour(cc_slice, levels=[1],
-                            colors=[(1., 1., 0.)],
-                            opacities=[1.])
+cc_ROI_actor = actor.contour_from_roi(cc_slice, color=(1., 1., 0.),
+                                      opacity=0.5)
 
 vol_actor = actor.slicer(t1_data)
 

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -58,26 +58,33 @@ anatomical structure of this brain:
 """
 
 from dipy.viz.colormap import line_colors
-from dipy.viz import fvtk
-candidate_streamlines_actor = fvtk.streamtube(candidate_sl,
-                                       line_colors(candidate_sl))
-cc_ROI_actor = fvtk.contour(cc_slice, levels=[1], colors=[(1., 1., 0.)],
+from dipy.viz import window, actor, fvtk
+
+# Enables/disables interactive visualization
+interactive = False
+
+candidate_streamlines_actor = actor.streamtube(candidate_sl, line_colors(candidate_sl))
+cc_ROI_actor = fvtk.contour(cc_slice, levels=[1],
+                            colors=[(1., 1., 0.)],
                             opacities=[1.])
 
-vol_actor = fvtk.slicer(t1_data)
+vol_actor = actor.slicer(t1_data)
 
-vol_actor.display(40, None, None)
+vol_actor.display(x=40)
 vol_actor2 = vol_actor.copy()
-vol_actor2.display(None, None, 35)
+vol_actor2.display(z=35)
 
 # Add display objects to canvas
-ren = fvtk.ren()
-fvtk.add(ren, candidate_streamlines_actor)
-fvtk.add(ren, cc_ROI_actor)
-fvtk.add(ren, vol_actor)
-fvtk.add(ren, vol_actor2)
-fvtk.record(ren, n_frames=1, out_path='life_candidates.png',
-            size=(800, 800))
+ren = window.Renderer()
+ren.add(candidate_streamlines_actor)
+ren.add(cc_ROI_actor)
+ren.add(vol_actor)
+ren.add(vol_actor2)
+window.record(n_frames=1,
+              out_path='life_candidates.png',
+              size=(800, 800))
+if interactive:
+    window.show(ren)
 
 """
 
@@ -171,13 +178,15 @@ optimized group of streamlines:
 
 """
 
-optimized_sl = list(np.array(candidate_sl)[np.where(fiber_fit.beta>0)[0]])
-ren = fvtk.ren()
-fvtk.add(ren, fvtk.streamtube(optimized_sl, line_colors(optimized_sl)))
-fvtk.add(ren, cc_ROI_actor)
-fvtk.add(ren, vol_actor)
-fvtk.record(ren, n_frames=1, out_path='life_optimized.png',
-            size=(800, 800))
+optimized_sl = list(np.array(candidate_sl)[np.where(fiber_fit.beta > 0)[0]])
+ren = window.Renderer()
+ren.add(actor.streamtube(optimized_sl, line_colors(optimized_sl)))
+ren.add(cc_ROI_actor)
+ren.add(vol_actor)
+window.record(ren, n_frames=1, out_path='life_optimized.png',
+              size=(800, 800))
+if interactive:
+    window.show(ren)
 
 """
 
@@ -231,8 +240,8 @@ voxel.
 
 beta_baseline = np.zeros(fiber_fit.beta.shape[0])
 pred_weighted = np.reshape(opt.spdot(fiber_fit.life_matrix, beta_baseline),
-                                     (fiber_fit.vox_coords.shape[0],
-                                      np.sum(~gtab.b0s_mask)))
+                           (fiber_fit.vox_coords.shape[0],
+                            np.sum(~gtab.b0s_mask)))
 mean_pred = np.empty((fiber_fit.vox_coords.shape[0], gtab.bvals.shape[0]))
 S0 = fiber_fit.b0_signal
 
@@ -261,12 +270,14 @@ without the model fit.
 
 fig, ax = plt.subplots(1)
 ax.hist(mean_rmse - model_rmse, bins=100, histtype='step')
-ax.text(0.2, 0.9,'Median RMSE, mean model: %.2f' % np.median(mean_rmse),
-     horizontalalignment='left',
-     verticalalignment='center', transform=ax.transAxes)
-ax.text(0.2, 0.8,'Median RMSE, LiFE: %.2f' % np.median(model_rmse),
-     horizontalalignment='left',
-     verticalalignment='center', transform=ax.transAxes)
+ax.text(0.2, 0.9, 'Median RMSE, mean model: %.2f' % np.median(mean_rmse),
+        horizontalalignment='left',
+        verticalalignment='center',
+        transform=ax.transAxes)
+ax.text(0.2, 0.8, 'Median RMSE, LiFE: %.2f' % np.median(model_rmse),
+        horizontalalignment='left',
+        verticalalignment='center',
+        transform=ax.transAxes)
 ax.set_xlabel('RMS Error')
 ax.set_ylabel('# voxels')
 fig.savefig('error_histograms.png')
@@ -305,9 +316,9 @@ from mpl_toolkits.axes_grid1 import AxesGrid
 fig = plt.figure()
 fig.subplots_adjust(left=0.05, right=0.95)
 ax = AxesGrid(fig, 111,
-              nrows_ncols = (1, 3),
-              label_mode = "1",
-              share_all = True,
+              nrows_ncols=(1, 3),
+              label_mode="1",
+              share_all=True,
               cbar_location="top",
               cbar_mode="each",
               cbar_size="10%",

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -10,9 +10,8 @@ First import the necessary modules:
 """
 
 import numpy as np
-import nibabel as nib
 from dipy.data import fetch_stanford_hardi, read_stanford_hardi, get_sphere
-from dipy.reconst.shm import CsaOdfModel, normalize_data
+from dipy.reconst.shm import CsaOdfModel
 from dipy.direction import peaks_from_model
 
 """
@@ -93,8 +92,12 @@ data_small = maskdata[13:43, 44:74, 28:29]
 from dipy.data import get_sphere
 sphere = get_sphere('symmetric724')
 
-from dipy.viz import fvtk
-r = fvtk.ren()
+from dipy.viz import window, actor
+
+# Enables/disables interactive visualization
+interactive = False
+
+r = window.Renderer()
 
 csaodfs = csamodel.fit(data_small).odf(sphere)
 
@@ -103,10 +106,14 @@ It is common with CSA ODFs to produce negative values, we can remove those using
 """
 
 csaodfs = np.clip(csaodfs, 0, np.max(csaodfs, -1)[..., None])
+csa_odfs_actor = actor.odf_slicer(csaodfs, sphere=sphere, colormap='jet', scale=0.4)
+csa_odfs_actor.display(z=0)
 
-fvtk.add(r, fvtk.sphere_funcs(csaodfs, sphere, colormap='jet'))
+r.add(csa_odfs_actor)
 print('Saving illustration as csa_odfs.png')
-fvtk.record(r, n_frames=1, out_path='csa_odfs.png', size=(600, 600))
+window.record(r, n_frames=1, out_path='csa_odfs.png', size=(600, 600))
+if interactive:
+    window.show(r)
 
 """
 .. figure:: csa_odfs.png

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -77,18 +77,26 @@ We can double-check that we have a good response function by visualizing the
 response function's ODF. Here is how you would do that:
 """
 
-from dipy.viz import fvtk
-ren = fvtk.ren()
+from dipy.viz import window, actor
+
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
 evals = response[0]
 evecs = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]).T
 from dipy.data import get_sphere
 sphere = get_sphere('symmetric724')
 from dipy.sims.voxel import single_tensor_odf
 response_odf = single_tensor_odf(sphere.vertices, evals, evecs)
-response_actor = fvtk.sphere_funcs(response_odf, sphere)
-fvtk.add(ren, response_actor)
+# transform our data from 1D to 4D
+response_odf = response_odf[None, None, None, :]
+response_actor = actor.odf_slicer(response_odf, sphere=sphere, colormap='jet')
+ren.add(response_actor)
 print('Saving illustration as csd_response.png')
-fvtk.record(ren, out_path='csd_response.png', size=(200, 200))
+window.record(ren, out_path='csd_response.png', size=(200, 200))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csd_response.png
@@ -98,7 +106,7 @@ fvtk.record(ren, out_path='csd_response.png', size=(200, 200))
 
 """
 
-fvtk.rm(ren, response_actor)
+ren.rm(response_actor)
 
 """
 Depending on the dataset, FA threshold may not be the best way to find the
@@ -143,13 +151,15 @@ like  a pancake:
 """
 
 response_signal = response.on_sphere(sphere)
-response_actor = fvtk.sphere_funcs(response_signal, sphere)
+response_actor = actor.odf_slicer(response_signal, sphere=sphere, colormap='jet')
 
-ren = fvtk.ren()
+ren = window.Renderer()
 
-fvtk.add(ren, response_actor)
+ren.add(response_actor)
 print('Saving illustration as csd_recursive_response.png')
-fvtk.record(ren, out_path='csd_recursive_response.png', size=(200, 200))
+window.record(ren, out_path='csd_recursive_response.png', size=(200, 200))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csd_recursive_response.png
@@ -159,7 +169,7 @@ fvtk.record(ren, out_path='csd_recursive_response.png', size=(200, 200))
 
 """
 
-fvtk.rm(ren, response_actor)
+ren.rm(response_actor)
 
 """
 Now, that we have the response function, we are ready to start the deconvolution
@@ -186,12 +196,14 @@ csd_odf = csd_fit.odf(sphere)
 Here we visualize only a 30x30 region.
 """
 
-fodf_spheres = fvtk.sphere_funcs(csd_odf, sphere, scale=1.3, norm=False)
+fodf_spheres = actor.odf_slicer(csd_odf, sphere=sphere, scale=1.3, norm=False, colormap='jet')
 
-fvtk.add(ren, fodf_spheres)
+ren.add(fodf_spheres)
 
 print('Saving illustration as csd_odfs.png')
-fvtk.record(ren, out_path='csd_odfs.png', size=(600, 600))
+window.record(ren, out_path='csd_odfs.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csd_odfs.png
@@ -212,12 +224,14 @@ csd_peaks = peaks_from_model(model=csd_model,
                              min_separation_angle=25,
                              parallel=True)
 
-fvtk.clear(ren)
-fodf_peaks = fvtk.peaks(csd_peaks.peak_dirs, csd_peaks.peak_values, scale=1.3)
-fvtk.add(ren, fodf_peaks)
+window.clear(ren)
+fodf_peaks = actor.peak_slicer(csd_peaks.peak_dirs, csd_peaks.peak_values, scale=1.3)
+ren.add(fodf_peaks)
 
 print('Saving illustration as csd_peaks.png')
-fvtk.record(ren, out_path='csd_peaks.png', size=(600, 600))
+window.record(ren, out_path='csd_peaks.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csd_peaks.png
@@ -230,11 +244,12 @@ We can finally visualize both the ODFs and peaks in the same space.
 
 fodf_spheres.GetProperty().SetOpacity(0.4)
 
-fvtk.add(ren, fodf_spheres)
+ren.add(fodf_spheres)
 
 print('Saving illustration as csd_both.png')
-fvtk.record(ren, out_path='csd_both.png', size=(600, 600))
-
+window.record(ren, out_path='csd_both.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csd_both.png

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -65,16 +65,24 @@ with deconvolution ODFs and observe that with the deconvolved method it is
 easier to resolve the correct fiber directions because the ODF is sharper.
 """
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
-ren = fvtk.ren()
+# Enables/disables interactive visualization
+interactive = False
 
+
+ren = window.Renderer()
+
+# concatenate data as 4D array
 odfs = np.vstack((odf_gt, dsi_odf, dsid_odf))[:, None, None]
+odf_actor = actor.odf_slicer(odfs, sphere=sphere, scale=0.5, colormap='jet')
 
-odf_actor = fvtk.sphere_funcs(odfs, sphere)
+odf_actor.display(y=0)
 odf_actor.RotateX(90)
-fvtk.add(ren, odf_actor)
-fvtk.record(ren, out_path='dsid.png', size=(300, 300))
+ren.add(odf_actor)
+window.record(ren, out_path='dsid.png', size=(300, 300))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: dsid.png

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -217,8 +217,12 @@ print('Computing tensor ellipsoids in a part of the splenium of the CC')
 from dipy.data import get_sphere
 sphere = get_sphere('symmetric724')
 
-from dipy.viz import fvtk
-ren = fvtk.ren()
+from dipy.viz import window, actor
+
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
 
 evals = tenfit.evals[13:43, 44:74, 28:29]
 evecs = tenfit.evecs[13:43, 44:74, 28:29]
@@ -232,10 +236,12 @@ contrast.
 cfa = RGB[13:43, 44:74, 28:29]
 cfa /= cfa.max()
 
-fvtk.add(ren, fvtk.tensor(evals, evecs, cfa, sphere))
+ren.add(fvtk.tensor(evals, evecs, cfa, sphere))
 
 print('Saving illustration as tensor_ellipsoids.png')
-fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids.png', size=(600, 600))
+window.record(ren, n_frames=1, out_path='tensor_ellipsoids.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: tensor_ellipsoids.png
@@ -244,7 +250,7 @@ fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids.png', size=(600, 600))
    Tensor Ellipsoids.
 """
 
-fvtk.clear(ren)
+window.clear(ren)
 
 """
 Finally, we can visualize the tensor Orientation Distribution Functions
@@ -253,10 +259,11 @@ for the same area as we did with the ellipsoids.
 
 tensor_odfs = tenmodel.fit(data[20:50, 55:85, 38:39]).odf(sphere)
 
-fvtk.add(ren, fvtk.sphere_funcs(tensor_odfs, sphere, colormap=None))
-#fvtk.show(r)
+ren.add(actor.odf_slicer(tensor_odfs, sphere, colormap=None))
 print('Saving illustration as tensor_odfs.png')
-fvtk.record(ren, n_frames=1, out_path='tensor_odfs.png', size=(600, 600))
+window.record(ren, n_frames=1, out_path='tensor_odfs.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: tensor_odfs.png

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -147,7 +147,7 @@ where more than one population of white matter fibers crosses.
 """
 
 print('Computing anisotropy measures (FA, MD, RGB)')
-from dipy.reconst.dti import fractional_anisotropy, color_fa, lower_triangular
+from dipy.reconst.dti import fractional_anisotropy, color_fa
 
 FA = fractional_anisotropy(tenfit.evals)
 
@@ -236,7 +236,7 @@ contrast.
 cfa = RGB[13:43, 44:74, 28:29]
 cfa /= cfa.max()
 
-ren.add(fvtk.tensor(evals, evecs, cfa, sphere))
+ren.add(actor.tensor_slicer(evals, evecs, scalar_colors=cfa, sphere=sphere, scale=0.3))
 
 print('Saving illustration as tensor_ellipsoids.png')
 window.record(ren, n_frames=1, out_path='tensor_ellipsoids.png', size=(600, 600))
@@ -259,7 +259,8 @@ for the same area as we did with the ellipsoids.
 
 tensor_odfs = tenmodel.fit(data[20:50, 55:85, 38:39]).odf(sphere)
 
-ren.add(actor.odf_slicer(tensor_odfs, sphere, colormap=None))
+odf_actor = actor.odf_slicer(tensor_odfs, sphere=sphere, scale=0.5, colormap=None)
+ren.add(odf_actor)
 print('Saving illustration as tensor_odfs.png')
 window.record(ren, n_frames=1, out_path='tensor_odfs.png', size=(600, 600))
 if interactive:

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -27,7 +27,7 @@ First import the necessary modules:
 """
 
 from dipy.reconst import mapmri
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.data import fetch_cenir_multib, read_cenir_multib, get_sphere
 from dipy.core.gradients import gradient_table
 import matplotlib.pyplot as plt
@@ -141,9 +141,11 @@ and also faster in practice [Fick2016a]_.
 
 We can then fit the MAPMRI model to the data.
 """
+
 mapfit_laplacian_aniso = map_model_laplacian_aniso.fit(data_small)
 mapfit_positivity_aniso = map_model_positivity_aniso.fit(data_small)
 mapfit_both_aniso = map_model_both_aniso.fit(data_small)
+
 """
 From the fitted models we will first illustrate the estimation of q-space
 indices. For completeness, we will compare the estimation using only Laplacian
@@ -175,6 +177,7 @@ cax = divider.append_axes("right", size="5%", pad=0.05)
 plt.colorbar(ind, cax=cax)
 
 plt.savefig('MAPMRI_maps_regularization.png')
+
 """
 .. figure:: MAPMRI_maps_regularization.png
    :align: center
@@ -383,11 +386,17 @@ print('odf.shape (%d, %d, %d, %d)' % odf.shape)
 Display the ODFs.
 """
 
-r = fvtk.ren()
-sfu = fvtk.sphere_funcs(odf, sphere, colormap='jet')
-sfu.RotateX(-90)
-fvtk.add(r, sfu)
-fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
+# Enables/disables interactive visualization
+interactive = False
+
+r = window.Renderer()
+sfu = actor.odf_slicer(odf, sphere=sphere, colormap='jet', scale=0.5)
+sfu.display(y=0)
+r.add(sfu)
+window.record(r, out_path='odfs.png', size=(600, 600))
+if interactive:
+    window.show(r)
+
 """
 .. figure:: odfs.png
    :align: center

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -11,10 +11,8 @@ First import the necessary modules:
 """
 
 from dipy.reconst.shore import ShoreModel
-from dipy.reconst.shm import sh_to_sf
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.data import fetch_isbi2013_2shell, read_isbi2013_2shell, get_sphere
-from dipy.core.gradients import gradient_table
 
 """
 Download and read the data for this tutorial.
@@ -84,11 +82,17 @@ print('odf.shape (%d, %d, %d)' % odf.shape)
 Display the ODFs
 """
 
-r = fvtk.ren()
-sfu = fvtk.sphere_funcs(odf[:, None, :], sphere, colormap='jet')
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
+sfu = actor.odf_slicer(odf[:, None, :], sphere=sphere, colormap='jet', scale=0.5)
 sfu.RotateX(-90)
-fvtk.add(r, sfu)
-fvtk.record(r, n_frames=1, out_path='odfs.png', size=(600, 600))
+sfu.display(y=0)
+ren.add(sfu)
+window.record(ren, out_path='odfs.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: odfs.png

--- a/doc/examples/restore_dti.py
+++ b/doc/examples/restore_dti.py
@@ -44,12 +44,15 @@ import dipy.reconst.dti as dti
 import dipy.data as dpd
 
 """
-``dipy.viz.fvtk`` is used for 3D visualization and matplotlib for 2D
+``dipy.viz`` package is used for 3D visualization and matplotlib for 2D
 visualizations:
 """
 
-import dipy.viz.fvtk as fvtk
+from dipy.viz import window, actor
 import matplotlib.pyplot as plt
+
+# Enables/disables interactive visualization
+interactive = False
 
 """
 If needed, the ``fetch_stanford_hardi`` function will download the raw dMRI
@@ -101,11 +104,12 @@ sphere = dpd.get_sphere('symmetric724')
 We visualize the ODFs in the ROI using fvtk:
 """
 
-ren = fvtk.ren()
-fvtk.add(ren, fvtk.tensor(evals1, evecs1, cfa1, sphere))
+ren = window.Renderer()
+ren.add(ren, fvtk.tensor(evals1, evecs1, cfa1, sphere))
 print('Saving illustration as tensor_ellipsoids_wls.png')
-fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids_wls.png',
-            size=(600, 600))
+window.record(ren, out_path='tensor_ellipsoids_wls.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: tensor_ellipsoids_wls.png
@@ -114,7 +118,7 @@ fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids_wls.png',
    Tensor Ellipsoids.
 """
 
-fvtk.clear(ren)
+window.clear(ren)
 
 """
 Next, we corrupt the data with some noise. To simulate a subject that moves
@@ -135,12 +139,12 @@ evals2 = fit_wls_noisy.evals
 evecs2 = fit_wls_noisy.evecs
 cfa2 = dti.color_fa(fa2, evecs2)
 
-ren = fvtk.ren()
-fvtk.add(ren, fvtk.tensor(evals2, evecs2, cfa2, sphere))
+ren = window.Renderer()
+ren.add(ren, fvtk.tensor(evals2, evecs2, cfa2, sphere))
 print('Saving illustration as tensor_ellipsoids_wls_noisy.png')
-fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids_wls_noisy.png',
-            size=(600, 600))
-
+window.record(ren, out_path='tensor_ellipsoids_wls_noisy.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 In places where the tensor model is particularly sensitive to noise, the
@@ -166,18 +170,19 @@ to identify the outliers in each voxel and is given as an input when
 initializing the TensorModel object:
 """
 
-dti_restore = dti.TensorModel(gtab,fit_method='RESTORE', sigma=sigma)
+dti_restore = dti.TensorModel(gtab, fit_method='RESTORE', sigma=sigma)
 fit_restore_noisy = dti_restore.fit(noisy_data)
 fa3 = fit_restore_noisy.fa
 evals3 = fit_restore_noisy.evals
 evecs3 = fit_restore_noisy.evecs
 cfa3 = dti.color_fa(fa3, evecs3)
 
-ren = fvtk.ren()
-fvtk.add(ren, fvtk.tensor(evals3, evecs3, cfa3, sphere))
+ren = window.Renderer()
+ren.add(ren, fvtk.tensor(evals3, evecs3, cfa3, sphere))
 print('Saving illustration as tensor_ellipsoids_restore_noisy.png')
-fvtk.record(ren, n_frames=1, out_path='tensor_ellipsoids_restore_noisy.png',
-            size=(600, 600))
+window.record(ren, out_path='tensor_ellipsoids_restore_noisy.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: tensor_ellipsoids_restore_noisy.png

--- a/doc/examples/restore_dti.py
+++ b/doc/examples/restore_dti.py
@@ -78,7 +78,7 @@ interest (ROI) surrounding the Corpus Callosum. We define that ROI as the
 following indices:
 """
 
-roi_idx = (slice(20,50), slice(55,85), slice(38,39))
+roi_idx = (slice(20, 50), slice(55, 85), slice(38, 39))
 
 """
 And use them to index into the data:
@@ -101,11 +101,11 @@ cfa1 = dti.color_fa(fa1, evecs1)
 sphere = dpd.get_sphere('symmetric724')
 
 """
-We visualize the ODFs in the ROI using fvtk:
+We visualize the ODFs in the ROI using ``dipy.viz`` module:
 """
 
 ren = window.Renderer()
-ren.add(ren, fvtk.tensor(evals1, evecs1, cfa1, sphere))
+ren.add(actor.tensor_slicer(evals1, evecs1, scalar_colors=cfa1, sphere=sphere, scale=0.3))
 print('Saving illustration as tensor_ellipsoids_wls.png')
 window.record(ren, out_path='tensor_ellipsoids_wls.png', size=(600, 600))
 if interactive:
@@ -140,7 +140,7 @@ evecs2 = fit_wls_noisy.evecs
 cfa2 = dti.color_fa(fa2, evecs2)
 
 ren = window.Renderer()
-ren.add(ren, fvtk.tensor(evals2, evecs2, cfa2, sphere))
+ren.add(actor.tensor_slicer(evals2, evecs2, scalar_colors=cfa2, sphere=sphere, scale=0.3))
 print('Saving illustration as tensor_ellipsoids_wls_noisy.png')
 window.record(ren, out_path='tensor_ellipsoids_wls_noisy.png', size=(600, 600))
 if interactive:
@@ -178,7 +178,7 @@ evecs3 = fit_restore_noisy.evecs
 cfa3 = dti.color_fa(fa3, evecs3)
 
 ren = window.Renderer()
-ren.add(ren, fvtk.tensor(evals3, evecs3, cfa3, sphere))
+ren.add(actor.tensor_slicer(evals3, evecs3, scalar_colors=cfa3, sphere=sphere, scale=0.3))
 print('Saving illustration as tensor_ellipsoids_restore_noisy.png')
 window.record(ren, out_path='tensor_ellipsoids_restore_noisy.png', size=(600, 600))
 if interactive:

--- a/doc/examples/segment_clustering_features.py
+++ b/doc/examples/segment_clustering_features.py
@@ -139,10 +139,13 @@ streamline.
 """
 
 import numpy as np
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import CenterOfMassFeature
 from dipy.segment.metric import EuclideanMetric
+
+# Enables/disables interactive visualization
+interactive = False
 
 # Get some streamlines.
 streamlines = get_streamlines()  # Previously defined.
@@ -158,19 +161,20 @@ clusters = qb.cluster(streamlines)
 centers = np.asarray(list(map(feature.extract, streamlines)))
 
 # Color each center of mass according to the cluster they belong to.
-rng = np.random.RandomState(42)
-colormap = fvtk.create_colormap(np.arange(len(clusters)))
+colormap = actor.create_colormap(np.arange(len(clusters)))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
 # Visualization
-ren = fvtk.ren()
-fvtk.clear(ren)
+ren = window.Renderer()
+window.clear(ren)
 ren.SetBackground(0, 0, 0)
-fvtk.add(ren, fvtk.streamtube(streamlines, fvtk.colors.white, opacity=0.05))
-fvtk.add(ren, fvtk.point(centers[:, 0, :], colormap_full, point_radius=0.2))
-fvtk.record(ren, n_frames=1, out_path='center_of_mass_feature.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, window.colors.white, opacity=0.05))
+ren.add(actor.point(centers[:, 0, :], colormap_full, point_radius=0.2))
+window.record(ren, n_frames=1, out_path='center_of_mass_feature.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: center_of_mass_feature.png
@@ -193,7 +197,7 @@ spatial position of a streamline. This can also be an alternative to the
 """
 
 import numpy as np
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import MidpointFeature
 from dipy.segment.metric import EuclideanMetric
@@ -211,19 +215,20 @@ clusters = qb.cluster(streamlines)
 midpoints = np.asarray(list(map(feature.extract, streamlines)))
 
 # Color each midpoint according to the cluster they belong to.
-rng = np.random.RandomState(42)
-colormap = fvtk.create_colormap(np.arange(len(clusters)))
+colormap = actor.create_colormap(np.arange(len(clusters)))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
 # Visualization
-ren = fvtk.ren()
-fvtk.clear(ren)
+ren = window.Renderer()
+window.clear(ren)
 ren.SetBackground(0, 0, 0)
-fvtk.add(ren, fvtk.point(midpoints[:, 0, :], colormap_full, point_radius=0.2))
-fvtk.add(ren, fvtk.streamtube(streamlines, fvtk.colors.white, opacity=0.05))
-fvtk.record(ren, n_frames=1, out_path='midpoint_feature.png', size=(600, 600))
+ren.add(actor.point(midpoints[:, 0, :], colormap_full, point_radius=0.2))
+ren.add(actor.streamtube(streamlines, window.colors.white, opacity=0.05))
+window.record(ren, n_frames=1, out_path='midpoint_feature.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: midpoint_feature.png
@@ -245,7 +250,7 @@ length of a streamline.
 """
 
 import numpy as np
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import ArcLengthFeature
 from dipy.segment.metric import EuclideanMetric
@@ -259,17 +264,19 @@ qb = QuickBundles(threshold=2., metric=metric)
 clusters = qb.cluster(streamlines)
 
 # Color each streamline according to the cluster they belong to.
-colormap = fvtk.create_colormap(np.ravel(clusters.centroids))
+colormap = actor.create_colormap(np.ravel(clusters.centroids))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
 # Visualization
-ren = fvtk.ren()
-fvtk.clear(ren)
+ren = window.Renderer()
+window.clear(ren)
 ren.SetBackground(0, 0, 0)
-fvtk.add(ren, fvtk.streamtube(streamlines, colormap_full))
-fvtk.record(ren, n_frames=1, out_path='arclength_feature.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, colormap_full))
+window.record(ren, out_path='arclength_feature.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: arclength_feature.png
@@ -295,7 +302,7 @@ using this feature.
 """
 
 import numpy as np
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import VectorOfEndpointsFeature
 from dipy.segment.metric import CosineMetric
@@ -309,17 +316,19 @@ qb = QuickBundles(threshold=0.1, metric=metric)
 clusters = qb.cluster(streamlines)
 
 # Color each streamline according to the cluster they belong to.
-colormap = fvtk.create_colormap(np.arange(len(clusters)))
+colormap = actor.create_colormap(np.arange(len(clusters)))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
 # Visualization
-ren = fvtk.ren()
-fvtk.clear(ren)
+ren = window.Renderer()
+window.clear(ren)
 ren.SetBackground(0, 0, 0)
-fvtk.add(ren, fvtk.streamtube(streamlines, colormap_full))
-fvtk.record(ren, n_frames=1, out_path='vector_of_endpoints_feature.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, colormap_full))
+window.record(ren, out_path='vector_of_endpoints_feature.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: vector_of_endpoints_feature.png

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -50,7 +50,6 @@ saving some computational time.
 **Note:** Inputs must be sequences of same length.
 """
 
-from dipy.viz import fvtk
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
 
@@ -171,10 +170,13 @@ orientation of a streamline.
 """
 
 import numpy as np
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import VectorOfEndpointsFeature
 from dipy.segment.metric import CosineMetric
+
+# Enables/disables interactive visualization
+interactive = False
 
 # Get some streamlines.
 streamlines = get_streamlines()  # Previously defined.
@@ -185,17 +187,19 @@ qb = QuickBundles(threshold=0.1, metric=metric)
 clusters = qb.cluster(streamlines)
 
 # Color each streamline according to the cluster they belong to.
-colormap = fvtk.create_colormap(np.arange(len(clusters)))
+colormap = actor.create_colormap(np.arange(len(clusters)))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
 # Visualization
-ren = fvtk.ren()
-fvtk.clear(ren)
+ren = window.Renderer()
+window.clear(ren)
 ren.SetBackground(0, 0, 0)
-fvtk.add(ren, fvtk.streamtube(streamlines, colormap_full))
-fvtk.record(ren, n_frames=1, out_path='cosine_metric.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, colormap_full))
+window.record(ren, out_path='cosine_metric.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: cosine_metric.png

--- a/doc/examples/segment_extending_clustering_framework.py
+++ b/doc/examples/segment_extending_clustering_framework.py
@@ -104,7 +104,7 @@ We start by loading the fornix streamlines.
 import numpy as np
 from nibabel import trackvis as tv
 from dipy.data import get_data
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
 fname = get_data('fornix')
 streams, hdr = tv.read(fname)
@@ -127,15 +127,20 @@ We will now visualize the clustering result.
 """
 
 # Color each streamline according to the cluster they belong to.
-colormap = fvtk.create_colormap(np.ravel(clusters.centroids))
+colormap = actor.create_colormap(np.ravel(clusters.centroids))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
-ren = fvtk.ren()
+ren = window.Renderer()
 ren.SetBackground(1, 1, 1)
-fvtk.add(ren, fvtk.streamtube(streamlines, colormap_full))
-fvtk.record(ren, n_frames=1, out_path='fornix_clusters_arclength.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, colormap_full))
+window.record(ren, out_path='fornix_clusters_arclength.png', size=(600, 600))
+
+# Enables/disables interactive visualization
+interactive = False
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: fornix_clusters_arclength.png
@@ -206,7 +211,7 @@ We start by loading the fornix streamlines.
 import numpy as np
 from nibabel import trackvis as tv
 from dipy.data import get_data
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
 fname = get_data('fornix')
 streams, hdr = tv.read(fname)
@@ -227,16 +232,17 @@ We will now visualize the clustering result.
 """
 
 # Color each streamline according to the cluster they belong to.
-colormap = fvtk.create_colormap(np.arange(len(clusters)))
+colormap = actor.create_colormap(np.arange(len(clusters)))
 colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
-ren = fvtk.ren()
+ren = window.Renderer()
 ren.SetBackground(1, 1, 1)
-fvtk.add(ren, fvtk.streamtube(streamlines, colormap_full))
-fvtk.record(ren, n_frames=1, out_path='fornix_clusters_cosine.png', size=(600, 600))
-
+ren.add(actor.streamtube(streamlines, colormap_full))
+window.record(ren, out_path='fornix_clusters_cosine.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: fornix_clusters_cosine.png

--- a/doc/examples/segment_quickbundles.py
+++ b/doc/examples/segment_quickbundles.py
@@ -14,7 +14,7 @@ from nibabel import trackvis as tv
 from dipy.segment.clustering import QuickBundles
 from dipy.io.pickles import save_pickle
 from dipy.data import get_data
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
 """
 For educational purposes we will try to cluster a small streamline bundle known
@@ -91,10 +91,15 @@ methods like `add`, `remove`, and `clear` to modify the clustering result.
 Lets first show the initial dataset.
 """
 
-ren = fvtk.ren()
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
 ren.SetBackground(1, 1, 1)
-fvtk.add(ren, fvtk.streamtube(streamlines, fvtk.colors.white))
-fvtk.record(ren, n_frames=1, out_path='fornix_initial.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, window.colors.white))
+window.record(ren, out_path='fornix_initial.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: fornix_initial.png
@@ -105,13 +110,15 @@ fvtk.record(ren, n_frames=1, out_path='fornix_initial.png', size=(600, 600))
 Show the centroids of the fornix after clustering (with random colors):
 """
 
-colormap = fvtk.create_colormap(np.arange(len(clusters)))
+colormap = actor.create_colormap(np.arange(len(clusters)))
 
-fvtk.clear(ren)
+window.clear(ren)
 ren.SetBackground(1, 1, 1)
-fvtk.add(ren, fvtk.streamtube(streamlines, fvtk.colors.white, opacity=0.05))
-fvtk.add(ren, fvtk.streamtube(clusters.centroids, colormap, linewidth=0.4))
-fvtk.record(ren, n_frames=1, out_path='fornix_centroids.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, window.colors.white, opacity=0.05))
+ren.add(actor.streamtube(clusters.centroids, colormap, linewidth=0.4))
+window.record(ren, out_path='fornix_centroids.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: fornix_centroids.png
@@ -126,10 +133,12 @@ colormap_full = np.ones((len(streamlines), 3))
 for cluster, color in zip(clusters, colormap):
     colormap_full[cluster.indices] = color
 
-fvtk.clear(ren)
+window.clear(ren)
 ren.SetBackground(1, 1, 1)
-fvtk.add(ren, fvtk.streamtube(streamlines, colormap_full))
-fvtk.record(ren, n_frames=1, out_path='fornix_clusters.png', size=(600, 600))
+ren.add(actor.streamtube(streamlines, colormap_full))
+window.record(ren, out_path='fornix_clusters.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: fornix_clusters.png

--- a/doc/examples/sfm_reconst.py
+++ b/doc/examples/sfm_reconst.py
@@ -14,7 +14,7 @@ First, we import the modules we will use in this example:
 import dipy.reconst.sfm as sfm
 import dipy.data as dpd
 import dipy.direction.peaks as dpp
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
 """
 For the purpose of this example, we will use the Stanford HARDI dataset (150
@@ -29,6 +29,9 @@ other examples.
 from dipy.data import read_stanford_hardi
 img, gtab = read_stanford_hardi()
 data = img.get_data()
+
+# Enables/disables interactive visualization
+interactive = False
 
 """
 Reconstruction of the fiber ODF in each voxel guides subsequent tracking
@@ -114,13 +117,15 @@ model on the sphere, and plot it.
 sf_fit = sf_model.fit(data_small)
 sf_odf = sf_fit.odf(sphere)
 
-fodf_spheres = fvtk.sphere_funcs(sf_odf, sphere, scale=1.3, norm=True)
+fodf_spheres = actor.odf_slicer(sf_odf, sphere=sphere, scale=1.3, colormap='jet')
 
-ren = fvtk.ren()
-fvtk.add(ren, fodf_spheres)
+ren = window.Renderer()
+ren.add(fodf_spheres)
 
 print('Saving illustration as sf_odfs.png')
-fvtk.record(ren, out_path='sf_odfs.png', size=(1000, 1000))
+window.record(ren, out_path='sf_odfs.png', size=(1000, 1000))
+if interactive:
+    window.show(ren)
 
 """
 We can extract the peaks from the ODF, and plot these as well
@@ -134,22 +139,26 @@ sf_peaks = dpp.peaks_from_model(sf_model,
                                 return_sh=False)
 
 
-fvtk.clear(ren)
-fodf_peaks = fvtk.peaks(sf_peaks.peak_dirs, sf_peaks.peak_values, scale=1.3)
-fvtk.add(ren, fodf_peaks)
+window.clear(ren)
+fodf_peaks = actor.peak_slicer(sf_peaks.peak_dirs, sf_peaks.peak_values, scale=1.3)
+ren.add(fodf_peaks)
 
 print('Saving illustration as sf_peaks.png')
-fvtk.record(ren, out_path='sf_peaks.png', size=(1000, 1000))
+window.record(ren, out_path='sf_peaks.png', size=(1000, 1000))
+if interactive:
+    window.show(ren)
 
 """
 Finally, we plot both the peaks and the ODFs, overlayed:
 """
 
 fodf_spheres.GetProperty().SetOpacity(0.4)
-fvtk.add(ren, fodf_spheres)
+ren.add(fodf_spheres)
 
 print('Saving illustration as sf_both.png')
-fvtk.record(ren, out_path='sf_both.png', size=(1000, 1000))
+window.record(ren, out_path='sf_both.png', size=(1000, 1000))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: sf_both.png

--- a/doc/examples/sfm_tracking.py
+++ b/doc/examples/sfm_tracking.py
@@ -106,7 +106,7 @@ Next, we will create a visualization of these streamlines, relative to this
 subject's T1-weighted anatomy:
 """
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.viz.colormap import line_colors
 from dipy.data import read_stanford_t1
 from dipy.tracking.utils import move_streamlines
@@ -115,6 +115,9 @@ t1 = read_stanford_t1()
 t1_data = t1.get_data()
 t1_aff = t1.affine
 color = line_colors(streamlines)
+
+# Enables/disables interactive visualization
+interactive = True
 
 """
 To speed up visualization, we will select a random sub-set of streamlines to
@@ -126,23 +129,24 @@ demonstration purposes, we subselect 900 streamlines.
 from dipy.tracking.streamline import select_random_set_of_streamlines
 plot_streamlines = select_random_set_of_streamlines(streamlines, 900)
 
-streamlines_actor = fvtk.streamtube(
+streamlines_actor = actor.streamtube(
     list(move_streamlines(plot_streamlines, inv(t1_aff))),
     line_colors(streamlines), linewidth=0.1)
 
-vol_actor = fvtk.slicer(t1_data)
+vol_actor = actor.slicer(t1_data)
 
 vol_actor.display(40, None, None)
 vol_actor2 = vol_actor.copy()
 vol_actor2.display(None, None, 35)
 
-ren = fvtk.ren()
-fvtk.add(ren, streamlines_actor)
-fvtk.add(ren, vol_actor)
-fvtk.add(ren, vol_actor2)
+ren = window.Renderer()
+ren.add(streamlines_actor)
+ren.add(vol_actor)
+ren.add(vol_actor2)
 
-fvtk.record(ren, n_frames=1, out_path='sfm_streamlines.png',
-            size=(800, 800))
+window.record(ren, out_path='sfm_streamlines.png', size=(800, 800))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: sfm_streamlines.png

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -63,7 +63,7 @@ plt.plot(signal, label='noiseless')
 
 plt.plot(signal_noisy, label='with noise')
 plt.legend()
-plt.show()
+#plt.show()
 plt.savefig('simulated_signal.png')
 
 """
@@ -85,17 +85,23 @@ sphere = sphere.subdivide(2)
 
 odf = multi_tensor_odf(sphere.vertices, mevals, angles, fractions)
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
-ren = fvtk.ren()
+# Enables/disables interactive visualization
+interactive = False
 
-odf_actor = fvtk.sphere_funcs(odf, sphere)
+ren = window.Renderer()
+
+odf_actor = actor.odf_slicer(odf[None, None, None, :], sphere=sphere, colormap='jet')
 odf_actor.RotateX(90)
 
-fvtk.add(ren, odf_actor)
+ren.add(odf_actor)
 
 print('Saving illustration as multi_tensor_simulation')
-fvtk.record(ren, out_path='multi_tensor_simulation.png', size=(300, 300))
+window.record(ren, out_path='multi_tensor_simulation.png', size=(300, 300))
+if interactive:
+    window.show(ren)
+
 
 """
 .. figure:: multi_tensor_simulation.png

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -111,25 +111,30 @@ Both, ``downsample`` and ``approx_polygon_track`` can be thought as methods for
 lossy compression of streamlines.
 """
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 
-ren = fvtk.ren()
-ren.SetBackground(*fvtk.colors.white)
-bundle_actor = fvtk.streamtube(bundle, fvtk.colors.red, linewidth=0.3)
+# Enables/disables interactive visualization
+interactive = False
 
-fvtk.add(ren, bundle_actor)
+ren = window.Renderer()
+ren.SetBackground(*window.colors.white)
+bundle_actor = actor.streamtube(bundle, window.colors.red, linewidth=0.3)
 
-bundle_actor2 = fvtk.streamtube(bundle_downsampled, fvtk.colors.red, linewidth=0.3)
+ren.add(bundle_actor)
+
+bundle_actor2 = actor.streamtube(bundle_downsampled, window.colors.red, linewidth=0.3)
 bundle_actor2.SetPosition(0, 40, 0)
 
-bundle_actor3 = fvtk.streamtube(bundle_downsampled2, fvtk.colors.red, linewidth=0.3)
+bundle_actor3 = actor.streamtube(bundle_downsampled2, window.colors.red, linewidth=0.3)
 bundle_actor3.SetPosition(0, 80, 0)
 
-fvtk.add(ren, bundle_actor2)
-fvtk.add(ren, bundle_actor3)
+ren.add(bundle_actor2)
+ren.add(bundle_actor3)
 
-fvtk.camera(ren, pos=(0, 0, 0), focal=(30, 0, 0))
-fvtk.record(ren, out_path='simulated_cosine_bundle.png', size=(900, 900))
+ren.set_camera(position=(0, 0, 0), focal_point=(30, 0, 0))
+window.record(out_path='simulated_cosine_bundle.png', size=(900, 900))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: simulated_cosine_bundle.png

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -94,34 +94,41 @@ above and all the streamlines that pass though that ROI. The ROI is the yellow
 region near the center of the axial image.
 """
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor, fvtk
 from dipy.viz.colormap import line_colors
+
+# Enables/disables interactive visualization
+interactive = False
 
 # Make display objects
 color = line_colors(cc_streamlines)
-cc_streamlines_actor = fvtk.line(cc_streamlines, line_colors(cc_streamlines))
+cc_streamlines_actor = actor.line(cc_streamlines, line_colors(cc_streamlines))
 cc_ROI_actor = fvtk.contour(cc_slice, levels=[1], colors=[(1., 1., 0.)],
                             opacities=[1.])
 
-vol_actor = fvtk.slicer(t1_data)
+vol_actor = actor.slicer(t1_data)
 
-vol_actor.display(40, None, None)
+vol_actor.display(x=40)
 vol_actor2 = vol_actor.copy()
-vol_actor2.display(None, None, 35)
+vol_actor2.display(z=35)
 
 # Add display objects to canvas
-r = fvtk.ren()
-fvtk.add(r, vol_actor)
-fvtk.add(r, vol_actor2)
-fvtk.add(r, cc_streamlines_actor)
-fvtk.add(r, cc_ROI_actor)
+r = window.Renderer()
+r.add(vol_actor)
+r.add(vol_actor2)
+r.add(cc_streamlines_actor)
+r.add(cc_ROI_actor)
 
 # Save figures
-fvtk.record(r, n_frames=1, out_path='corpuscallosum_axial.png',
-            size=(800, 800))
-fvtk.camera(r, [-1, 0, 0], [0, 0, 0], viewup=[0, 0, 1])
-fvtk.record(r, n_frames=1, out_path='corpuscallosum_sagittal.png',
-            size=(800, 800))
+window.record(r, n_frames=1, out_path='corpuscallosum_axial.png',
+              size=(800, 800))
+if interactive:
+    window.show(r)
+r.set_camera(position=[-1, 0, 0], focal_point=[0, 0, 0], view_up=[0, 0, 1])
+window.record(r, n_frames=1, out_path='corpuscallosum_sagittal.png',
+              size=(800, 800))
+if interactive:
+    window.show(r)
 
 """
 .. figure:: corpuscallosum_axial.png

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -94,7 +94,7 @@ above and all the streamlines that pass though that ROI. The ROI is the yellow
 region near the center of the axial image.
 """
 
-from dipy.viz import window, actor, fvtk
+from dipy.viz import window, actor
 from dipy.viz.colormap import line_colors
 
 # Enables/disables interactive visualization
@@ -103,8 +103,8 @@ interactive = False
 # Make display objects
 color = line_colors(cc_streamlines)
 cc_streamlines_actor = actor.line(cc_streamlines, line_colors(cc_streamlines))
-cc_ROI_actor = fvtk.contour(cc_slice, levels=[1], colors=[(1., 1., 0.)],
-                            opacities=[1.])
+cc_ROI_actor = actor.contour_from_roi(cc_slice, color=(1., 1., 0.),
+                                      opacity=0.5)
 
 vol_actor = actor.slicer(t1_data)
 

--- a/doc/examples/tracking_eudx_odf.py
+++ b/doc/examples/tracking_eudx_odf.py
@@ -61,19 +61,24 @@ csa_sl_fname = 'csa_streamline.trk'
 nib.trackvis.write(csa_sl_fname, csa_streamlines_trk, hdr, points_space='voxel')
 
 """
-Visualize the streamlines with fvtk (python vtk is required).
+Visualize the streamlines with `dipy.viz` module (python vtk is required).
 """
 
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.viz.colormap import line_colors
 
-r = fvtk.ren()
+# Enables/disables interactive visualization
+interactive = False
 
-fvtk.add(r, fvtk.line(csa_streamlines, line_colors(csa_streamlines)))
+ren = window.Renderer()
+
+ren.add(actor.line(csa_streamlines, line_colors(csa_streamlines)))
 
 print('Saving illustration as tensor_tracks.png')
 
-fvtk.record(r, n_frames=1, out_path='csa_tracking.png', size=(600, 600))
+window.record(ren, out_path='csa_tracking.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csa_tracking.png
@@ -94,13 +99,15 @@ eu = EuDX(csapeaks.peak_values,
 
 csa_streamlines_mult_peaks = [streamline for streamline in eu]
 
-fvtk.clear(r)
+window.clear(ren)
 
-fvtk.add(r, fvtk.line(csa_streamlines_mult_peaks, line_colors(csa_streamlines_mult_peaks)))
+ren.add(actor.line(csa_streamlines_mult_peaks, line_colors(csa_streamlines_mult_peaks)))
 
 print('Saving illustration as csa_tracking_mpeaks.png')
 
-fvtk.record(r, n_frames=1, out_path='csa_tracking_mpeaks.png', size=(600, 600))
+window.record(ren, out_path='csa_tracking_mpeaks.png', size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: csa_tracking_mpeaks.png

--- a/doc/examples/tracking_eudx_tensor.py
+++ b/doc/examples/tracking_eudx_tensor.py
@@ -123,8 +123,8 @@ Every streamline will be coloured according to its orientation
 from dipy.viz.colormap import line_colors
 
 """
-`actor.line` create a streamline actor for streamline visualization
-and `ren.add` adds this actor in the scene
+`actor.line` creates a streamline actor for streamline visualization
+and `ren.add` adds this actor to the scene
 """
 
 ren.add(actor.streamtube(tensor_streamlines, line_colors(tensor_streamlines)))

--- a/doc/examples/tracking_eudx_tensor.py
+++ b/doc/examples/tracking_eudx_tensor.py
@@ -15,7 +15,6 @@ tracking.
 """
 
 import os
-import sys
 import numpy as np
 import nibabel as nib
 
@@ -101,20 +100,21 @@ nib.trackvis.write(ten_sl_fname, tensor_streamlines_trk, hdr, points_space='voxe
 
 """
 If you don't want to use Trackvis to visualize the file you can use our
-lightweight `fvtk` module.
+lightweight `dipy.viz` module.
 """
 
 try:
-    from dipy.viz import fvtk
+    from dipy.viz import window, actor
 except ImportError:
     raise ImportError('Python vtk module is not installed')
+    import sys
     sys.exit()
 
 """
 Create a scene.
 """
 
-ren = fvtk.ren()
+ren = window.Renderer()
 
 """
 Every streamline will be coloured according to its orientation
@@ -123,16 +123,20 @@ Every streamline will be coloured according to its orientation
 from dipy.viz.colormap import line_colors
 
 """
-fvtk.line adds a streamline actor for streamline visualization
-and fvtk.add adds this actor in the scene
+`actor.line` create a streamline actor for streamline visualization
+and `ren.add` adds this actor in the scene
 """
 
-fvtk.add(ren, fvtk.streamtube(tensor_streamlines, line_colors(tensor_streamlines)))
+ren.add(actor.streamtube(tensor_streamlines, line_colors(tensor_streamlines)))
 
 print('Saving illustration as tensor_tracks.png')
 
 ren.SetBackground(1, 1, 1)
-fvtk.record(ren, n_frames=1, out_path='tensor_tracks.png', size=(600, 600))
+window.record(ren, out_path='tensor_tracks.png', size=(600, 600))
+# Enables/disables interactive visualization
+interactive = False
+if interactive:
+	window.show(ren)
 
 """
 .. figure:: tensor_tracks.png

--- a/doc/examples/tracking_tissue_classifier.py
+++ b/doc/examples/tracking_tissue_classifier.py
@@ -34,10 +34,13 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response)
 from dipy.tracking.local import LocalTracking
 from dipy.tracking import utils
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.viz.colormap import line_colors
 
-ren = fvtk.ren()
+# Enables/disables interactive visualization
+interactive = False
+
+ren = window.Renderer()
 
 hardi_img, gtab, labels_img = read_stanford_labels()
 _, _, img_pve_wm = read_stanford_pve_maps()
@@ -123,10 +126,12 @@ save_trk("deterministic_threshold_classifier_all.trk",
 
 streamlines = [sl for sl in all_streamlines_threshold_classifier]
 
-fvtk.clear(ren)
-fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
-fvtk.record(ren, out_path='all_streamlines_threshold_classifier.png',
-            size=(600, 600))
+window.clear(ren)
+ren.add(actor.line(streamlines, line_colors(streamlines)))
+window.record(ren, out_path='all_streamlines_threshold_classifier.png',
+              size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: all_streamlines_threshold_classifier.png
@@ -189,10 +194,12 @@ save_trk("deterministic_binary_classifier_all.trk",
          labels.shape)
 
 streamlines = [sl for sl in all_streamlines_binary_classifier]
-fvtk.clear(ren)
-fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
-fvtk.record(ren, out_path='all_streamlines_binary_classifier.png',
-            size=(600, 600))
+window.clear(ren)
+ren.add(actor.line(streamlines, line_colors(streamlines)))
+window.record(ren, out_path='all_streamlines_binary_classifier.png',
+              size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: all_streamlines_binary_classifier.png
@@ -277,10 +284,12 @@ save_trk("deterministic_act_classifier_all.trk",
 
 streamlines = [sl for sl in all_streamlines_act_classifier]
 
-fvtk.clear(ren)
-fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
-fvtk.record(ren, out_path='all_streamlines_act_classifier.png',
-            size=(600, 600))
+window.clear(ren)
+ren.add(actor.line(streamlines, line_colors(streamlines)))
+window.record(ren, out_path='all_streamlines_act_classifier.png',
+              size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: all_streamlines_act_classifier.png
@@ -303,10 +312,12 @@ save_trk("deterministic_act_classifier_valid.trk",
 
 streamlines = [sl for sl in valid_streamlines_act_classifier]
 
-fvtk.clear(ren)
-fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
-fvtk.record(ren, out_path='valid_streamlines_act_classifier.png',
-            size=(600, 600))
+window.clear(ren)
+ren.add(actor.line(streamlines, line_colors(streamlines)))
+window.record(ren, out_path='valid_streamlines_act_classifier.png',
+              size=(600, 600))
+if interactive:
+    window.show(ren)
 
 """
 .. figure:: valid_streamlines_act_classifier.png

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -108,15 +108,15 @@ Practical
 
 3. **What do you use for visualization?**
 
-  For 3D visualization we use ``fvtk`` which depends in turn on ``python-vtk``::
+  For 3D visualization we use ``dipy.viz`` which depends in turn on ``python-vtk``::
 
-    from dipy.viz import fvtk
+    from dipy.viz import window, actor
 
   For 2D visualization we use matplotlib_.
 
 4. **What about interactive visualization?**
 
-  There is already interaction in the ``fvtk`` module, but we have started a
+  There is already interaction in the ``dipy.viz`` module, but we have started a
   new project only for visualization which we plan to integrate in dipy_
   in the near future.  For more information, have a look at http://fos.me
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -114,13 +114,7 @@ Practical
 
   For 2D visualization we use matplotlib_.
 
-4. **What about interactive visualization?**
-
-  There is already interaction in the ``dipy.viz`` module, but we have started a
-  new project only for visualization which we plan to integrate in dipy_
-  in the near future.  For more information, have a look at http://fos.me
-
-5. **Which file formats do you support?**
+4. **Which file formats do you support?**
 
   Nifti (.nii), Dicom (Siemens(read-only)), Trackvis (.trk), DIPY (.dpy),
   Numpy (.npy, ,npz), text and any other formats supported by nibabel and
@@ -133,18 +127,18 @@ Practical
   For object serialization you can use ``dipy.io.pickles`` functions
   ``load_pickle``, ``save_pickle``.
 
-6. **What is dpy**?
+5. **What is dpy**?
 
   ``dpy`` is an ``hdf5`` file format which we use in DIPY to store
   tractography and other information. This allows us to store huge
   tractographies and load different parts of the datasets
   directly from the disk as if it were in memory.
 
-7. **Which python editor should I use?**
+6. **Which python editor should I use?**
 
   Any text editor would do the job but we prefer the following: PyCharm, Sublime, Aptana, Emacs, Vim and Eclipse (with PyDev).
 
-8. **I have problems reading my dicom files using nibabel, what should I do?**
+7. **I have problems reading my dicom files using nibabel, what should I do?**
 
   Use Chris Rorden's dcm2nii to transform them to nifti files.
   http://www.cabiatl.com/mricro/mricron/dcm2nii.html
@@ -152,7 +146,7 @@ Practical
   http://code.google.com/p/pydicom/
   and then use nibabel to store the data as niftis.
 
-9. **Where can I find diffusion data?**
+8. **Where can I find diffusion data?**
 
   Have a look at Beijing Enhanced
   http://fcon_1000.projects.nitrc.org/indi/IndiRetro.html

--- a/scratch/very_scratch/get_vertices.py
+++ b/scratch/very_scratch/get_vertices.py
@@ -37,36 +37,36 @@ def get_vertex_set(key):
         elif sphere_dic[key]['object'] == 'npy':
             vertices = np.load(filepath)
         elif entry['object'] == 'dicom':
-            data,affine,bvals,gradients=dcm.read_mosaic_dir(filepath)
-            #print (bvals.shape, gradients.shape)
-            grad3 = np.vstack((bvals,bvals,bvals)).transpose()
-            #print grad3.shape
-            #vertices = grad3*gradients
+            data,affine,bvals,gradients = dcm.read_mosaic_dir(filepath)
+            # print (bvals.shape, gradients.shape)
+            grad3 = np.vstack((bvals, bvals, bvals)).transpose()
+            # print grad3.shape
+            # vertices = grad3*gradients
             vertices = gradients
         if omit > 0:
-            vertices = vertices[omit:,:]
+            vertices = vertices[omit:, :]
         if entry['hemi']:
             vertices = np.vstack([vertices, -vertices])
 
-        return vertices[omit:,:]
+        return vertices[omit:, :]
 
-print sphere_dic.keys()
+print(sphere_dic.keys())
 
-#vertices = get_vertex_set('create5')
-#vertices = get_vertex_set('siem64')
-#vertices = get_vertex_set('dsi102')
+# vertices = get_vertex_set('create5')
+# vertices = get_vertex_set('siem64')
+# vertices = get_vertex_set('dsi102')
 
 vertices = get_vertex_set('fy362')
 gradients = get_vertex_set('siem64')
 gradients = gradients[:gradients.shape[0]/2]
-print gradients.shape
+print(gradients.shape)
 
-from dipy.viz import fvtk
-sph=-np.sinc(np.dot(gradients[1],vertices.T))
-r=fvtk.ren()
-#sph = np.arange(vertices.shape[0]) 
-print sph.shape
-cols=fvtk.colors(sph,'jet')
-fvtk.add(r,fvtk.point(vertices,cols,point_radius=.1,theta=10,phi=10))
-fvtk.show(r)
+from dipy.viz import window, actor
+sph = -np.sinc(np.dot(gradients[1], vertices.T))
+ren = window.Renderer()
+# sph = np.arange(vertices.shape[0])
+print(sph.shape)
+cols = window.colors(sph, 'jet')
+ren.add(actor.point(vertices, cols, point_radius=.1, theta=10, phi=10))
+window.show(ren)
 


### PR DESCRIPTION
The goal of this PR is to replace `fvtk` by the new `viz` API in all examples.  Most of the work is done.

Last work to do:
 
- [x]  create `tensor_slicer` in actor instead of using `fvtk.tensor`
- [x] replace `fvtk.contour` by something else. Maybe by #1165 from @kesshijordan in some case. 