### PR TITLE
FIX : improve epilogue accessibility for workflow

### DIFF
--- a/dipy/__init__.py
+++ b/dipy/__init__.py
@@ -36,6 +36,7 @@ if sys.version[0:3] < '2.6':
     raise ImportError('Dipy needs Python version 2.6 or above')
 
 from .info import __version__
+from .testing import setup_test
 
 # Test callable
 from numpy.testing import Tester

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function, absolute_import
 import math
 import numpy as np
 import numpy.linalg as npl
+from dipy.testing import setup_test
 
 # epsilon for testing whether a number is close to zero
 _EPS = np.finfo(float).eps * 4.0

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -3,6 +3,8 @@ from os.path import dirname, abspath, join as pjoin
 from dipy.testing.spherepoints import sphere_points
 from dipy.testing.decorators import doctest_skip_parser
 from numpy.testing import assert_array_equal
+import numpy as np
+from distutils.version import LooseVersion
 
 # set path to example data
 IO_DATA_PATH = abspath(pjoin(dirname(__file__),
@@ -21,3 +23,17 @@ else:
 def assert_arrays_equal(arrays1, arrays2):
     for arr1, arr2 in zip(arrays1, arrays2):
         assert_array_equal(arr1, arr2)
+
+def setup_test():
+    """ Set numpy print options to "legacy" for new versions of numpy
+
+    If imported into a file, nosetest will run this before any doctests.
+
+    Note:
+
+    More informations :
+    https://github.com/numpy/numpy/commit/710e0327687b9f7653e5ac02d222ba62c657a718
+    https://github.com/nipy/nibabel/pull/556
+    """
+    if LooseVersion(np.__version__) >= LooseVersion('1.14'):
+        np.set_printoptions(sign='legacy')

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -29,9 +29,8 @@ def setup_test():
 
     If imported into a file, nosetest will run this before any doctests.
 
-    Note:
-
-    More informations :
+    References
+    -----------
     https://github.com/numpy/numpy/commit/710e0327687b9f7653e5ac02d222ba62c657a718
     https://github.com/nipy/nibabel/pull/556
     """

--- a/dipy/tracking/life.py
+++ b/dipy/tracking/life.py
@@ -17,6 +17,7 @@ from dipy.tracking.streamline import transform_streamlines
 from dipy.tracking.vox2track import _voxel2streamline
 import dipy.data as dpd
 import dipy.core.optimize as opt
+from dipy.testing import setup_test
 
 
 def gradient(f):

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -2,6 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 from dipy.utils.six.moves import xrange
+from dipy.testing import setup_test
 
 import numpy as np
 from scipy.interpolate import splprep, splev

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -13,6 +13,7 @@ import dipy.tracking.utils as ut
 from dipy.tracking.utils import streamline_near_roi
 from dipy.core.geometry import dist_to_corner
 import dipy.align.vector_fields as vfu
+from dipy.testing import setup_test
 
 
 def unlist_streamlines(streamlines):

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -64,6 +64,7 @@ from numpy import (asarray, ceil, dot, empty, eye, sqrt)
 from dipy.io.bvectxt import ornt_mapping
 from dipy.tracking import metrics
 from dipy.tracking.vox2track import _streamlines_in_mask
+from dipy.testing import setup_test
 
 # Import helper functions shared with vox2track
 from dipy.tracking._utils import (_mapping_to_voxel, _to_voxel_coordinates)

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -97,6 +97,10 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         self.doc = npds['Parameters']
         self.description = ' '.join(npds['Extended Summary'])
 
+        if npds['References']:
+            ref_text = [text if text else "\n" for text in npds['References']]
+            self.epilog += "\n{}".format(''.join([text for text in ref_text]))
+
         self.outputs = [param for param in npds['Parameters'] if
                         'out_' in param[0]]
 

--- a/dipy/workflows/tests/test_iap.py
+++ b/dipy/workflows/tests/test_iap.py
@@ -4,7 +4,7 @@ import sys
 from dipy.workflows.base import IntrospectiveArgumentParser
 from dipy.workflows.flow_runner import run_flow
 from dipy.workflows.tests.workflow_tests_utils import TestFlow, \
-    DummyCombinedWorkflow
+    DummyCombinedWorkflow, DummyWorkflow1
 
 
 def test_iap():
@@ -36,6 +36,13 @@ def test_iap():
     # Test if **args really fits dummy_flow's arguments
     return_values = dummy_flow.run(**args)
     npt.assert_array_equal(return_values, all_results + [2.0])
+
+
+def test_iap_epilog():
+    parser = IntrospectiveArgumentParser()
+    dummy_flow = DummyWorkflow1()
+    parser.add_workflow(dummy_flow)
+    assert "dummy references" in parser.epilog
 
 
 def test_flow_runner():

--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -21,6 +21,10 @@ class DummyWorkflow1(Workflow):
             fake output directory (default '')
         out_combined : string
             fake out file (default out_combined.txt)
+
+        References
+        -----------
+        dummy references
         """
         return param1
 


### PR DESCRIPTION
The goal of this PR is to resolve #1344. 

Now, epilog is setting up via the keyword `References` in workflow docstring.

