### PR TITLE
From tables to h5py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     - python: 2.7
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.25.1 numpy==1.7.1 scipy==0.9.0 nibabel==2.1.0"
+        - DEPENDS="cython==0.25.1 numpy==1.7.1 scipy==0.9.0 nibabel==2.1.0 h5py==2.4.0"
     - python: 2.7
       env:
         - DEPENDS="$DEPENDS scikit_learn"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 addons:
   apt:
     packages:
-      # For runs with pytables
       - libhdf5-serial-dev
 
 env:
@@ -39,11 +38,11 @@ matrix:
         - DEPENDS="cython==0.25.1 numpy==1.7.1 scipy==0.9.0 nibabel==2.1.0"
     - python: 2.7
       env:
-        - DEPENDS="$DEPENDS scikit_learn tables"
+        - DEPENDS="$DEPENDS scikit_learn"
     - python: 3.5
       env:
         - COVERAGE=1
-        - DEPENDS="$DEPENDS scikit_learn tables"
+        - DEPENDS="$DEPENDS scikit_learn"
     # To test vtk functionality
     - python: 2.7
       sudo: true   # This is set to true for apt-get
@@ -54,7 +53,7 @@ matrix:
         - LIBGL_ALWAYS_INDIRECT=y
         - VENV_ARGS="--system-site-packages --python=/usr/bin/python2.7"
         - TEST_WITH_XVFB=true
-        - DEPENDS="$DEPENDS scikit_learn tables"
+        - DEPENDS="$DEPENDS scikit_learn"
 
     - python: 2.7
       env:

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -83,6 +83,7 @@ CYTHON_MIN_VERSION='0.25.1'
 NUMPY_MIN_VERSION='1.7.1'
 SCIPY_MIN_VERSION='0.9'
 NIBABEL_MIN_VERSION='2.1.0'
+H5PY_MIN_VERSION='2.4.0'
 
 # Main setup parameters
 NAME                = 'dipy'
@@ -105,4 +106,5 @@ VERSION             = __version__
 PROVIDES            = ["dipy"]
 REQUIRES            = ["numpy (>=%s)" % NUMPY_MIN_VERSION,
                        "scipy (>=%s)" % SCIPY_MIN_VERSION,
-                       "nibabel (>=%s)" % NIBABEL_MIN_VERSION]
+                       "nibabel (>=%s)" % NIBABEL_MIN_VERSION,
+                       "h5py (>=%s)" % H5PY_MIN_VERSION]

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -51,8 +51,7 @@ class Dpy(object):
         ...     T=dpr.read_tracksi([0,1,2,0,0,2])
         ...     dpr.close()
         ...     os.remove(fname) #delete file from disk
-        >>> dpy_example()  # skip if not have_tables
-
+        >>> dpy_example()
         """
 
         self.mode = mode

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -56,12 +56,11 @@ class Dpy(object):
 
         self.mode = mode
         self.f = h5py.File(fname, mode=self.mode)
-        self.N = 5 * 10**9
         self.compression = compression
 
         if self.mode == 'w':
 
-            self.f.attrs['version'] = np.string_('0.0.1')
+            self.f.attrs['version'] = '0.0.1'
 
             self.streamlines = self.f.create_group('streamlines')
 
@@ -88,9 +87,7 @@ class Dpy(object):
 
     def version(self):
 
-        # ver = self.f.root.version[:]
-        # return ver[0].decode()
-        return self.f.attrs['version'][:]
+        return self.f.attrs['version']
 
     def write_track(self, track):
         """ write on track each time
@@ -99,8 +96,6 @@ class Dpy(object):
         self.tracks[-track.shape[0]:] = track.astype(np.float32)
         self.curr_pos += track.shape[0]
 
-        #from pdb import set_trace
-        #set_trace()
         self.offsets.resize(self.offsets.shape[0] + 1, axis=0)
         self.offsets[-1] = self.curr_pos
 

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -60,7 +60,7 @@ class Dpy(object):
 
         if self.mode == 'w':
 
