### PR TITLE
Fix: numpy legacy print again...

### DIFF
--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -36,4 +36,4 @@ def setup_test():
     https://github.com/nipy/nibabel/pull/556
     """
     if LooseVersion(np.__version__) >= LooseVersion('1.14'):
-        np.set_printoptions(legacy=True)
+        np.set_printoptions(legacy='1.13')


### PR DESCRIPTION
set version of Numpy print options due to recent change