### PR TITLE
ENH: Add support for ArraySequence in`set_number_of_points` function

### DIFF
--- a/dipy/tracking/benchmarks/bench_streamline.py
+++ b/dipy/tracking/benchmarks/bench_streamline.py
@@ -99,8 +99,8 @@ def bench_length():
     print("Speed up of {0:.2f}x".format(python_time/cython_time))
 
     # Make sure it produces the same results.
-    assert_array_equal([length_python(s) for s in DATA["streamlines"]],
-                       length(DATA["streamlines"]))
+    assert_array_almost_equal([length_python(s) for s in DATA["streamlines"]],
+                              length(DATA["streamlines"]))
 
     streamlines = DATA['streamlines_arrseq']
     cython_time_arrseq = measure("length(streamlines)", repeat)

--- a/dipy/tracking/benchmarks/bench_streamline.py
+++ b/dipy/tracking/benchmarks/bench_streamline.py
@@ -15,7 +15,7 @@ Run this benchmark with:
 """
 import numpy as np
 from numpy.testing import measure
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from dipy.data import get_data
 from nibabel import trackvis as tv
@@ -54,29 +54,34 @@ def generate_streamlines(nb_streamlines, min_nb_points, max_nb_points, rng):
 
 
 def bench_set_number_of_points():
-    repeat = 1
-    nb_points_per_streamline = 100
+    repeat = 5
     nb_points = 42
-    nb_streamlines = int(1e4)
-    streamlines = [np.random.rand(nb_points_per_streamline,
-                                  3).astype("float32")
-                   for i in range(nb_streamlines)]
+    nb_streamlines = DATA['nb_streamlines']
+    streamlines = DATA["streamlines"]  # Streamlines as a list of ndarrays.
 
-    print("Timing set_number_of_points() in Cython"
-          "({0} streamlines)".format(nb_streamlines))
+    msg = "Timing set_number_of_points() with {0:,} streamlines."
+    print(msg.format(nb_streamlines * repeat))
     cython_time = measure("set_number_of_points(streamlines, nb_points)",
                           repeat)
-    print("Cython time: {0:.3}sec".format(cython_time))
-    del streamlines
+    print("Cython time: {0:.3f} sec".format(cython_time))
 
-    streamlines = [np.random.rand(nb_points_per_streamline,
-                                  3).astype("float32")
-                   for i in range(nb_streamlines)]
     python_time = measure("[set_number_of_points_python(s, nb_points)"
                           " for s in streamlines]", repeat)
-    print("Python time: {0:.2}sec".format(python_time))
-    print("Speed up of {0}x".format(python_time/cython_time))
-    del streamlines
+    print("Python time: {0:.2f} sec".format(python_time))
+    print("Speed up of {0:.2f}x".format(python_time/cython_time))
+
+    # Make sure it produces the same results.
+    assert_array_almost_equal([set_number_of_points_python(s) for s in DATA["streamlines"]],
+                              set_number_of_points(DATA["streamlines"]))
+
+    streamlines = DATA['streamlines_arrseq']
+    cython_time_arrseq = measure("set_number_of_points(streamlines, nb_points)", repeat)
+    print("Cython time (ArrSeq): {0:.3f} sec".format(cython_time_arrseq))
+    print("Speed up of {0:.2f}x".format(python_time/cython_time_arrseq))
+
+    # Make sure it produces the same results.
+    assert_array_equal(set_number_of_points(DATA["streamlines"]),
+                       set_number_of_points(DATA["streamlines_arrseq"]))
 
 
 def bench_length():
@@ -84,12 +89,13 @@ def bench_length():
     nb_streamlines = DATA['nb_streamlines']
     streamlines = DATA["streamlines"]  # Streamlines as a list of ndarrays.
 
-    print("Timing length() with {0:,} streamlines.".format(nb_streamlines))
+    msg = "Timing length() with {0:,} streamlines."
+    print(msg.format(nb_streamlines * repeat))
     python_time = measure("[length_python(s) for s in streamlines]", repeat)
-    print("Python time: {0:.2}sec".format(python_time))
+    print("Python time: {0:.2f} sec".format(python_time))
 
     cython_time = measure("length(streamlines)", repeat)
-    print("Cython time: {0:.3}sec".format(cython_time))
+    print("Cython time: {0:.3f} sec".format(cython_time))
     print("Speed up of {0:.2f}x".format(python_time/cython_time))
 
     # Make sure it produces the same results.
@@ -98,7 +104,7 @@ def bench_length():
 
     streamlines = DATA['streamlines_arrseq']
     cython_time_arrseq = measure("length(streamlines)", repeat)
-    print("Cython time (ArrSeq): {0:.3}sec".format(cython_time_arrseq))
+    print("Cython time (ArrSeq): {0:.3f} sec".format(cython_time_arrseq))
     print("Speed up of {0:.2f}x".format(python_time/cython_time_arrseq))
 
     # Make sure it produces the same results.

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -379,18 +379,15 @@ def set_number_of_points(streamlines, nb_points=3):
 
                 streamline = streamline.astype(dtype)
 
-            new_modified_streamline = np.empty((nb_points,
-                                                streamline.shape[1]),
-                                               dtype=dtype)
+            new_streamline = np.empty((nb_points, streamline.shape[1]),
+                                      dtype=dtype)
             if dtype == np.float32:
-                c_set_number_of_points[float2d](streamline,
-                                                modified_streamline)
+                c_set_number_of_points[float2d](streamline, new_streamline)
             else:
-                c_set_number_of_points[double2d](streamline,
-                                                 modified_streamline)
+                c_set_number_of_points[double2d](streamline, new_streamline)
 
             # HACK: To avoid memleaks we have to recast with astype(dtype).
-            new_streamlines.append(modified_streamline.astype(dtype))
+            new_streamlines.append(new_streamline.astype(dtype))
 
     elif dtype == np.float32:
         # All streamlines have composed of float32 points

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -114,7 +114,6 @@ def length(streamlines):
                                       streamlines._lengths.astype(np.intp),
                                       arclengths)
 
-
         return arclengths
 
     only_one_streamlines = False
@@ -201,7 +200,7 @@ cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
         np.npy_intp N = streamline.shape[0]
         np.npy_intp D = streamline.shape[1]
         np.npy_intp new_N = out.shape[0]
-        double ratio, step, next_point
+        double ratio, step, next_point, delta
         np.npy_intp i, j, k, dim
 
     # Get arclength at each point.
@@ -218,17 +217,19 @@ cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
     while next_point < arclengths[N-1]:
         if next_point == arclengths[k]:
             for dim in range(D):
-                out[i,dim] = streamline[j,dim];
+                out[i, dim] = streamline[j, dim]
 
             next_point += step
             i += 1
             j += 1
             k += 1
         elif next_point < arclengths[k]:
-            ratio = 1 - ((arclengths[k]-next_point) / (arclengths[k]-arclengths[k-1]))
+            ratio = 1 - ((arclengths[k]-next_point) /
+                         (arclengths[k]-arclengths[k-1]))
 
             for dim in range(D):
-                out[i,dim] = streamline[j-1,dim] + ratio * (streamline[j,dim] - streamline[j-1,dim])
+                delta = streamline[j, dim] - streamline[j-1, dim]
+                out[i, dim] = streamline[j-1, dim] + ratio * delta
 
             next_point += step
             i += 1
@@ -238,12 +239,16 @@ cdef void c_set_number_of_points(Streamline streamline, Streamline out) nogil:
 
     # Last resampled point always the one from original streamline.
     for dim in range(D):
-        out[new_N-1,dim] = streamline[N-1,dim]
+        out[new_N-1, dim] = streamline[N-1, dim]
 
     free(arclengths)
 
 
-cdef void c_set_number_of_points_from_arraysequence(Streamline points, long[:] offsets, long[:] lengths, long nb_points, Streamline out) nogil:
+cdef void c_set_number_of_points_from_arraysequence(Streamline points,
+                                                    np.npy_intp[:] offsets,
+                                                    np.npy_intp[:] lengths,
+                                                    long nb_points,
+                                                    Streamline out) nogil:
     cdef:
         np.npy_intp i, j, k
         np.npy_intp offset, length
@@ -253,15 +258,6 @@ cdef void c_set_number_of_points_from_arraysequence(Streamline points, long[:] o
     for i in range(offsets.shape[0]):
         offset = offsets[i]
         length = lengths[i]
-
-        #arclengths[i] = 0
-        #for j in range(1, lengths[i]):
-        #    sum_dn_sqr = 0.0
-        #    for k in range(points.shape[1]):
-        #        dn = points[offset+j, k] - points[offset+j-1, k]
-        #        sum_dn_sqr += dn*dn
-
-        #    arclengths[i] += sqrt(sum_dn_sqr)
 
         c_set_number_of_points(points[offset:offset+length, :],
                                out[offset_out:offset_out+nb_points, :])
@@ -279,21 +275,28 @@ def set_number_of_points(streamlines, nb_points=3):
 
     Parameters
     ----------
-    streamlines : one or a list of array-like shape (N,3)
-       array representing x,y,z of N points in a streamline
+    streamlines : ndarray or a list or :class:`dipy.tracking.Streamlines`
+        If ndarray, must have shape (N,3) where N is the number of points
+        of the streamline.
+        If list, each item must be ndarray shape (Ni,3) where Ni is the number
+        of points of streamline i.
+        If :class:`dipy.tracking.Streamlines`, its `common_shape` must be 3.
+
     nb_points : int
-       integer representing number of points wanted along the curve.
+        integer representing number of points wanted along the curve.
 
     Returns
     -------
-    modified_streamlines : one or a list of array-like shape (`nb_points`,3)
-       array representing x,y,z of `nb_points` points that were interpolated.
+    new_streamlines : ndarray or a list or :class:`dipy.tracking.Streamlines`
+        Results of the downsampling or upsampling process.
 
     Examples
     --------
     >>> from dipy.tracking.streamline import set_number_of_points
     >>> import numpy as np
-    >>> # One streamline: a semi-circle
+
+    One streamline, a semi-circle:
+
     >>> theta = np.pi*np.linspace(0, 1, 100)
     >>> x = np.cos(theta)
     >>> y = np.sin(theta)
@@ -302,12 +305,14 @@ def set_number_of_points(streamlines, nb_points=3):
     >>> modified_streamline = set_number_of_points(streamline, 3)
     >>> len(modified_streamline)
     3
-    >>> # Multiple streamlines
+
+    Multiple streamlines:
+
     >>> streamlines = [streamline, streamline[::2]]
-    >>> modified_streamlines = set_number_of_points(streamlines, 10)
+    >>> new_streamlines = set_number_of_points(streamlines, 10)
     >>> [len(s) for s in streamlines]
     [100, 50]
-    >>> [len(s) for s in modified_streamlines]
+    >>> [len(s) for s in new_streamlines]
     [10, 10]
 
     '''
@@ -315,18 +320,28 @@ def set_number_of_points(streamlines, nb_points=3):
         if len(streamlines) == 0:
             return Streamlines()
 
+        nb_streamlines = len(streamlines)
         dtype = streamlines._data.dtype
-        modified_streamlines = Streamlines()
-        modified_streamlines._data = np.zeros((len(streamlines)*nb_points, 3), dtype=dtype)
-        modified_streamlines._offsets = nb_points * np.arange(len(streamlines), dtype=np.intp)
-        modified_streamlines._lengths = nb_points * np.ones(len(streamlines), dtype=np.intp)
+        new_streamlines = Streamlines()
+        new_streamlines._data = np.zeros((nb_streamlines * nb_points, 3),
+                                         dtype=dtype)
+        new_streamlines._offsets = nb_points * np.arange(nb_streamlines,
+                                                         dtype=np.intp)
+        new_streamlines._lengths = nb_points * np.ones(nb_streamlines,
+                                                       dtype=np.intp)
 
         if dtype == np.float32:
-            c_set_number_of_points_from_arraysequence[float2d](streamlines._data, streamlines._offsets, streamlines._lengths, nb_points, modified_streamlines._data)
+            c_set_number_of_points_from_arraysequence[float2d](
+                streamlines._data, streamlines._offsets,
+                streamlines._lengths, nb_points,
+                new_streamlines._data)
         else:
-            c_set_number_of_points_from_arraysequence[double2d](streamlines._data, streamlines._offsets, streamlines._lengths, nb_points, modified_streamlines._data)
+            c_set_number_of_points_from_arraysequence[double2d](
+                streamlines._data, streamlines._offsets,
+                streamlines._lengths, nb_points,
+                new_streamlines._data)
 
-        return modified_streamlines
+        return new_streamlines
 
     only_one_streamlines = False
     if type(streamlines) is np.ndarray:
@@ -348,7 +363,7 @@ def set_number_of_points(streamlines, nb_points=3):
             raise ValueError("All streamlines must have at least 2 points.")
 
     # Allocate memory for each modified streamline
-    modified_streamlines = []
+    new_streamlines = []
     cdef np.npy_intp i
 
     if dtype is None:
@@ -358,55 +373,68 @@ def set_number_of_points(streamlines, nb_points=3):
             # HACK: To avoid memleaks we have to recast with astype(dtype).
             streamline = streamlines[i].astype(dtype)
             if dtype != np.float32 and dtype != np.float64:
-                dtype = np.float64 if dtype == np.int64 or dtype == np.uint64 else np.float32
+                dtype = np.float32
+                if dtype == np.int64 or dtype == np.uint64:
+                    dtype = np.float64
+
                 streamline = streamline.astype(dtype)
 
-            modified_streamline = np.empty((nb_points, streamline.shape[1]), dtype=dtype)
+            new_modified_streamline = np.empty((nb_points,
+                                                streamline.shape[1]),
+                                               dtype=dtype)
             if dtype == np.float32:
-                c_set_number_of_points[float2d](streamline, modified_streamline)
+                c_set_number_of_points[float2d](streamline,
+                                                modified_streamline)
             else:
-                c_set_number_of_points[double2d](streamline, modified_streamline)
+                c_set_number_of_points[double2d](streamline,
+                                                 modified_streamline)
 
             # HACK: To avoid memleaks we have to recast with astype(dtype).
-            modified_streamlines.append(modified_streamline.astype(dtype))
+            new_streamlines.append(modified_streamline.astype(dtype))
 
     elif dtype == np.float32:
         # All streamlines have composed of float32 points
         for i in range(len(streamlines)):
             streamline = streamlines[i].astype(dtype)
-            modified_streamline = np.empty((nb_points, streamline.shape[1]), dtype=streamline.dtype)
+            modified_streamline = np.empty((nb_points, streamline.shape[1]),
+                                           dtype=streamline.dtype)
             c_set_number_of_points[float2d](streamline, modified_streamline)
             # HACK: To avoid memleaks we have to recast with astype(dtype).
-            modified_streamlines.append(modified_streamline.astype(dtype))
+            new_streamlines.append(modified_streamline.astype(dtype))
     elif dtype == np.float64:
         # All streamlines are composed of float64 points
         for i in range(len(streamlines)):
             streamline = streamlines[i].astype(dtype)
-            modified_streamline = np.empty((nb_points, streamline.shape[1]), dtype=streamline.dtype)
+            modified_streamline = np.empty((nb_points, streamline.shape[1]),
+                                           dtype=streamline.dtype)
             c_set_number_of_points[double2d](streamline, modified_streamline)
             # HACK: To avoid memleaks we have to recast with astype(dtype).
-            modified_streamlines.append(modified_streamline.astype(dtype))
+            new_streamlines.append(modified_streamline.astype(dtype))
     elif dtype == np.int64 or dtype == np.uint64:
-        # All streamlines are composed of int64 or uint64 points so convert them in float64 one at the time
+        # All streamlines are composed of int64 or uint64 points so convert
+        # them in float64 one at the time
         for i in range(len(streamlines)):
             streamline = streamlines[i].astype(np.float64)
-            modified_streamline = np.empty((nb_points, streamline.shape[1]), dtype=streamline.dtype)
+            modified_streamline = np.empty((nb_points, streamline.shape[1]),
+                                           dtype=streamline.dtype)
             c_set_number_of_points[double2d](streamline, modified_streamline)
-            # HACK: To avoid memleaks we have to recast with astype(np.float64).
-            modified_streamlines.append(modified_streamline.astype(np.float64))
+            # HACK: To avoid memleaks we've to recast with astype(np.float64).
+            new_streamlines.append(modified_streamline.astype(np.float64))
     else:
-        # All streamlines are composed of points with a dtype fitting in 32bits so convert them in float32 one at the time
+        # All streamlines are composed of points with a dtype fitting in
+        # 32bits so convert them in float32 one at the time
         for i in range(len(streamlines)):
             streamline = streamlines[i].astype(np.float32)
-            modified_streamline = np.empty((nb_points, streamline.shape[1]), dtype=streamline.dtype)
+            modified_streamline = np.empty((nb_points, streamline.shape[1]),
+                                           dtype=streamline.dtype)
             c_set_number_of_points[float2d](streamline, modified_streamline)
-            # HACK: To avoid memleaks we have to recast with astype(np.float32).
-            modified_streamlines.append(modified_streamline.astype(np.float32))
+            # HACK: To avoid memleaks we've to recast with astype(np.float32).
+            new_streamlines.append(modified_streamline.astype(np.float32))
 
     if only_one_streamlines:
-        return modified_streamlines[0]
+        return new_streamlines[0]
     else:
-        return modified_streamlines
+        return new_streamlines
 
 
 cdef double c_norm_of_cross_product(double bx, double by, double bz,

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -332,13 +332,13 @@ def set_number_of_points(streamlines, nb_points=3):
 
         if dtype == np.float32:
             c_set_number_of_points_from_arraysequence[float2d](
-                streamlines._data, streamlines._offsets,
-                streamlines._lengths, nb_points,
+                streamlines._data, streamlines._offsets.astype(np.intp),
+                streamlines._lengths.astype(np.intp), nb_points,
                 new_streamlines._data)
         else:
             c_set_number_of_points_from_arraysequence[double2d](
-                streamlines._data, streamlines._offsets,
-                streamlines._lengths, nb_points,
+                streamlines._data, streamlines._offsets.astype(np.intp),
+                streamlines._lengths.astype(np.intp), nb_points,
                 new_streamlines._data)
 
         return new_streamlines

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -198,57 +198,61 @@ def set_number_of_points_python(xyz, n_pols=3):
 def test_set_number_of_points():
     # Test resampling of only one streamline
     nb_points = 12
-    modified_streamline_cython = set_number_of_points(
+    new_streamline_cython = set_number_of_points(
         streamline, nb_points)
-    modified_streamline_python = set_number_of_points_python(
+    new_streamline_python = set_number_of_points_python(
         streamline, nb_points)
-    assert_equal(len(modified_streamline_cython), nb_points)
+    assert_equal(len(new_streamline_cython), nb_points)
     # Using a 5 digits precision because of streamline is in float32.
-    assert_array_almost_equal(modified_streamline_cython,
-                              modified_streamline_python, 5)
+    assert_array_almost_equal(new_streamline_cython,
+                              new_streamline_python, 5)
 
-    modified_streamline_cython = set_number_of_points(
+    new_streamline_cython = set_number_of_points(
         streamline_64bit, nb_points)
-    modified_streamline_python = set_number_of_points_python(
+    new_streamline_python = set_number_of_points_python(
         streamline_64bit, nb_points)
-    assert_equal(len(modified_streamline_cython), nb_points)
-    assert_array_almost_equal(modified_streamline_cython,
-                              modified_streamline_python)
+    assert_equal(len(new_streamline_cython), nb_points)
+    assert_array_almost_equal(new_streamline_cython,
+                              new_streamline_python)
 
     res = []
     simple_streamline = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]], 'f4')
     for nb_points in range(2, 200):
-        modified_streamline_cython = set_number_of_points(
+        new_streamline_cython = set_number_of_points(
             simple_streamline, nb_points)
-        res.append(nb_points - len(modified_streamline_cython))
+        res.append(nb_points - len(new_streamline_cython))
     assert_equal(np.sum(res), 0)
 
     # Test resampling of multiple streamlines of different nb_points
     nb_points = 12
-    modified_streamlines_cython = set_number_of_points(
+    new_streamlines_cython = set_number_of_points(
         streamlines, nb_points)
 
     for i, s in enumerate(streamlines):
-        modified_streamline_python = set_number_of_points_python(s, nb_points)
+        new_streamline_python = set_number_of_points_python(s, nb_points)
         # Using a 5 digits precision because of streamline is in float32.
-        assert_array_almost_equal(modified_streamlines_cython[i],
-                                  modified_streamline_python, 5)
+        assert_array_almost_equal(new_streamlines_cython[i],
+                                  new_streamline_python, 5)
 
     # ArraySequence
-    modified_streamlines_as_seq_cython = set_number_of_points(Streamlines(streamlines), nb_points)
-    assert_array_almost_equal(modified_streamlines_as_seq_cython, modified_streamlines_cython)
+    arrseq = Streamlines(streamlines)
+    new_streamlines_as_seq_cython = set_number_of_points(arrseq, nb_points)
+    assert_array_almost_equal(new_streamlines_as_seq_cython,
+                              new_streamlines_cython)
 
-    modified_streamlines_cython = set_number_of_points(
+    new_streamlines_cython = set_number_of_points(
         streamlines_64bit, nb_points)
 
     for i, s in enumerate(streamlines_64bit):
-        modified_streamline_python = set_number_of_points_python(s, nb_points)
-        assert_array_almost_equal(modified_streamlines_cython[i],
-                                  modified_streamline_python)
+        new_streamline_python = set_number_of_points_python(s, nb_points)
+        assert_array_almost_equal(new_streamlines_cython[i],
+                                  new_streamline_python)
 
     # ArraySequence
-    modified_streamlines_as_seq_cython = set_number_of_points(Streamlines(streamlines_64bit), nb_points)
-    assert_array_almost_equal(modified_streamlines_as_seq_cython, modified_streamlines_cython)
+    arrseq = Streamlines(streamlines_64bit)
+    new_streamlines_as_seq_cython = set_number_of_points(arrseq, nb_points)
+    assert_array_almost_equal(new_streamlines_as_seq_cython,
+                              new_streamlines_cython)
 
     # Test streamlines with mixed dtype
     streamlines_mixed_dtype = [streamline,
@@ -261,19 +265,19 @@ def test_set_number_of_points():
                        [nb_points] * len(streamlines_mixed_dtype))
 
     # Test streamlines with different shape
-    modified_streamlines_cython = set_number_of_points(
+    new_streamlines_cython = set_number_of_points(
         heterogeneous_streamlines, nb_points)
 
     for i, s in enumerate(heterogeneous_streamlines):
-        modified_streamline_python = set_number_of_points_python(s, nb_points)
-        assert_array_almost_equal(modified_streamlines_cython[i],
-                                  modified_streamline_python)
+        new_streamline_python = set_number_of_points_python(s, nb_points)
+        assert_array_almost_equal(new_streamlines_cython[i],
+                                  new_streamline_python)
 
     # Test streamline with integer dtype
-    modified_streamline = set_number_of_points(streamline.astype(np.int32))
-    assert_true(modified_streamline.dtype == np.float32)
-    modified_streamline = set_number_of_points(streamline.astype(np.int64))
-    assert_true(modified_streamline.dtype == np.float64)
+    new_streamline = set_number_of_points(streamline.astype(np.int32))
+    assert_true(new_streamline.dtype == np.float32)
+    new_streamline = set_number_of_points(streamline.astype(np.int64))
+    assert_true(new_streamline.dtype == np.float64)
 
     # Test empty list
     assert_equal(set_number_of_points([]), [])
@@ -283,7 +287,8 @@ def test_set_number_of_points():
 
     # We do not support list of lists, it should be numpy ndarray.
     streamline_unsupported = [[1, 2, 3], [4, 5, 5], [2, 1, 3], [4, 2, 1]]
-    assert_raises(AttributeError, set_number_of_points, streamline_unsupported)
+    assert_raises(AttributeError,
+                  set_number_of_points, streamline_unsupported)
 
     # Test setting number of points of a numpy with flag WRITABLE=False
     streamline_readonly = streamline.copy()
@@ -297,7 +302,8 @@ def test_set_number_of_points():
         streamlines_readonly.append(s.copy())
         streamlines_readonly[-1].setflags(write=False)
 
-    assert_equal(len(set_number_of_points(streamlines_readonly, nb_points=42)),
+    assert_equal(len(set_number_of_points_python(streamlines_readonly,
+                                                 nb_points=42)),
                  len(streamlines_readonly))
 
     streamlines_readonly = []
@@ -305,7 +311,8 @@ def test_set_number_of_points():
         streamlines_readonly.append(s.copy())
         streamlines_readonly[-1].setflags(write=False)
 
-    assert_equal(len(set_number_of_points(streamlines_readonly, nb_points=42)),
+    assert_equal(len(set_number_of_points(streamlines_readonly,
+                                          nb_points=42)),
                  len(streamlines_readonly))
 
     # Test if nb_points is less than 2
@@ -716,6 +723,7 @@ def test_compress_streamlines_memory_leaks():
     # one since we kept the returned value.
     assert_equal(list_refcount_after, list_refcount_before+1)
 
+
 def generate_sl(streamlines):
     """
     Helper function that takes a sequence and returns a generator
