### PR TITLE
FIX: update printing format for numpy 1.14

### DIFF
--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -32,7 +32,8 @@ def setup_test():
     References
     -----------
     https://github.com/numpy/numpy/commit/710e0327687b9f7653e5ac02d222ba62c657a718
+    https://github.com/numpy/numpy/commit/734b907fc2f7af6e40ec989ca49ee6d87e21c495
     https://github.com/nipy/nibabel/pull/556
     """
     if LooseVersion(np.__version__) >= LooseVersion('1.14'):
-        np.set_printoptions(sign='legacy')
+        np.set_printoptions(legacy=True)


### PR DESCRIPTION
This PR is for resolving #1376  due to the change [here](https://github.com/numpy/numpy/commit/734b907fc2f7af6e40ec989ca49ee6d87e21c495#diff-6c34f1538350ce17eb53b35d2f0282a1R512) on Numpy