-            self.f.attrs['version'] = '0.0.1'
+            self.f.attrs['version'] = u'0.0.1'
 
             self.streamlines = self.f.create_group('streamlines')
 

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -1,6 +1,6 @@
 """ A class for handling large tractography datasets.
 
-    It is built using the pytables tools which in turn implement
+    It is built using the h5py which in turn implement
     key features of the HDF5 (hierachical data format) API [1]_.
 
     References

--- a/dipy/io/dpy.py
+++ b/dipy/io/dpy.py
@@ -60,12 +60,9 @@ class Dpy(object):
 
         if self.mode == 'w':
 
-            self.streamlines = f.create_group('streamlines')
+            self.f.attrs['version'] = np.string_('0.0.1')
 
-            # create a version number
-            self.version = self.streamlines.create_dataset(
-                    'version',
-                    [b"0.0.2"])
+            self.streamlines = self.f.create_group('streamlines')
 
             self.tracks = self.streamlines.create_dataset(
                     'tracks',
@@ -75,12 +72,12 @@ class Dpy(object):
 
             self.offsets = self.streamlines.create_dataset(
                     'offsets',
-                    shape=(0,),
+                    shape=(1,),
                     dtype='i8',
                     maxshape=(None))
 
             self.curr_pos = 0
-            self.offsets.append(np.array([self.curr_pos]).astype(np.int64))
+            self.offsets[:] = np.array([self.curr_pos]).astype(np.int64)
 
         if self.mode == 'r':
             self.tracks = self.f['streamlines']['tracks']
@@ -89,8 +86,10 @@ class Dpy(object):
             self.offs_pos = 0
 
     def version(self):
-        ver = self.f.root.version[:]
-        return ver[0].decode()
+
+        # ver = self.f.root.version[:]
+        # return ver[0].decode()
+        return self.f.attrs['version'][:]
 
     def write_track(self, track):
         """ write on track each time

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -60,16 +60,16 @@ def load_peaks(fname, verbose=False):
     except KeyError:
         affine = None
 
-    peak_dirs = pamh.peak_dirs[:]
-    peak_values = pamh.peak_values[:]
-    peak_indices = pamh.peak_indices[:]
+    peak_dirs = pamh['peak_dirs'][:]
+    peak_values = pamh['peak_values'][:]
+    peak_indices = pamh['peak_indices'][:]
 
     try:
         shm_coeff = pamh['shm_coeff'][:]
     except KeyError:
         shm_coeff = None
 
-    sphere_vertices = pamh.sphere_vertices[:]
+    sphere_vertices = pamh['sphere_vertices'][:]
 
     try:
         odf = pamh['odf'][:]
@@ -82,11 +82,11 @@ def load_peaks(fname, verbose=False):
     pam.peak_indices = peak_indices
     pam.shm_coeff = shm_coeff
     pam.sphere = Sphere(xyz=sphere_vertices)
-    pam.B = pamh.B[:]
-    pam.total_weight = pamh.total_weight[:][0]
-    pam.ang_thr = pamh.ang_thr[:][0]
-    pam.gfa = pamh.gfa[:]
-    pam.qa = pamh.qa[:]
+    pam.B = pamh['B'][:]
+    pam.total_weight = pamh['total_weight'][:][0]
+    pam.ang_thr = pamh['ang_thr'][:][0]
+    pam.gfa = pamh['gfa'][:]
+    pam.qa = pamh['qa'][:]
     pam.odf = odf
 
     f.close()

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -41,7 +41,7 @@ def load_peaks(fname, verbose=False):
     pam : PeaksAndMetrics object
     """
 
-    if os.path.splitext(fname)[1] != '.pam5':
+    if os.path.splitext(fname)[1].lower() != '.pam5':
         raise IOError('This function supports only PAM5 (HDF5) files')
 
     f = h5py.File(fname, 'r')

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -50,10 +50,10 @@ def load_peaks(fname, verbose=False):
 
     pamh = f['pam']
 
-    version = f.attrs['version'][:]
+    version = f.attrs['version']
 
     if version != '0.0.1':
-        raise IOError('Incorrect PAM5 file version')
+        raise IOError('Incorrect PAM5 file version {0}'.format(version,))
 
     try:
         affine = pamh['affine'][:]

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -7,39 +7,22 @@ from dipy.direction.peaks import (PeaksAndMetrics,
                                   reshape_peaks_for_visualization)
 from dipy.core.sphere import Sphere
 from dipy.io.image import save_nifti
-
-from distutils.version import LooseVersion
-
-# Conditional import machinery for pytables
-from dipy.utils.optpkg import optional_package
-
-# Allow import, but disable doctests, if we don't have pytables
-tables, have_tables, _ = optional_package('tables', 'PyTables is not installed')
-
-# Useful variable for backward compatibility.
-TABLES_LESS_3_0 = LooseVersion(tables.__version__) < "3.0" if have_tables else False
+import h5py
 
 
-def _safe_save(f, group, array, name):
+def _safe_save(group, array, name):
     """ Safe saving of arrays with specific names
 
     Parameters
     ----------