@@ -917,9 +925,9 @@ def test_orient_by_rois():
     npt.assert_raises(ValueError, orient_by_rois, *[generate_sl(streamlines),
                                                     mask1_vol,
                                                     mask2_vol],
-                                                   **dict(in_place=True,
-                                                          affine=None,
-                                                          as_generator=True))
+                      **dict(in_place=True,
+                             affine=None,
+                             as_generator=True))
 
     # But you can input a generator and get a non-generator as output:
     new_streamlines = orient_by_rois(generate_sl(streamlines),

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -302,8 +302,8 @@ def test_set_number_of_points():
         streamlines_readonly.append(s.copy())
         streamlines_readonly[-1].setflags(write=False)
 
-    assert_equal(len(set_number_of_points_python(streamlines_readonly,
-                                                 nb_points=42)),
+    assert_equal(len(set_number_of_points(streamlines_readonly,
+                                          nb_points=42)),
                  len(streamlines_readonly))
 
     streamlines_readonly = []

--- a/dipy/tracking/tests/test_streamline.py
+++ b/dipy/tracking/tests/test_streamline.py
@@ -234,6 +234,10 @@ def test_set_number_of_points():
         assert_array_almost_equal(modified_streamlines_cython[i],
                                   modified_streamline_python, 5)
 
+    # ArraySequence
+    modified_streamlines_as_seq_cython = set_number_of_points(Streamlines(streamlines), nb_points)
+    assert_array_almost_equal(modified_streamlines_as_seq_cython, modified_streamlines_cython)
+
     modified_streamlines_cython = set_number_of_points(
         streamlines_64bit, nb_points)
 
@@ -241,6 +245,10 @@ def test_set_number_of_points():
         modified_streamline_python = set_number_of_points_python(s, nb_points)
         assert_array_almost_equal(modified_streamlines_cython[i],
                                   modified_streamline_python)
+
+    # ArraySequence
+    modified_streamlines_as_seq_cython = set_number_of_points(Streamlines(streamlines_64bit), nb_points)
+    assert_array_almost_equal(modified_streamlines_as_seq_cython, modified_streamlines_cython)
 
     # Test streamlines with mixed dtype
     streamlines_mixed_dtype = [streamline,


### PR DESCRIPTION
Second small PR that aims to support Nibabel's `ArraySequence`objects (the first one was #1076).

Specifically, this PR improves `dipy.tracking.streamlinespeed.set_number_of_points` to support `ArraySequence` objects. This gives pretty good speedup even over the current Cython version (all speedups are with respect to the Python implementation):

```bash
Timing set_number_of_points() in 100,000 streamlines.
Cython time: 0.590 sec
Python time: 61.76 sec
Speed up of 104.68x
Cython time (ArrSeq): 0.13 sec
Speed up of 475.08x
```