### PR TITLE
Fix piesno type

### DIFF
--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -1,17 +1,15 @@
 from __future__ import division, print_function
 
+from datetime import datetime
+
+import nibabel as nib
 import numpy as np
 from dipy.denoise.denspeed import nlmeans_3d
-# from warnings import warn
-# import warnings
-
-# warnings.simplefilter('always', DeprecationWarning)
-# warn(DeprecationWarning("Module 'dipy.denoise.nlmeans' is deprecated,"
-#                         " use module 'dipy.denoise.non_local_means' instead"))
+from dipy.denoise.noise_estimate import estimate_sigma, piesno
 
 
 def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
-            rician=True, num_threads=None):
+            rician=False, num_threads=None):
     r""" Non-local means for denoising 3D and 4D images
 
     Parameters
@@ -45,12 +43,6 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                       HARDI, MICCAI 2008
 
     """
-
-    # warn(DeprecationWarning("function 'dipy.denoise.nlmeans'"
-    #                        " is deprecated, use module "
-    #                        "'dipy.denoise.non_local_means'"
-    #                        " instead"))
-
     if arr.ndim == 3:
         sigma = np.ones(arr.shape, dtype=np.float64) * sigma
         return nlmeans_3d(arr, mask, sigma,
@@ -67,6 +59,7 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
             sigma = np.ones(arr.shape, dtype=np.float64) * sigma
 
         for i in range(arr.shape[-1]):
+            start = datetime.now()
             denoised_arr[..., i] = nlmeans_3d(arr[..., i],
                                               mask,
                                               sigma[..., i],
@@ -74,8 +67,41 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                                               block_radius,
                                               rician,
                                               num_threads).astype(arr.dtype)
+            print(datetime.now() - start)
 
         return denoised_arr
 
     else:
         raise ValueError("Only 3D or 4D array are supported!", arr.shape)
+
+
+def main():
+    # input_path = '/home/nil/libs/scilpy-data/fa.nii.gz'
+    # output_path = '/home/nil/libs/scilpy-data/fa_nlm.nii.gz'
+    input_path = '/home/nil/dwi.nii.gz'
+    output_path = '/home/nil/dwi_nlm.nii.gz'
+    # input_path = '/home/nil/libs/scilpy-data/test.nii.gz'
+    # output_path = '/home/nil/libs/scilpy-data/dwi_nlmeans.nii.gz'
+
+    print('Denoising {0}'.format(input_path))
+    image = nib.load(input_path)
+    data = image.get_data()
+    print(data.shape)
+    # data = data[20:124, 20:168, 20:130]
+
+    print('Estimating sigma')
+    #sigma = estimate_sigma(data)
+    sigma = piesno(data, 1)
+    print('Found sigma {0}'.format(sigma))
+
+    start = datetime.now()
+    denoised_data = nlmeans(data, sigma, patch_radius=6, block_radius=5)
+    print('Total time:', datetime.now() - start)
+    denoised_image = nib.Nifti1Image(
+        denoised_data, image.affine, image.header)
+
+    denoised_image.to_filename(output_path)
+    print('Denoised volume saved as {0}'.format(output_path))
+
+
+main()

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -1,15 +1,17 @@
 from __future__ import division, print_function
 
-from datetime import datetime
-
-import nibabel as nib
 import numpy as np
 from dipy.denoise.denspeed import nlmeans_3d
-from dipy.denoise.noise_estimate import estimate_sigma, piesno
+# from warnings import warn
+# import warnings
+
+# warnings.simplefilter('always', DeprecationWarning)
+# warn(DeprecationWarning("Module 'dipy.denoise.nlmeans' is deprecated,"
+#                         " use module 'dipy.denoise.non_local_means' instead"))
 
 
 def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
-            rician=False, num_threads=None):
+            rician=True, num_threads=None):
     r""" Non-local means for denoising 3D and 4D images
 
     Parameters
@@ -43,6 +45,12 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                       HARDI, MICCAI 2008
 
     """