-    f : HDF5 file handle
     group : HDF5 group
     array : array
     name : string
     """
 
-    if not have_tables:
-        # We generate a TripWireError via this call
-        _ = tables.any_attributes
-
-    func_create_carray = f.createCArray if TABLES_LESS_3_0 else f.create_carray
-
     if array is not None:
-        atom = tables.Atom.from_dtype(array.dtype)
-        ds = func_create_carray(group, name, atom, array.shape)
+        ds = group.create_dataset(name, shape=array.shape,
+                                  dtype=array.dtype, chunks=True)
         ds[:] = array
 
 
@@ -61,25 +44,20 @@ def load_peaks(fname, verbose=False):
     if os.path.splitext(fname)[1] != '.pam5':
         raise IOError('This function supports only PAM5 (HDF5) files')
 
-    if TABLES_LESS_3_0:
-        func_open_file = tables.openFile
-    else:
-        func_open_file = tables.open_file
-
-    f = func_open_file(fname, 'r')
+    f = h5py.File(fname, 'r')
 
     pam = PeaksAndMetrics()
 
-    pamh = f.root.pam
+    pamh = f['pam']
 
-    version = f.root.version[0].decode()
+    version = f.attrs['version'][:]
 
     if version != '0.0.1':
         raise IOError('Incorrect PAM5 file version')
 
     try:
-        affine = pamh.affine[:]
-    except tables.NoSuchNodeError:
+        affine = pamh['affine'][:]
+    except KeyError:
         affine = None
 
     peak_dirs = pamh.peak_dirs[:]
@@ -87,15 +65,15 @@ def load_peaks(fname, verbose=False):
     peak_indices = pamh.peak_indices[:]
 
     try:
-        shm_coeff = pamh.shm_coeff[:]
-    except tables.NoSuchNodeError:
+        shm_coeff = pamh['shm_coeff'][:]
+    except KeyError:
         shm_coeff = None
 
     sphere_vertices = pamh.sphere_vertices[:]
 
     try:
-        odf = pamh.odf[:]
-    except tables.NoSuchNodeError:
+        odf = pamh['odf'][:]
+    except KeyError:
         odf = None
 
     pam.affine = affine
@@ -168,41 +146,29 @@ def save_peaks(fname, pam, affine=None, verbose=False):
         msg += ' and peak_indices'
         raise ValueError(msg)
 
-    if TABLES_LESS_3_0:
-        func_open_file = tables.openFile
-    else:
-        func_open_file = tables.open_file
+    f = h5py.File(fname, 'w')
 
-    f = func_open_file(fname, 'w')
+    group = f.create_group('pam')
+    f.attrs['version'] = np.string_('0.0.1')
 
-    if TABLES_LESS_3_0:
-        func_create_group = f.createGroup
-        func_create_array = f.createArray
-    else:
-        func_create_group = f.create_group
-        func_create_array = f.create_array
-
-    group = func_create_group(f.root, 'pam')
-    version = func_create_array(f.root, 'version',
-                                [b"0.0.1"], 'PAM5 version number')
-    version_string = f.root.version[0].decode()
+    version_string = f.attrs['version']
 
     affine = pam.affine if hasattr(pam, 'affine') else affine
     shm_coeff = pam.shm_coeff if hasattr(pam, 'shm_coeff') else None
     odf = pam.odf if hasattr(pam, 'odf') else None
 
-    _safe_save(f, group, affine, 'affine')
-    _safe_save(f, group, pam.peak_dirs, 'peak_dirs')
-    _safe_save(f, group, pam.peak_values, 'peak_values')
-    _safe_save(f, group, pam.peak_indices, 'peak_indices')
-    _safe_save(f, group, shm_coeff, 'shm_coeff')
-    _safe_save(f, group, pam.sphere.vertices, 'sphere_vertices')
-    _safe_save(f, group, pam.B, 'B')
-    _safe_save(f, group, np.array([pam.total_weight]), 'total_weight')
-    _safe_save(f, group, np.array([pam.ang_thr]), 'ang_thr')
-    _safe_save(f, group, pam.gfa, 'gfa')
-    _safe_save(f, group, pam.qa, 'qa')
-    _safe_save(f, group, odf, 'odf')
+    _safe_save(group, affine, 'affine')
+    _safe_save(group, pam.peak_dirs, 'peak_dirs')
+    _safe_save(group, pam.peak_values, 'peak_values')
+    _safe_save(group, pam.peak_indices, 'peak_indices')
+    _safe_save(group, shm_coeff, 'shm_coeff')
+    _safe_save(group, pam.sphere.vertices, 'sphere_vertices')
+    _safe_save(group, pam.B, 'B')
+    _safe_save(group, np.array([pam.total_weight]), 'total_weight')
+    _safe_save(group, np.array([pam.ang_thr]), 'ang_thr')
+    _safe_save(group, pam.gfa, 'gfa')
+    _safe_save(group, pam.qa, 'qa')
+    _safe_save(group, odf, 'odf')
 
     f.close()
 

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -149,7 +149,7 @@ def save_peaks(fname, pam, affine=None, verbose=False):
     f = h5py.File(fname, 'w')
 
     group = f.create_group('pam')
-    f.attrs['version'] = '0.0.1'
+    f.attrs['version'] = u'0.0.1'
 
     version_string = f.attrs['version']
 

--- a/dipy/io/peaks.py
+++ b/dipy/io/peaks.py
@@ -149,7 +149,7 @@ def save_peaks(fname, pam, affine=None, verbose=False):
     f = h5py.File(fname, 'w')
 
     group = f.create_group('pam')
-    f.attrs['version'] = np.string_('0.0.1')
+    f.attrs['version'] = '0.0.1'
 
     version_string = f.attrs['version']
 

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from nibabel.tmpdirs import InTemporaryDirectory
 
-from dipy.io.dpy import Dpy, have_tables
+from dipy.io.dpy import Dpy
 
 
 from nose.tools import assert_true, assert_false, \
@@ -12,12 +12,7 @@ from nose.tools import assert_true, assert_false, \
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy.testing as npt
 
-# Decorator to protect tests from being run without pytables present
-iftables = npt.dec.skipif(not have_tables,
-                          'Pytables does not appear to be installed')
 
-
-@iftables
 def test_dpy():
     fname = 'test.bin'
     with InTemporaryDirectory():

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -5,12 +5,8 @@ from nibabel.tmpdirs import InTemporaryDirectory
 
 from dipy.io.dpy import Dpy
 
-
-from nose.tools import assert_true, assert_false, \
-     assert_equal, assert_raises
-
-from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy.testing as npt
+from dipy.tracking.streamline import Streamlines
 
 
 def test_dpy():
@@ -23,13 +19,22 @@ def test_dpy():
         dpw.write_track(A)
         dpw.write_track(B)
         dpw.write_track(C)
-        dpw.write_tracks([C, B, A])
+        dpw.write_tracks(Streamlines([C, B, A]))
+
+        all_tracks = np.ascontiguousarray(np.vstack([A, B, C, C, B, A]))
+        npt.assert_array_equal(all_tracks, dpw.tracks[:])
         dpw.close()
+
         dpr = Dpy(fname, 'r')
-        assert_equal(dpr.version() == '0.0.1', True)
+        npt.assert_equal(dpr.version() == '0.0.1', True)
         T = dpr.read_tracksi([0, 1, 2, 0, 0, 2])
         T2 = dpr.read_tracks()
-        assert_equal(len(T2), 6)
+        npt.assert_equal(len(T2), 6)
         dpr.close()
-        assert_array_equal(A, T[0])
-        assert_array_equal(C, T[5])
+        npt.assert_array_equal(A, T[0])
+        npt.assert_array_equal(C, T[5])
+
+
+if __name__ == '__main__':
+
+    npt.run_module_suite()

--- a/dipy/io/tests/test_dpy.py
+++ b/dipy/io/tests/test_dpy.py
@@ -26,7 +26,7 @@ def test_dpy():
         dpw.close()
 
         dpr = Dpy(fname, 'r')
-        npt.assert_equal(dpr.version() == '0.0.1', True)
+        npt.assert_equal(dpr.version() == u'0.0.1', True)
         T = dpr.read_tracksi([0, 1, 2, 0, 0, 2])
         T2 = dpr.read_tracks()
         npt.assert_equal(len(T2), 6)

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -127,4 +127,6 @@ def test_io_save_peaks_error():
 
 
 if __name__ == '__main__':
-    npt.run_module_suite()
+    #npt.run_module_suite()
+    test_io_peaks()
+    test_io_save_peaks_error()

--- a/dipy/io/tests/test_io_peaks.py
+++ b/dipy/io/tests/test_io_peaks.py
@@ -8,20 +8,9 @@ from nibabel.tmpdirs import InTemporaryDirectory
 
 from dipy.reconst.peaks import PeaksAndMetrics
 from dipy.data import get_sphere
-from dipy.io.peaks import load_peaks, save_peaks, peaks_to_niftis, _safe_save
-
-# Conditional import machinery for pytables
-from dipy.utils.optpkg import optional_package
-from dipy.utils.tripwire import TripWireError
-
-# Allow import, but disable doctests, if we don't have pytables
-tables, have_tables, _ = optional_package('tables')
-
-# Decorator to protect tests from being run without pytables present
-iftables = npt.dec.skipif(not have_tables, 'Pytables does not appear to be installed')
+from dipy.io.peaks import load_peaks, save_peaks, peaks_to_niftis
 
 
-@iftables
 def test_io_peaks():
     with InTemporaryDirectory():
         fname = 'test.pam5'
@@ -135,23 +124,6 @@ def test_io_save_peaks_error():
         pam.gfa = np.zeros((10, 10, 10))
         pam.qa = np.zeros((10, 10, 10, 5))
         pam.odf = np.zeros((10, 10, 10, sphere.vertices.shape[0]))
-
-        if not have_tables:
-            npt.assert_raises(TripWireError, save_peaks, fname, pam)
-
-
-@npt.dec.skipif(have_tables)
-def test_io_safe_save_error():
-
-    class Mock(object):
-        pass
-
-    fake_hdf5 = Mock()
-    fake_group = Mock()
-    fake_array = np.eye(4)
-    fake_name = "function_tester"
-
-    npt.assert_raises(TripWireError, _safe_save, fake_hdf5, fake_group, fake_array, fake_name)
 
 
 if __name__ == '__main__':

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -10,26 +10,15 @@ from nibabel.tmpdirs import TemporaryDirectory
 from dipy.data import get_data
 from dipy.workflows.reconst import ReconstCSDFlow, ReconstCSAFlow
 
-# Conditional import machinery for pytables
-from dipy.utils.optpkg import optional_package
 
-# Allow import, but disable doctests, if we don't have pytables
-tables, have_tables, _ = optional_package('tables')
-
-# Decorator to protect tests from being run without pytables present
-iftables = npt.dec.skipif(not have_tables,
-                          'Pytables does not appear to be installed')
-
-
-@iftables
 def test_reconst_csa():
     reconst_flow_core(ReconstCSAFlow)
 
-@iftables
+
 def test_reconst_csd():
     reconst_flow_core(ReconstCSDFlow)
 
-@iftables
+
 def reconst_flow_core(flow):
     with TemporaryDirectory() as out_dir:
         data_path, bval_path, bvec_path = get_data('small_64D')
@@ -73,7 +62,7 @@ def reconst_flow_core(flow):
 
         pam = load_peaks(reconst_flow.last_generated_outputs['out_pam'])
         npt.assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape),
-                                   peaks_dir_data)
+                            peaks_dir_data)
         npt.assert_allclose(pam.peak_values, peaks_vals_data)
         npt.assert_allclose(pam.peak_indices, peaks_idx_data)
         npt.assert_allclose(pam.shm_coeff, shm_data)

--- a/doc/dependencies.rst
+++ b/doc/dependencies.rst
@@ -7,9 +7,9 @@ Dependencies
 Depends on a few standard libraries: python_ (the core language), numpy_ (for
 numerical computation), scipy_ (for more specific mathematical operations),
 cython_ (for extra speed) and nibabel_ (for file formats; we require version 2.1
-or higher). Optionally, it can use python-vtk_ (for visualisation), pytables_
+or higher). Optionally, it can use python-vtk_ (for visualisation), h5py_
 (for handling large datasets), matplotlib_ (for scientific plotting), and
-ipython_ (for interaction with the code and its results). cvxopt_ (version
-1.1.7 or later) is required for some modules.
+ipython_ (for interaction with the code and its results). cvxpy is required for
+some modules.
 
 .. include:: links_names.inc

--- a/doc/dependencies.rst
+++ b/doc/dependencies.rst
@@ -6,9 +6,9 @@ Dependencies
 
 Depends on a few standard libraries: python_ (the core language), numpy_ (for
 numerical computation), scipy_ (for more specific mathematical operations),
-cython_ (for extra speed) and nibabel_ (for file formats; we require version 2.1
-or higher). Optionally, it can use python-vtk_ (for visualisation), h5py_
-(for handling large datasets), matplotlib_ (for scientific plotting), and
+cython_ (for extra speed), nibabel_ (for file formats; we require version 2.1
+or higher) and h5py_ (for handling large datasets. Optionally, it can use
+ python-vtk_ (for visualisation), matplotlib_ (for scientific plotting), and
 ipython_ (for interaction with the code and its results). cvxpy is required for
 some modules.
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -244,7 +244,7 @@ then::
 
 You might want the optional packages too (highly recommended)::
 
-    sudo apt-get install ipython python-tables python-vtk python-matplotlib
+    sudo apt-get install ipython python-h5py python-vtk python-matplotlib
 
 
 Now follow :ref:`install-source-nix`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cython>=0.25.1
 numpy>=1.7.1
 scipy>=0.9
 nibabel>=2.1.0
+h5py>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,9 @@ SetupDependency('scipy', info.SCIPY_MIN_VERSION,
 SetupDependency('nibabel', info.NIBABEL_MIN_VERSION,
                 req_type='install_requires',
                 heavy=False).check_fill(extra_setuptools_args)
+SetupDependency('h5py', info.H5PY_MIN_VERSION,
+                req_type='install_requires',
+                heavy=False).check_fill(extra_setuptools_args)
 
 cmdclass = dict(
     build_py=pybuilder,


### PR DESCRIPTION
Switching from pytables to h5py. H5py still works with older numpy versions. pytables needs newer versions. Therefore h5py is easier to depend on. Also it seems that h5py gives better access to low level functions. Finally, testing in travis should be much simpler without the pytables dependency as that api has been changing quite a bit.