+
+    # warn(DeprecationWarning("function 'dipy.denoise.nlmeans'"
+    #                        " is deprecated, use module "
+    #                        "'dipy.denoise.non_local_means'"
+    #                        " instead"))
+
     if arr.ndim == 3:
         sigma = np.ones(arr.shape, dtype=np.float64) * sigma
         return nlmeans_3d(arr, mask, sigma,
@@ -59,7 +67,6 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
             sigma = np.ones(arr.shape, dtype=np.float64) * sigma
 
         for i in range(arr.shape[-1]):
-            start = datetime.now()
             denoised_arr[..., i] = nlmeans_3d(arr[..., i],
                                               mask,
                                               sigma[..., i],
@@ -67,41 +74,8 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
                                               block_radius,
                                               rician,
                                               num_threads).astype(arr.dtype)
-            print(datetime.now() - start)
 
         return denoised_arr
 
     else:
         raise ValueError("Only 3D or 4D array are supported!", arr.shape)
-
-
-def main():
-    # input_path = '/home/nil/libs/scilpy-data/fa.nii.gz'
-    # output_path = '/home/nil/libs/scilpy-data/fa_nlm.nii.gz'
-    input_path = '/home/nil/dwi.nii.gz'
-    output_path = '/home/nil/dwi_nlm.nii.gz'
-    # input_path = '/home/nil/libs/scilpy-data/test.nii.gz'
-    # output_path = '/home/nil/libs/scilpy-data/dwi_nlmeans.nii.gz'
-
-    print('Denoising {0}'.format(input_path))
-    image = nib.load(input_path)
-    data = image.get_data()
-    print(data.shape)
-    # data = data[20:124, 20:168, 20:130]
-
-    print('Estimating sigma')
-    #sigma = estimate_sigma(data)
-    sigma = piesno(data, 1)
-    print('Found sigma {0}'.format(sigma))
-
-    start = datetime.now()
-    denoised_data = nlmeans(data, sigma, patch_radius=6, block_radius=5)
-    print('Total time:', datetime.now() - start)
-    denoised_image = nib.Nifti1Image(
-        denoised_data, image.affine, image.header)
-
-    denoised_image.to_filename(output_path)
-    print('Denoised volume saved as {0}'.format(output_path))
-
-
-main()

--- a/dipy/denoise/noise_estimate.py
+++ b/dipy/denoise/noise_estimate.py
@@ -227,7 +227,7 @@ def _piesno_3D(data, N, alpha=0.01, l=100, itermax=100, eps=1e-5,
 
     phi = np.arange(1, l + 1) * m / l
     K = data.shape[-1]
-    sum_m2 = np.sum(data**2, axis=-1, dtype=np.float32)
+    sum_m2 = np.sum(data.astype(np.float32)**2, axis=2)
 
     sigma_prev = 0
     sigma = m

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -10,7 +10,6 @@ from dipy.denoise.noise_estimate import _piesno_3D
 from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 import dipy.data as dpd
 import dipy.core.gradients as dpg
-import dipy.sims.voxel as vox
 
 
 def test_inv_nchi():
@@ -77,6 +76,16 @@ def test_piesno():
     sigma = _piesno_3D(1000*np.ones_like(rician_noise), N=1, alpha=0.01, l=1,
                        eps=1e-10, return_mask=False, initial_estimation=10)
     assert_(np.all(sigma == 10))
+
+
+def test_piesno_type():
+    # This is testing if the `sum_m2` cast is overflowing
+    data = np.ones((10, 10, 10), dtype=np.int16)
+    for i in range(10):
+        data[:, i, :] = i * 26
+
+    sigma = piesno(data, N=2, alpha=0.01, l=1, eps=1e-10, return_mask=False)
+    assert_almost_equal(sigma, 79.970003117424739)
 
 
 def test_estimate_sigma():

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -10,6 +10,7 @@ from dipy.denoise.noise_estimate import _piesno_3D
 from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 import dipy.data as dpd
 import dipy.core.gradients as dpg
+import dipy.sims.voxel as vox
 
 
 def test_inv_nchi():
@@ -76,19 +77,6 @@ def test_piesno():
     sigma = _piesno_3D(1000*np.ones_like(rician_noise), N=1, alpha=0.01, l=1,
                        eps=1e-10, return_mask=False, initial_estimation=10)
     assert_(np.all(sigma == 10))
-
-
-def test_piesno_type():
-    # This is testing if the `sum_m2` cast is overflowing
-    data = np.ones((10, 10, 10), dtype=np.int16)
-    for i in range(10):
-        data[:, i, :] = i * 26
-
-    sigma = piesno(data, N=2, alpha=0.01, l=1, eps=1e-10, return_mask=False)
-    assert_almost_equal(sigma, 79.970003117424739)
-
-
-test_piesno_type()
 
 
 def test_estimate_sigma():

--- a/dipy/denoise/tests/test_noise_estimate.py
+++ b/dipy/denoise/tests/test_noise_estimate.py
@@ -10,7 +10,6 @@ from dipy.denoise.noise_estimate import _piesno_3D
 from dipy.denoise.pca_noise_estimate import pca_noise_estimate
 import dipy.data as dpd
 import dipy.core.gradients as dpg
-import dipy.sims.voxel as vox
 
 
 def test_inv_nchi():
@@ -77,6 +76,19 @@ def test_piesno():
     sigma = _piesno_3D(1000*np.ones_like(rician_noise), N=1, alpha=0.01, l=1,
                        eps=1e-10, return_mask=False, initial_estimation=10)
     assert_(np.all(sigma == 10))
+
+
+def test_piesno_type():
+    # This is testing if the `sum_m2` cast is overflowing
+    data = np.ones((10, 10, 10), dtype=np.int16)
+    for i in range(10):
+        data[:, i, :] = i * 26
+
+    sigma = piesno(data, N=2, alpha=0.01, l=1, eps=1e-10, return_mask=False)
+    assert_almost_equal(sigma, 79.970003117424739)
+
+
+test_piesno_type()
 
 
 def test_estimate_sigma():


### PR DESCRIPTION
I found a problem with piesno. The line 

    np.sum(data**2, axis=-1, dtype=np.float32)

doesn't do what you think it does. For a dwi for example, the `dtype` is `int16` and some values^2 are greater then 2^15.

The problem is that `data**2` is still in `int16`, then it's converted to a `float32` so this image is curiously bounded with the `int16` bounds :)

Moreover, I changed `axis=-1` to `axis=2` because we always know the right axis... it's 2.