### PR TITLE
NF - Particle Filtering Tractography (merge)

### DIFF
--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -1,0 +1,43 @@
+import numpy as np
+import numpy.testing as npt
+
+from dipy.core.sphere import HemiSphere, unit_octahedron
+from dipy.direction.pmf import SimplePmfGen, SHCoeffPmfGen
+
+
+def test_pmf_from_sh():
+    sphere = HemiSphere.from_sphere(unit_octahedron)
+    pmfgen = SHCoeffPmfGen(np.ones([2, 2, 2, 28]), sphere, None)
+
+    # Test that the pmf is greater than 0 for a valid point
+    pmf = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'))
+    npt.assert_equal(np.sum(pmf) > 0, True)
+
+    # Test that the pmf is 0 for invalid Points
+    npt.assert_array_equal(pmfgen.get_pmf(np.array([-1, 0, 0], dtype='float')),
+                           np.zeros(len(sphere.vertices)))
+    npt.assert_array_equal(pmfgen.get_pmf(np.array([0, 0, 10], dtype='float')),
+                           np.zeros(len(sphere.vertices)))
+
+
+def test_pmf_from_array():
+    sphere = HemiSphere.from_sphere(unit_octahedron)
+    pmfgen = SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)]))
+
+    # Test that the pmf is greater than 0 for a valid point
+    pmf = pmfgen.get_pmf(np.array([0, 0, 0], dtype='float'))
+    npt.assert_equal(np.sum(pmf) > 0, True)
+
+    # Test that the pmf is 0 for invalid Points
+    npt.assert_array_equal(pmfgen.get_pmf(np.array([-1, 0, 0], dtype='float')),
+                           np.zeros(len(sphere.vertices)))
+    npt.assert_array_equal(pmfgen.get_pmf(np.array([0, 0, 10], dtype='float')),
+                           np.zeros(len(sphere.vertices)))
+
+    npt.assert_raises(
+        ValueError,
+        lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])*-1))
+
+
+if __name__ == '__main__':
+    npt.run_module_suite()

--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -56,7 +56,7 @@ temp_3 = np.where(temp_3 < 20, 3, 1)
 square_1[99:157, 99:157, :] = temp_3
 
 
-def test_greyscale_image():
+def test_grayscale_image():
 
     com = ConstantObservationModel()
     icm = IteratedConditionalModes()
@@ -124,7 +124,7 @@ def test_greyscale_image():
     npt.assert_(icm_segmentation.min() == 0)
 
 
-def test_greyscale_iter():
+def test_grayscale_iter():
 
     max_iter = 15
     beta = np.float64(0.1)
@@ -195,11 +195,11 @@ def test_greyscale_iter():
         npt.assert_(PLY[100, 100, 1, 3] > PLY[100, 100, 1, 1])
         npt.assert_(PLY[100, 100, 1, 3] > PLY[100, 100, 1, 2])
 
-        mu_upd, sigmasq_upd = com.update_param(image_gauss, PLY, mu, nclasses)        
+        mu_upd, sigmasq_upd = com.update_param(image_gauss, PLY, mu, nclasses)
         npt.assert_(mu_upd[0] >= 0.0)
         npt.assert_(mu_upd[1] >= 0.0)
         npt.assert_(mu_upd[2] >= 0.0)
-        npt.assert_(mu_upd[3] >= 0.0)    
+        npt.assert_(mu_upd[3] >= 0.0)
         npt.assert_(sigmasq_upd[0] >= 0.0)
         npt.assert_(sigmasq_upd[1] >= 0.0)
         npt.assert_(sigmasq_upd[2] >= 0.0)
@@ -294,7 +294,7 @@ def test_square_iter():
         npt.assert_(mu_upd[0] >= 0.0)
         npt.assert_(mu_upd[1] >= 0.0)
         npt.assert_(mu_upd[2] >= 0.0)
-        npt.assert_(mu_upd[3] >= 0.0)    
+        npt.assert_(mu_upd[3] >= 0.0)
         npt.assert_(sigmasq_upd[0] >= 0.0)
         npt.assert_(sigmasq_upd[1] >= 0.0)
         npt.assert_(sigmasq_upd[2] >= 0.0)

--- a/dipy/tracking/local/__init__.py
+++ b/dipy/tracking/local/__init__.py
@@ -1,9 +1,15 @@
-from .localtracking import LocalTracking
-from .tissue_classifier import (
-    ActTissueClassifier, BinaryTissueClassifier, ThresholdTissueClassifier,
-    TissueClassifier)
 from .direction_getter import DirectionGetter
+from .localtracking import LocalTracking, ParticleFilteringTracking
+from .tissue_classifier import (ActTissueClassifier,
+                                BinaryTissueClassifier,
+                                CmcTissueClassifier,
+                                ConstrainedTissueClassifier,
+                                ThresholdTissueClassifier,
+                                TissueClassifier)
+
 from dipy.tracking import utils
 
-__all__ = ["ActTissueClassifier", "BinaryTissueClassifier", "LocalTracking",
-           "ThresholdTissueClassifier"]
+__all__ = ["ActTissueClassifier", "BinaryTissueClassifier",
+           "CmcTissueClassifier", "ConstrainedTissueClassifier",
+           "DirectionGetter", "LocalTracking", "ParticleFilteringTracking",
+           "ThresholdTissueClassifier", "TissueClassifier"]

--- a/dipy/tracking/local/localtrack.pyx
+++ b/dipy/tracking/local/localtrack.pyx
@@ -140,7 +140,7 @@ def local_tracker(
 
     if (seed_pos.shape[0] != 3 or first_step.shape[0] != 3 or
             voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
-        raise ValueError()
+        raise ValueError('Invalid input parameter dimensions.')
 
     for i in range(3):
         dir[i] = first_step[i]
@@ -220,8 +220,8 @@ def pft_tracker(
         np.int_t[:, :, :]  particle_states):
     """Tracks one direction from a seed using the particle filtering algorithm.
 
-    This function is the main workhorse of the ``LocalTracking`` class defined
-    in ``dipy.tracking.local.localtracking``.
+    This function is the main workhorse of the ``ParticleFilteringTracking``
+    class defined in ``dipy.tracking.local.localtracking``.
 
     Parameters
     ----------
@@ -281,7 +281,7 @@ def pft_tracker(
 
     if (seed_pos.shape[0] != 3 or first_step.shape[0] != 3 or
             voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
-        raise ValueError()
+        raise ValueError('Invalid input parameter dimensions.')
 
     for i in range(3):
         dir[i] = first_step[i]

--- a/dipy/tracking/local/localtrack.pyx
+++ b/dipy/tracking/local/localtrack.pyx
@@ -6,9 +6,10 @@ cimport numpy as np
 import numpy as np
 from .direction_getter cimport DirectionGetter
 from .tissue_classifier cimport(
-    TissueClass, TissueClassifier,
+    TissueClass, TissueClassifier, ConstrainedTissueClassifier,
     TRACKPOINT, ENDPOINT, OUTSIDEIMAGE, INVALIDPOINT)
 from dipy.tracking.local.interpolation cimport trilinear_interpolate4d_c
+from dipy.utils.fast_numpy cimport cumsum, where_to_insert
 
 
 cdef extern from "dpy_math.h" nogil:
@@ -65,7 +66,7 @@ cdef void step_to_boundary(double * point, double * direction,
         point[i] += smallest_step * direction[i]
 
 
-cdef void fixed_step(double * point, double * direction, double stepsize) nogil:
+cdef void fixed_step(double * point, double * direction, double step_size) nogil:
     """Updates point by stepping in direction.
 
     Parameters
@@ -79,7 +80,7 @@ cdef void fixed_step(double * point, double * direction, double stepsize) nogil:
 
     """
     for i in range(3):
-        point[i] += direction[i] * stepsize
+        point[i] += direction[i] * step_size
 
 
 cdef inline void copypoint(double * a, double * b) nogil:
@@ -88,12 +89,13 @@ cdef inline void copypoint(double * a, double * b) nogil:
 
 
 def local_tracker(
-        DirectionGetter dg, TissueClassifier tc,
+        DirectionGetter dg,
+        TissueClassifier tc,
         np.float_t[:] seed,
         np.float_t[:] first_step,
         np.float_t[:] voxel_size,
-        np.float_t[:,:] streamline,
-        double stepsize,
+        np.float_t[:, :] streamline,
+        double step_size,
         int fixedstep):
     cdef:
         int i
@@ -104,22 +106,22 @@ def local_tracker(
         raise ValueError()
 
     i = _local_tracker(dg, tc, seed, first_step, voxel_size, streamline,
-                       stepsize, fixedstep, &tissue_class)
+                       step_size, fixedstep, &tissue_class)
     return i, tissue_class
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef int _local_tracker(
-        DirectionGetter dg, TissueClassifier tc,
-        np.float_t[:] seed,
-        np.float_t[:] first_step,
-        np.float_t[:] voxel_size,
-        np.float_t[:,:] streamline,
-        double stepsize,
-        int fixedstep,
-        TissueClass* tissue_class):
+cdef int _local_tracker(DirectionGetter dg,
+                        TissueClassifier tc,
+                        np.float_t[:] seed,
+                        np.float_t[:] first_step,
+                        np.float_t[:] voxel_size,
+                        np.float_t[:, :] streamline,
+                        double step_size,
+                        int fixedstep,
+                        TissueClass* tissue_class):
     """Tracks one direction from a seed.
 
     This function is the main workhorse of the ``LocalTracking`` class defined
@@ -141,10 +143,10 @@ cdef int _local_tracker(
     streamline : array, float, 2d, (N, 3)
         Output of tracking will be put into this array. The length of this
         array, ``N``, will set the maximum allowable length of the streamline.
-    stepsize : float
+    step_size : float
         Size of tracking steps in mm if ``fixed_step``.
     fixedstep : bool
-        If true, a fixed stepsize is used, otherwise a variable step size is
+        If true, a fixed step_size is used, otherwise a variable step size is
         used.
 
     Returns
@@ -175,7 +177,7 @@ cdef int _local_tracker(
     cdef:
         size_t i
         double point[3], dir[3], vs[3], voxdir[3]
-        void (*step)(double * , double*, double) nogil
+        void (*step)(double*, double*, double) nogil
 
     if fixedstep:
         step = fixed_step
@@ -193,8 +195,8 @@ cdef int _local_tracker(
             break
         for j in range(3):
             voxdir[j] = dir[j] / vs[j]
-        step(point, voxdir, stepsize)
-        copypoint(point, & streamline[i, 0])
+        step(point, voxdir, step_size)
+        copypoint(point, &streamline[i, 0])
         tissue_class[0] = tc.check_point_c(point)
         if tissue_class[0] == TRACKPOINT:
             continue
@@ -208,3 +210,246 @@ cdef int _local_tracker(
         # maximum length of streamline has been reached, return everything
         i = streamline.shape[0]
     return i
+
+
+def pft_tracker(
+        DirectionGetter dg,
+        ConstrainedTissueClassifier tc,
+        np.float_t[:] seed,
+        np.float_t[:] first_step,
+        np.float_t[:] voxel_size,
+        np.float_t[:, :] streamline,
+        np.float_t[:, :] directions,
+        double step_size,
+        int pft_nbr_back_steps,
+        int pft_max_steps,
+        int pft_max_trial,
+        int particle_count,
+        np.float_t[:, :, :, :] particle_paths,
+        np.float_t[:, :, :, :] particle_dirs,
+        np.float_t[:, :] particle_weights,
+        np.int_t[:, :, :]  particle_states):
+    cdef:
+        int i
+        TissueClass tissue_class
+
+    if (seed.shape[0] != 3 or first_step.shape[0] != 3 or
+            voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
+        raise ValueError()
+
+    i = _pft_tracker(dg, tc, seed, first_step, voxel_size, streamline,
+                     directions, step_size, &tissue_class, pft_nbr_back_steps,
+                     pft_max_steps, pft_max_trial, particle_count,
+                     particle_paths, particle_dirs, particle_weights,
+                     particle_states)
+    return i, tissue_class
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef _pft_tracker(DirectionGetter dg,
+                  ConstrainedTissueClassifier tc,
+                  np.float_t[:] seed,
+                  np.float_t[:] first_step,
+                  np.float_t[:] voxel_size,
+                  np.float_t[:, :] streamline,
+                  np.float_t[:, :] directions,
+                  double step_size,
+                  TissueClass * tissue_class,
+                  int pft_nbr_back_steps,
+                  int pft_max_steps,
+                  int pft_max_trial,
+                  int particle_count,
+                  np.float_t[:, :, :, :] particle_paths,
+                  np.float_t[:, :, :, :] particle_dirs,
+                  np.float_t[:, :] particle_weights,
+                  np.int_t[:, :, :] particle_states):
+
+    if (seed.shape[0] != 3 or first_step.shape[0] != 3 or
+            voxel_size.shape[0] != 3 or streamline.shape[1] != 3):
+        raise ValueError()
+    cdef:
+        int i, pft_trial, pft_streamline_i, pft_nbr_steps, strl_array_len
+        double point[3], dir[3], vs[3], voxdir[3]
+
+        void (*step)(double* , double*, double) nogil
+    pft_trial = 0
+
+    for j in range(3):
+        streamline[0, j] = point[j] = seed[j]
+        dir[j] = first_step[j]
+        vs[j] = voxel_size[j]
+    copypoint(dir, &directions[0, 0])
+
+    tissue_class[0] = TRACKPOINT
+    i = 0
+    strl_array_len = streamline.shape[0]
+    while i < strl_array_len - 1:
+        if dg.get_direction_c(point, dir):
+            # no valid diffusion direction to follow
+            tissue_class[0] = INVALIDPOINT
+        else:
+            for j in range(3):
+                voxdir[j] = dir[j] / vs[j]
+            i += 1
+            fixed_step(point, voxdir, step_size)
+            copypoint(point, &streamline[i, 0])
+            copypoint(dir, &directions[i, 0])
+
+            tissue_class[0] = tc.check_point_c(point)
+
+        if tissue_class[0] == TRACKPOINT:
+            continue
+        elif tissue_class[0] == ENDPOINT:
+            i += 1
+            break
+        elif tissue_class[0] == INVALIDPOINT:
+            if pft_trial < pft_max_trial and i > 1:
+                pft_streamline_i = min(i - 1, pft_nbr_back_steps)
+                pft_nbr_steps = min(pft_max_steps,
+                                    strl_array_len - pft_streamline_i - 1)
+                i = _pft(streamline,
+                         pft_streamline_i,
+                         directions,
+                         dg,
+                         tc,
+                         voxel_size,
+                         step_size,
+                         tissue_class,
+                         pft_nbr_steps,
+                         particle_count,
+                         particle_paths,
+                         particle_dirs,
+                         particle_weights,
+                         particle_states)
+
+                pft_trial += 1
+                # update the current point with the PFT results
+                copypoint(&streamline[i, 0], point)
+                copypoint(&directions[i, 0], dir)
+
+                if not tissue_class[0] == TRACKPOINT:
+                    break
+            else:
+                i += 1
+                break
+        elif tissue_class[0] == OUTSIDEIMAGE:
+            break
+    return i
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef _pft(np.float_t[:, :] streamline,
+          int streamline_i,
+          np.float_t[:, :] directions,
+          DirectionGetter dg,
+          ConstrainedTissueClassifier tc,
+          np.float_t[:] voxel_size,
+          double step_size,
+          TissueClass * tissue_class,
+          int pft_nbr_steps,
+          int particle_count,
+          np.float_t[:, :, :, :] particle_paths,
+          np.float_t[:, :, :, :] particle_dirs,
+          np.float_t[:, :] particle_weights,
+          np.int_t[:, :, :] particle_states):
+    cdef:
+        double sum_weights, sum_squared, N_effective, rdm_sample
+        double point[3], dir[3], vs[3], voxdir[3]
+        int s, p, j
+
+    if pft_nbr_steps <= 0:
+        return INVALIDPOINT, streamline_i
+
+    for j in range(3):
+        vs[j] = voxel_size[j]
+
+    for p in range(particle_count):
+        copypoint(&streamline[streamline_i, 0], &particle_paths[0, p, 0, 0])
+        copypoint(&directions[streamline_i, 0], &particle_dirs[0, p, 0, 0])
+        particle_weights[0, p] = 1. / particle_count
+        particle_states[0, p, 0] = TRACKPOINT
+        particle_states[0, p, 1] = 0
+
+    for s in range(pft_nbr_steps):
+        for p in range(particle_count):
+            if not particle_states[0, p, 0] == TRACKPOINT:
+                for j in range(3):
+                    particle_paths[0, p, s, j] = 0
+                    particle_dirs[0, p, s, j] = 0
+                continue  # move to the next particle
+            copypoint(&particle_paths[0, p, s, 0], point)
+            copypoint(&particle_dirs[0, p, s, 0], dir)
+
+            if dg.get_direction_c(point, dir):
+                particle_states[0, p, 0] = INVALIDPOINT
+            else:
+                for j in range(3):
+                    voxdir[j] = dir[j] / vs[j]
+                fixed_step(point, voxdir, step_size)
+                copypoint(point, &particle_paths[0, p, s + 1, 0])
+                copypoint(dir, &particle_dirs[0, p, s + 1, 0])
+                particle_states[0, p, 0] = tc.check_point_c(point)
+                particle_states[0, p, 1] = s + 1
+                particle_weights[0, p] *= 1 - tc.get_exclude_c(point)
+                if (particle_states[0, p, 0] == INVALIDPOINT and
+                        particle_weights[0, p] > 0):
+                    particle_states[0, p, 0] = TRACKPOINT
+
+        sum_weights = 0
+        for p in range(particle_count):
+            sum_weights += particle_weights[0, p]
+        sum_squared = 0
+        for p in range(particle_count):
+            particle_weights[0, p] = particle_weights[0, p] / sum_weights
+            sum_squared += particle_weights[0, p] * particle_weights[0, p]
+
+        # Resample the particles if the weights are too uneven.
+        # Particles with negligable weights are replaced by duplicates of
+        # those with high weigths through resampling
+        N_effective = 1. / sum_squared
+        if N_effective < particle_count / 10.:
+            # copy data in the temp arrays
+            for pp in range(particle_count):
+                for ss in range(pft_nbr_steps):
+                    copypoint(&particle_paths[0, pp, ss, 0],
+                              &particle_paths[1, pp, ss, 0])
+                    copypoint(&particle_dirs[0, pp, ss, 0],
+                              &particle_dirs[1, pp, ss, 0])
+                particle_weights[1, pp] = particle_weights[0, pp]
+                particle_states[1, pp, 0] = particle_states[0, pp, 0]
+                particle_states[1, pp, 1] = particle_states[0, pp, 1]
+
+            # sample N new particle
+            cumsum(&particle_weights[1, 0],
+                   &particle_weights[1, 0],
+                   particle_count)
+            for pp in range(particle_count):
+                rdm_sample = random() * particle_weights[1, particle_count - 1]
+                p_source = where_to_insert(&particle_weights[1, 0],
+                                           rdm_sample,
+                                           particle_count)
+                for ss in range(pft_nbr_steps):
+                    copypoint(&particle_paths[1, p_source, ss, 0],
+                              &particle_paths[0, pp, ss, 0])
+                    copypoint(&particle_dirs[1, p_source, ss, 0],
+                              &particle_dirs[0, pp, ss, 0])
+                particle_states[0, pp, 0] = particle_states[1, p_source, 0]
+                particle_states[0, pp, 1] = particle_states[1, p_source, 1]
+                particle_weights[0, pp] = 1. / particle_count
+
+    # update the streamline with the trajectory of one particle
+    cumsum(&particle_weights[0, 0],
+           &particle_weights[0, 0],
+           particle_count)
+    rdm_sample = random() * particle_weights[0, particle_count - 1]
+    p = where_to_insert(&particle_weights[0, 0], rdm_sample, particle_count)
+
+    for s in range(particle_states[0, p, 1]):
+        copypoint(&particle_paths[0, p, s, 0], &streamline[streamline_i + s, 0])
+        copypoint(&particle_dirs[0, p, s, 0], &directions[streamline_i + s, 0])
+    tissue_class[0] = <TissueClass> particle_states[0, p, 0]
+    return streamline_i + particle_states[0, p, 1] - 1

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -1,8 +1,11 @@
 import numpy as np
 
-from dipy.tracking.local.localtrack import local_tracker
+from dipy.tracking.local.localtrack import local_tracker, pft_tracker
+from dipy.tracking.local.tissue_classifier import ConstrainedTissueClassifier
+
 from dipy.align import Bunch
 from dipy.tracking import utils
+
 
 # enum TissueClass (tissue_classifier.pxd) is not accessible
 # from here. To be changed when minimal cython version > 0.21.
@@ -68,6 +71,7 @@ class LocalTracking(object):
             If true, return all generated streamlines, otherwise only
             streamlines reaching end points or exiting the image.
         """
+
         self.direction_getter = direction_getter
         self.tissue_classifier = tissue_classifier
         self.seeds = seeds
@@ -76,10 +80,20 @@ class LocalTracking(object):
         self.affine = affine
         self._voxel_size = self._get_voxel_size(affine)
         self.step_size = step_size
-        self.fixed = fixedstep
+        self.fixed_stepsize = fixedstep
         self.max_cross = max_cross
-        self.maxlen = maxlen
+        self.max_length = maxlen
         self.return_all = return_all
+
+    def _tracker(self, seed, first_step, streamline):
+        return local_tracker(self.direction_getter,
+                             self.tissue_classifier,
+                             seed,
+                             first_step,
+                             self._voxel_size,
+                             streamline,
+                             self.step_size,
+                             self.fixed_stepsize)
 
     def __iter__(self):
         # Make tracks, move them to point space and return
@@ -88,38 +102,29 @@ class LocalTracking(object):
 
     def _generate_streamlines(self):
         """A streamline generator"""
-        N = self.maxlen
-        dg = self.direction_getter
-        tc = self.tissue_classifier
-        ss = self.step_size
-        fixed = self.fixed
-        max_cross = self.max_cross
-        vs = self._voxel_size
 
         # Get inverse transform (lin/offset) for seeds
         inv_A = np.linalg.inv(self.affine)
         lin = inv_A[:3, :3]
         offset = inv_A[:3, 3]
 
-        F = np.empty((N + 1, 3), dtype=float)
+        F = np.empty((self.max_length + 1, 3), dtype=float)
         B = F.copy()
         for s in self.seeds:
             s = np.dot(lin, s) + offset
-            directions = dg.initial_direction(s)
+            directions = self.direction_getter.initial_direction(s)
             if directions.size == 0 and self.return_all:
                 # only the seed position
                 yield [s]
-            directions = directions[:max_cross]
+            directions = directions[:self.max_cross]
             for first_step in directions:
-                stepsF, tissue_class = local_tracker(dg, tc, s, first_step,
-                                                     vs, F, ss, fixed)
+                stepsF, tissue_class = self._tracker(s, first_step, F)
                 if not (self.return_all or
                         tissue_class == TissueTypes.ENDPOINT or
                         tissue_class == TissueTypes.OUTSIDEIMAGE):
                     continue
                 first_step = -first_step
-                stepsB, tissue_class = local_tracker(dg, tc, s, first_step,
-                                                     vs, B, ss, fixed)
+                stepsB, tissue_class = self._tracker(s, first_step, B)
                 if not (self.return_all or
                         tissue_class == TissueTypes.ENDPOINT or
                         tissue_class == TissueTypes.OUTSIDEIMAGE):
@@ -128,6 +133,114 @@ class LocalTracking(object):
                 if stepsB == 1:
                     streamline = F[:stepsF].copy()
                 else:
-                    parts = (B[stepsB-1:0:-1], F[:stepsF])
+                    parts = (B[stepsB - 1:0:-1], F[:stepsF])
                     streamline = np.concatenate(parts, axis=0)
                 yield streamline
+
+
+class ParticleFilteringTracking(LocalTracking):
+    """A streamline generator using the particle filtering tractography method
+    """
+
+    def __init__(self, direction_getter, tissue_classifier, seeds, affine,
+                 step_size, max_cross=None, maxlen=500,
+                 pft_back_tracking_dist=2, pft_front_tracking_dist=1,
+                 pft_max_trial=20, particle_count=15, return_all=True):
+        """Creates streamlines by using local fiber-tracking.
+
+        Parameters
+        ----------
+        direction_getter : instance of ProbabilisticDirectionGetter
+            Used to get directions for fiber tracking.
+        tissue_classifier : instance of ConstrainedTissueClassifier
+            Identifies endpoints and invalid points to inform tracking.
+        seeds : array (N, 3)
+            Points to seed the tracking. Seed points should be given in point
+            space of the track (see ``affine``).
+        affine : array (4, 4)
+            Coordinate space for the streamline point with respect to voxel
+            indices of input data. This affine can contain scaling, rotational,
+            and translational components but should not contain any shearing.
+            An identity matrix can be used to generate streamlines in "voxel
+            coordinates" as long as isotropic voxels were used to acquire the
+            data.
+        step_size : float
+            Step size used for tracking.
+        max_cross : int or None
+            The maximum number of direction to track from each seed in crossing
+            voxels. By default all initial directions are tracked.
+        maxlen : int
+            Maximum number of steps to track from seed. Used to prevent
+            infinite loops.
+        pft_back_tracking_dist : float
+            Distance in mm to back track before starting the particle filtering
+            tractography. The total particle filtering tractography distance is
+            equal to back_tracking_dist + front_tracking_dist.
+            By default this is set to 2 mm.
+        pft_front_tracking_dist : float
+            Distance in mm to run the particle filtering tractography after the
+            the back track distance. The total particle filtering tractography
+            distance is equal to back_tracking_dist + front_tracking_dist. By
+            default this is set to 1 mm.
+        pft_pft_max_trial : int
+            Maximum number of trial for the particle filtering tractography
+            (Prevents infinite loops).
+        particle_count : int
+            Number of particles to use in the particle filter.
+        return_all : bool
+            If true, return all generated streamlines, otherwise only
+            streamlines reaching end points or exiting the image.
+        """
+
+        if not isinstance(tissue_classifier, ConstrainedTissueClassifier):
+            raise ValueError("expecting ConstrainedTissueClassifier")
+
+        self.pft_nbr_back_steps = int(np.ceil(pft_back_tracking_dist
+                                              / step_size))
+        self.pft_max_steps = int(np.ceil((pft_back_tracking_dist
+                                          + pft_front_tracking_dist)
+                                         / step_size))
+        if not self.pft_max_steps > 0:
+            raise ValueError("The number of PFT steps must be greater than 0.")
+
+        self.directions = np.empty((maxlen + 1, 3), dtype=float)
+
+        self.pft_max_trial = pft_max_trial
+        self.particle_count = particle_count
+        self.particle_paths = np.empty((2, self.particle_count,
+                                        self.pft_max_steps + 1, 3),
+                                       dtype=float)
+        self.particle_weights = np.empty((2, self.particle_count),
+                                         dtype=float)
+        self.particle_dirs = np.empty((2, self.particle_count,
+                                       self.pft_max_steps + 1, 3),
+                                      dtype=float)
+        self.particle_states = np.empty((2, self.particle_count, 2),
+                                        dtype=int)
+        super(ParticleFilteringTracking, self).__init__(direction_getter,
+                                                        tissue_classifier,
+                                                        seeds,
+                                                        affine,
+                                                        step_size,
+                                                        max_cross,
+                                                        maxlen,
+                                                        True,
+                                                        return_all)
+
+    def _tracker(self, seed, first_step, streamline):
+        return pft_tracker(self.direction_getter,
+                           self.tissue_classifier,
+                           seed,
+                           first_step,
+                           self._voxel_size,
+                           streamline,
+                           self.directions,
+                           self.step_size,
+                           self.pft_nbr_back_steps,
+                           self.pft_max_steps,
+                           self.pft_max_trial,
+                           self.particle_count,
+                           self.particle_paths,
+                           self.particle_dirs,
+                           self.particle_weights,
+                           self.particle_states)

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -79,6 +79,8 @@ class LocalTracking(object):
             raise ValueError("affine should be a (4, 4) array.")
         if step_size <= 0:
             raise ValueError("step_size must be greater than 0.")
+        if maxlen < 1:
+            raise ValueError("maxlen must be greater than 0.")
         self.affine = affine
         self._voxel_size = np.ascontiguousarray(self._get_voxel_size(affine),
                                                 dtype=float)
@@ -132,7 +134,6 @@ class LocalTracking(object):
                         tissue_class == TissueTypes.ENDPOINT or
                         tissue_class == TissueTypes.OUTSIDEIMAGE):
                     continue
-
                 if stepsB == 1:
                     streamline = F[:stepsF].copy()
                 else:
@@ -198,12 +199,12 @@ class ParticleFilteringTracking(LocalTracking):
         if not isinstance(tissue_classifier, ConstrainedTissueClassifier):
             raise ValueError("expecting ConstrainedTissueClassifier")
 
-        self.pft_nbr_back_steps = int(np.ceil(pft_back_tracking_dist
-                                              / step_size))
+        self.pft_max_nbr_back_steps = int(np.ceil(pft_back_tracking_dist
+                                                  / step_size))
         self.pft_max_steps = int(np.ceil((pft_back_tracking_dist
                                           + pft_front_tracking_dist)
                                          / step_size))
-        if not self.pft_max_steps > 0 or not self.pft_nbr_back_steps >= 0:
+        if not self.pft_max_steps > 0 or not self.pft_max_nbr_back_steps >= 0:
             raise ValueError("The number of PFT steps must be greater than 0.")
 
         self.directions = np.empty((maxlen + 1, 3), dtype=float)
@@ -236,7 +237,7 @@ class ParticleFilteringTracking(LocalTracking):
                            streamline,
                            self.directions,
                            self.step_size,
-                           self.pft_nbr_back_steps,
+                           self.pft_max_nbr_back_steps,
                            self.pft_max_steps,
                            self.pft_max_trial,
                            self.particle_count,

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -201,10 +201,14 @@ class ParticleFilteringTracking(LocalTracking):
 
         self.pft_max_nbr_back_steps = int(np.ceil(pft_back_tracking_dist
                                                   / step_size))
-        self.pft_max_steps = int(np.ceil((pft_back_tracking_dist
-                                          + pft_front_tracking_dist)
-                                         / step_size))
-        if not self.pft_max_steps > 0 or not self.pft_max_nbr_back_steps >= 0:
+        self.pft_max_nbr_front_steps = int(np.ceil(pft_front_tracking_dist
+                                                   / step_size))
+        self.pft_max_steps = (self.pft_max_nbr_back_steps
+                              + self.pft_max_nbr_front_steps)
+
+        if (self.pft_max_nbr_front_steps < 0
+                or self.pft_max_nbr_back_steps < 0
+                or self.pft_max_steps < 1):
             raise ValueError("The number of PFT steps must be greater than 0.")
 
         self.directions = np.empty((maxlen + 1, 3), dtype=float)
@@ -238,7 +242,7 @@ class ParticleFilteringTracking(LocalTracking):
                            self.directions,
                            self.step_size,
                            self.pft_max_nbr_back_steps,
-                           self.pft_max_steps,
+                           self.pft_max_nbr_front_steps,
                            self.pft_max_trial,
                            self.particle_count,
                            self.particle_paths,

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -213,7 +213,7 @@ class ParticleFilteringTracking(LocalTracking):
         self.particle_paths = np.empty((2, self.particle_count,
                                         self.pft_max_steps + 1, 3),
                                        dtype=float)
-        self.particle_weights = np.empty((2, self.particle_count), dtype=float)
+        self.particle_weights = np.empty(self.particle_count, dtype=float)
         self.particle_dirs = np.empty((2, self.particle_count,
                                        self.pft_max_steps + 1, 3), dtype=float)
         self.particle_states = np.empty((2, self.particle_count, 2), dtype=int)

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -15,7 +15,6 @@ TissueTypes = Bunch(OUTSIDEIMAGE=-1, INVALIDPOINT=0, TRACKPOINT=1, ENDPOINT=2)
 
 
 class LocalTracking(object):
-    """A streamline generator for local tracking methods"""
 
     @staticmethod
     def _get_voxel_size(affine):
@@ -143,14 +142,13 @@ class LocalTracking(object):
 
 
 class ParticleFilteringTracking(LocalTracking):
-    """A streamline generator using the particle filtering tractography method
-    """
 
     def __init__(self, direction_getter, tissue_classifier, seeds, affine,
                  step_size, max_cross=None, maxlen=500,
                  pft_back_tracking_dist=2, pft_front_tracking_dist=1,
                  pft_max_trial=20, particle_count=15, return_all=True):
-        """Creates streamlines by using local fiber-tracking.
+        r"""A streamline generator using the particle filtering tractography
+        method [1]_.
 
         Parameters
         ----------
@@ -194,6 +192,12 @@ class ParticleFilteringTracking(LocalTracking):
         return_all : bool
             If true, return all generated streamlines, otherwise only
             streamlines reaching end points or exiting the image.
+
+        References
+        ----------
+        .. [1] Girard, G., Whittingstall, K., Deriche, R., & Descoteaux, M.
+               Towards quantitative connectivity analysis: reducing
+               tractography biases. NeuroImage, 98, 266-278, 2014.
         """
 
         if not isinstance(tissue_classifier, ConstrainedTissueClassifier):

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -78,7 +78,8 @@ class LocalTracking(object):
         if affine.shape != (4, 4):
             raise ValueError("affine should be a (4, 4) array.")
         self.affine = affine
-        self._voxel_size = self._get_voxel_size(affine)
+        self._voxel_size = np.ascontiguousarray(self._get_voxel_size(affine),
+                                                dtype=float)
         self.step_size = step_size
         self.fixed_stepsize = fixedstep
         self.max_cross = max_cross
@@ -210,13 +211,10 @@ class ParticleFilteringTracking(LocalTracking):
         self.particle_paths = np.empty((2, self.particle_count,
                                         self.pft_max_steps + 1, 3),
                                        dtype=float)
-        self.particle_weights = np.empty((2, self.particle_count),
-                                         dtype=float)
+        self.particle_weights = np.empty((2, self.particle_count), dtype=float)
         self.particle_dirs = np.empty((2, self.particle_count,
-                                       self.pft_max_steps + 1, 3),
-                                      dtype=float)
-        self.particle_states = np.empty((2, self.particle_count, 2),
-                                        dtype=int)
+                                       self.pft_max_steps + 1, 3), dtype=float)
+        self.particle_states = np.empty((2, self.particle_count, 2), dtype=int)
         super(ParticleFilteringTracking, self).__init__(direction_getter,
                                                         tissue_classifier,
                                                         seeds,

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -203,24 +203,27 @@ class ParticleFilteringTracking(LocalTracking):
                                                   / step_size))
         self.pft_max_nbr_front_steps = int(np.ceil(pft_front_tracking_dist
                                                    / step_size))
-        self.pft_max_steps = (self.pft_max_nbr_back_steps
-                              + self.pft_max_nbr_front_steps)
+        pft_max_steps = (self.pft_max_nbr_back_steps +
+                         self.pft_max_nbr_front_steps)
 
         if (self.pft_max_nbr_front_steps < 0
                 or self.pft_max_nbr_back_steps < 0
-                or self.pft_max_steps < 1):
+                or pft_max_steps < 1):
             raise ValueError("The number of PFT steps must be greater than 0.")
+
+        if particle_count <= 0:
+            raise ValueError("The particle count must be greater than 0.")
 
         self.directions = np.empty((maxlen + 1, 3), dtype=float)
 
         self.pft_max_trial = pft_max_trial
         self.particle_count = particle_count
         self.particle_paths = np.empty((2, self.particle_count,
-                                        self.pft_max_steps + 1, 3),
+                                        pft_max_steps + 1, 3),
                                        dtype=float)
         self.particle_weights = np.empty(self.particle_count, dtype=float)
         self.particle_dirs = np.empty((2, self.particle_count,
-                                       self.pft_max_steps + 1, 3), dtype=float)
+                                       pft_max_steps + 1, 3), dtype=float)
         self.particle_states = np.empty((2, self.particle_count, 2), dtype=int)
         super(ParticleFilteringTracking, self).__init__(direction_getter,
                                                         tissue_classifier,

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -224,7 +224,9 @@ class ParticleFilteringTracking(LocalTracking):
         self.particle_weights = np.empty(self.particle_count, dtype=float)
         self.particle_dirs = np.empty((2, self.particle_count,
                                        pft_max_steps + 1, 3), dtype=float)
-        self.particle_states = np.empty((2, self.particle_count, 2), dtype=int)
+        self.particle_steps = np.empty((2, self.particle_count), dtype=int)
+        self.particle_tissue_classes = np.empty((2, self.particle_count),
+                                                dtype=int)
         super(ParticleFilteringTracking, self).__init__(direction_getter,
                                                         tissue_classifier,
                                                         seeds,
@@ -251,4 +253,5 @@ class ParticleFilteringTracking(LocalTracking):
                            self.particle_paths,
                            self.particle_dirs,
                            self.particle_weights,
-                           self.particle_states)
+                           self.particle_steps,
+                           self.particle_tissue_classes)

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -77,6 +77,8 @@ class LocalTracking(object):
         self.seeds = seeds
         if affine.shape != (4, 4):
             raise ValueError("affine should be a (4, 4) array.")
+        if step_size <= 0:
+            raise ValueError("step_size must be greater than 0.")
         self.affine = affine
         self._voxel_size = np.ascontiguousarray(self._get_voxel_size(affine),
                                                 dtype=float)
@@ -183,7 +185,7 @@ class ParticleFilteringTracking(LocalTracking):
             the back track distance. The total particle filtering tractography
             distance is equal to back_tracking_dist + front_tracking_dist. By
             default this is set to 1 mm.
-        pft_pft_max_trial : int
+        pft_max_trial : int
             Maximum number of trial for the particle filtering tractography
             (Prevents infinite loops).
         particle_count : int
@@ -201,7 +203,7 @@ class ParticleFilteringTracking(LocalTracking):
         self.pft_max_steps = int(np.ceil((pft_back_tracking_dist
                                           + pft_front_tracking_dist)
                                          / step_size))
-        if not self.pft_max_steps > 0:
+        if not self.pft_max_steps > 0 or not self.pft_nbr_back_steps >= 0:
             raise ValueError("The number of PFT steps must be greater than 0.")
 
         self.directions = np.empty((maxlen + 1, 3), dtype=float)

--- a/dipy/tracking/local/tests/test_tissue_classifier.py
+++ b/dipy/tracking/local/tests/test_tissue_classifier.py
@@ -6,7 +6,8 @@ import scipy.ndimage
 from dipy.core.ndindex import ndindex
 from dipy.tracking.local import (BinaryTissueClassifier,
                                  ThresholdTissueClassifier,
-                                 ActTissueClassifier)
+                                 ActTissueClassifier,
+                                 CmcTissueClassifier)
 from dipy.tracking.local.localtracking import TissueTypes
 
 
@@ -149,6 +150,56 @@ def test_act_tissue_classifier():
         pts = np.array(pts, dtype='float64')
         state = act_tc.check_point(pts)
         npt.assert_equal(state, TissueTypes.OUTSIDEIMAGE)
+
+
+def test_cmc_tissue_classifier():
+    """This tests that the cmc tissue classifier returns expected
+     tissue types.
+    """
+
+    gm = np.array([[[1, 1], [0, 0], [0, 0]]])
+    wm = np.array([[[0, 0], [1, 1], [0, 0]]])
+    csf = np.array([[[0, 0], [0, 0], [1, 1]]])
+    include_map = gm
+    exclude_map = csf
+
+    cmc_tc = CmcTissueClassifier(include_map=include_map,
+                                 exclude_map=exclude_map,
+                                 step_size=1,
+                                 average_voxel_size=1)
+    cmc_tc_from_pve = CmcTissueClassifier.from_pve(wm_map=wm,
+                                                   gm_map=gm,
+                                                   csf_map=csf,
+                                                   step_size=1,
+                                                   average_voxel_size=1)
+
+    # test contructors
+    for idx in np.ndindex(wm.shape):
+        idx = np.asarray(idx, dtype="float64")
+        npt.assert_almost_equal(cmc_tc.get_include(idx),
+                                cmc_tc_from_pve.get_include(idx))
+        npt.assert_almost_equal(cmc_tc.get_exclude(idx),
+                                cmc_tc_from_pve.get_exclude(idx))
+
+    # test voxel center
+    for ind in ndindex(wm.shape):
+        pts = np.array(ind, dtype='float64')
+        state = cmc_tc.check_point(pts)
+        if csf[ind] == 1:
+            npt.assert_equal(state, TissueTypes.INVALIDPOINT)
+        elif gm[ind] == 1:
+            npt.assert_equal(state, TissueTypes.ENDPOINT)
+        else:
+            npt.assert_equal(state, TissueTypes.TRACKPOINT)
+
+    # test outside points
+    outside_pts = [[100, 100, 100], [0, -1, 1], [0, 10, 2],
+                   [0, 0.5, -0.51], [0, -0.51, 0.1]]
+    for pts in outside_pts:
+        pts = np.array(pts, dtype='float64')
+        state = cmc_tc.check_point(pts)
+        npt.assert_equal(state, TissueTypes.OUTSIDEIMAGE)
+
 
 if __name__ == '__main__':
     run_module_suite()

--- a/dipy/tracking/local/tests/test_tissue_classifier.py
+++ b/dipy/tracking/local/tests/test_tissue_classifier.py
@@ -202,4 +202,4 @@ def test_cmc_tissue_classifier():
 
 
 if __name__ == '__main__':
-    run_module_suite()
+    npt.run_module_suite()

--- a/dipy/tracking/local/tests/test_tissue_classifier.py
+++ b/dipy/tracking/local/tests/test_tissue_classifier.py
@@ -22,7 +22,7 @@ def test_binary_tissue_classifier():
     btc_boolean = BinaryTissueClassifier(mask > 0)
     btc_float64 = BinaryTissueClassifier(mask)
 
-    # test voxel center
+    # Test voxel center
     for ind in ndindex(mask.shape):
         pts = np.array(ind, dtype='float64')
         state_boolean = btc_boolean.check_point(pts)
@@ -34,7 +34,7 @@ def test_binary_tissue_classifier():
             npt.assert_equal(state_boolean, TissueTypes.ENDPOINT)
             npt.assert_equal(state_float64, TissueTypes.ENDPOINT)
 
-    # test random points in voxel
+    # Test random points in voxel
     for ind in ndindex(mask.shape):
         for _ in range(50):
             pts = np.array(ind, dtype='float64') + np.random.random(3) - 0.5
@@ -47,7 +47,7 @@ def test_binary_tissue_classifier():
                 npt.assert_equal(state_boolean, TissueTypes.ENDPOINT)
                 npt.assert_equal(state_float64, TissueTypes.ENDPOINT)
 
-    # test outside points
+    # Test outside points
     outside_pts = [[100, 100, 100], [0, -1, 1], [0, 10, 2],
                    [0, 0.5, -0.51], [0, -0.51, 0.1], [4, 0, 0]]
     for pts in outside_pts:
@@ -67,7 +67,7 @@ def test_threshold_tissue_classifier():
 
     ttc = ThresholdTissueClassifier(tissue_map.astype('float32'), 0.5)
 
-    # test voxel center
+    # Test voxel center
     for ind in ndindex(tissue_map.shape):
         pts = np.array(ind, dtype='float64')
         state = ttc.check_point(pts)
@@ -76,7 +76,7 @@ def test_threshold_tissue_classifier():
         else:
             npt.assert_equal(state, TissueTypes.ENDPOINT)
 
-    # test random points in voxel
+    # Test random points in voxel
     inds = [[0, 1.4, 2.2], [0, 2.3, 2.3], [0, 2.2, 1.3], [0, 0.9, 2.2],
             [0, 2.8, 1.1], [0, 1.1, 3.3], [0, 2.1, 1.9], [0, 3.1, 3.1],
             [0, 0.1, 0.1], [0, 0.9, 0.5], [0, 0.9, 0.5], [0, 2.9, 0.1]]
@@ -90,7 +90,7 @@ def test_threshold_tissue_classifier():
         else:
             npt.assert_equal(state, TissueTypes.ENDPOINT)
 
-    # test outside points
+    # Test outside points
     outside_pts = [[100, 100, 100], [0, -1, 1], [0, 10, 2],
                    [0, 0.5, -0.51], [0, -0.51, 0.1]]
     for pts in outside_pts:
@@ -114,7 +114,7 @@ def test_act_tissue_classifier():
 
     act_tc = ActTissueClassifier(include_map=gm, exclude_map=csf)
 
-    # test voxel center
+    # Test voxel center
     for ind in ndindex(wm.shape):
         pts = np.array(ind, dtype='float64')
         state = act_tc.check_point(pts)
@@ -125,7 +125,7 @@ def test_act_tissue_classifier():
         else:
             npt.assert_equal(state, TissueTypes.TRACKPOINT)
 
-    # test random points in voxel
+    # Test random points in voxel
     inds = [[0, 1.4, 2.2], [0, 2.3, 2.3], [0, 2.2, 1.3], [0, 0.9, 2.2],
             [0, 2.8, 1.1], [0, 1.1, 3.3], [0, 2.1, 1.9], [0, 3.1, 3.1],
             [0, 0.1, 0.1], [0, 0.9, 0.5], [0, 0.9, 0.5], [0, 2.9, 0.1]]
@@ -143,7 +143,7 @@ def test_act_tissue_classifier():
         else:
             npt.assert_equal(state, TissueTypes.TRACKPOINT)
 
-    # test outside points
+    # Test outside points
     outside_pts = [[100, 100, 100], [0, -1, 1], [0, 10, 2],
                    [0, 0.5, -0.51], [0, -0.51, 0.1]]
     for pts in outside_pts:
@@ -173,7 +173,7 @@ def test_cmc_tissue_classifier():
                                                    step_size=1,
                                                    average_voxel_size=1)
 
-    # test contructors
+    # Test contructors
     for idx in np.ndindex(wm.shape):
         idx = np.asarray(idx, dtype="float64")
         npt.assert_almost_equal(cmc_tc.get_include(idx),
@@ -181,7 +181,7 @@ def test_cmc_tissue_classifier():
         npt.assert_almost_equal(cmc_tc.get_exclude(idx),
                                 cmc_tc_from_pve.get_exclude(idx))
 
-    # test voxel center
+    # Test voxel center
     for ind in ndindex(wm.shape):
         pts = np.array(ind, dtype='float64')
         state = cmc_tc.check_point(pts)
@@ -192,13 +192,14 @@ def test_cmc_tissue_classifier():
         else:
             npt.assert_equal(state, TissueTypes.TRACKPOINT)
 
-    # test outside points
+    # Test outside points
     outside_pts = [[100, 100, 100], [0, -1, 1], [0, 10, 2],
                    [0, 0.5, -0.51], [0, -0.51, 0.1]]
     for pts in outside_pts:
         pts = np.array(pts, dtype='float64')
-        state = cmc_tc.check_point(pts)
-        npt.assert_equal(state, TissueTypes.OUTSIDEIMAGE)
+        npt.assert_equal(cmc_tc.check_point(pts), TissueTypes.OUTSIDEIMAGE)
+        npt.assert_equal(cmc_tc.get_exclude(pts), 0)
+        npt.assert_equal(cmc_tc.get_include(pts), 0)
 
 
 if __name__ == '__main__':

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -4,18 +4,18 @@ import numpy as np
 import numpy.testing as npt
 
 from dipy.core.sphere import HemiSphere, unit_octahedron
-from dipy.data import get_data
+from dipy.core.gradients import gradient_table
+from dipy.data import get_data, get_sphere
 from dipy.direction import (DeterministicMaximumDirectionGetter,
                             PeaksAndMetrics,
                             ProbabilisticDirectionGetter)
-from dipy.tracking.local import (ActTissueClassifier,
-                                 BinaryTissueClassifier,
-                                 DirectionGetter,
-                                 LocalTracking,
-                                 ThresholdTissueClassifier,
-                                 TissueClassifier)
+from dipy.tracking.local import (ActTissueClassifier, BinaryTissueClassifier,
+                                 DirectionGetter, LocalTracking,
+                                 ParticleFilteringTracking,
+                                 ThresholdTissueClassifier, TissueClassifier)
 from dipy.tracking.local.interpolation import trilinear_interpolate4d
 from dipy.tracking.local.localtracking import TissueTypes
+from dipy.tracking.utils import seeds_from_mask
 
 
 def test_stop_conditions():
@@ -214,7 +214,8 @@ def test_probabilistic_odf_weighted_tracker():
     mask = (simple_image > 0).astype(float)
     tc = ThresholdTissueClassifier(mask, .5)
 
-    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, sphere, pmf_threshold=0.1)
+    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, sphere,
+                                               pmf_threshold=0.1)
     streamlines = LocalTracking(dg, tc, seeds, np.eye(4), 1.)
 
     expected = [np.array([[0., 1., 0.],
@@ -260,7 +261,75 @@ def test_probabilistic_odf_weighted_tracker():
         npt.assert_(np.allclose(sl, expected[1]))
 
 
-def test_maximum_deterministic_tracker():
+def test_ParticleFilteringTractography():
+    """This tests that the ParticleFilteringTracking produces
+    more streamlines connecting the gray matter than LocalTracking.
+    """
+    #sphere = HemiSphere.from_sphere(unit_octahedron)
+    sphere = get_sphere('repulsion100')
+
+    # Simple tissue masks
+    simple_wm = np.array([[0, 0, 0, 0, 0, 0],
+                          [0, 0, 1, 0, 0, 0],
+                          [0, 1, 1, 1, 0, 0],
+                          [0, 1, 1, 1, 0, 0],
+                          [0, 0, 0, 0, 0, 0]])
+    simple_wm = np.dstack([np.zeros(simple_wm.shape),
+                           simple_wm,
+                           simple_wm,
+                           simple_wm,
+                           np.zeros(simple_wm.shape)])
+    simple_gm = np.array([[0, 0, 0, 0, 0, 0],
+                          [0, 1, 0, 0, 0, 0],
+                          [0, 1, 0, 0, 1, 0],
+                          [0, 0, 0, 0, 1, 0],
+                          [0, 0, 0, 0, 0, 0]])
+    simple_gm = np.dstack([np.zeros(simple_gm.shape),
+                           simple_gm,
+                           simple_gm,
+                           simple_gm,
+                           np.zeros(simple_gm.shape)])
+    simple_csf = np.ones(simple_wm.shape) - simple_wm - simple_gm
+    tc = ActTissueClassifier.from_pve(simple_wm, simple_gm, simple_csf)
+    seeds = seeds_from_mask(simple_wm, density=2)
+
+    # Random pfm in every voxels
+    shape_img = list(simple_wm.shape)
+    shape_img.extend([sphere.vertices.shape[0]])
+    np.random.seed(0)  # fix the randominity
+    pmf = np.random.random(shape_img)
+
+    # Test that PFT recover equal or more streamlines than localTracking
+    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 60, sphere)
+    local_streamlines = LocalTracking(dg, tc, seeds, np.eye(4), 0.2,
+                                      max_cross=1, return_all=False)
+    local_streamlines = [s for s in local_streamlines]
+    pft_streamlines = ParticleFilteringTracking(dg, tc, seeds, np.eye(4), 0.2,
+                                                max_cross=1, return_all=False)
+    pft_streamlines = [s for s in pft_streamlines]
+    npt.assert_(np.array([len(pft_streamlines) > 0]))
+    npt.assert_(np.array([len(pft_streamlines) >= len(local_streamlines)]))
+
+    # Test that the number of streamline return with return_all=True equal the
+    # number of seeds places
+    pft_streamlines = ParticleFilteringTracking(dg, tc, seeds, np.eye(4), 0.2,
+                                                max_cross=1, return_all=True)
+    pft_streamlines = [s for s in pft_streamlines]
+    npt.assert_(np.array([len(pft_streamlines) == len(seeds)]))
+
+    # Test with wrong tissueclassifier type
+    tc_bin = BinaryTissueClassifier(simple_wm)
+
+    def test_PFT_init():
+        pft_streamlines = ParticleFilteringTracking(dg, tc_bin, seeds,
+                                                    np.eye(4), 0.2)
+        pft_streamlines = ParticleFilteringTracking(dg, tc_bin, seeds,
+                                                    np.eye(4), 0.2,
+                                                    pft_nbr_steps=0)
+    npt.assert_raises(ValueError, test_PFT_init)
+
+
+def test_MaximumDeterministicTracker():
     """This tests that the Maximum Deterministic Direction Getter plays nice
     LocalTracking and produces reasonable streamlines in a simple example.
     """

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -399,6 +399,15 @@ def test_particle_filtering_tractography():
         lambda: ParticleFilteringTracking(dg, tc, seeds, np.eye(4), step_size,
                                           maxlen=-1))
 
+    # Test with invalid particle count
+    npt.assert_raises(
+        ValueError,
+        lambda: ParticleFilteringTracking(dg, tc, seeds, np.eye(4), step_size,
+                                          particle_count=0))
+    npt.assert_raises(
+        ValueError,
+        lambda: ParticleFilteringTracking(dg, tc, seeds, np.eye(4), step_size,
+                                          particle_count=-1))
 
 def test_maximum_deterministic_tracker():
     """This tests that the Maximum Deterministic Direction Getter plays nice

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -298,10 +298,10 @@ def test_particle_filtering_tractography():
     tc = ActTissueClassifier.from_pve(simple_wm, simple_gm, simple_csf)
     seeds = seeds_from_mask(simple_wm, density=2)
 
-    # Random pfm in every voxels
+    # Random pmf in every voxel
     shape_img = list(simple_wm.shape)
     shape_img.extend([sphere.vertices.shape[0]])
-    np.random.seed(0)  # fix the randominity
+    np.random.seed(0)  # Random number generator initialization
     pmf = np.random.random(shape_img)
 
     # Test that PFT recover equal or more streamlines than localTracking
@@ -377,6 +377,7 @@ def test_particle_filtering_tractography():
         ValueError,
         lambda: ParticleFilteringTracking(dg, tc, seeds, np.eye(4), 0.2,
                                           maxlen=-1))
+
 
 def test_maximum_deterministic_tracker():
     """This tests that the Maximum Deterministic Direction Getter plays nice

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -359,9 +359,9 @@ def test_particle_filtering_tractography():
                                                 step_size, max_cross=1,
                                                 return_all=True)
     pft_streamlines = list(pft_streamlines)
-    npt.assert_(len(pft_streamlines[0]) == 3)  # INVALIDPOINT
-    npt.assert_(len(pft_streamlines[1]) == 3)  # ENDPOINT
-    npt.assert_(len(pft_streamlines[2]) == 1)  # OUTSIDEIMAGE
+    npt.assert_equal(len(pft_streamlines[0]), 3)  # INVALIDPOINT
+    npt.assert_equal(len(pft_streamlines[1]), 3)  # ENDPOINT
+    npt.assert_equal(len(pft_streamlines[2]), 1)  # OUTSIDEIMAGE
 
     # Test with wrong tissueclassifier type
     tc_bin = BinaryTissueClassifier(simple_wm)

--- a/dipy/tracking/local/tissue_classifier.pxd
+++ b/dipy/tracking/local/tissue_classifier.pxd
@@ -1,5 +1,4 @@
 
-
 cdef enum TissueClass:
     PYERROR = -2
     OUTSIDEIMAGE = -1
@@ -29,6 +28,23 @@ cdef class ThresholdTissueClassifier(TissueClassifier):
     pass
 
 
-cdef class ActTissueClassifier(TissueClassifier):
+cdef class ConstrainedTissueClassifier(TissueClassifier):
     cdef:
         double[:, :, :] include_map, exclude_map
+    cpdef double get_exclude(self, double[::1] point)
+    cdef double get_exclude_c(self, double* point)
+    cpdef double get_include(self, double[::1] point)
+    cdef double get_include_c(self, double* point)
+    pass
+
+
+cdef class ActTissueClassifier(ConstrainedTissueClassifier):
+    pass
+
+
+cdef class CmcTissueClassifier(ConstrainedTissueClassifier):
+    cdef:
+        double step_size
+        double average_voxel_size
+        double correction_factor
+    pass

--- a/dipy/tracking/local/tissue_classifier.pyx
+++ b/dipy/tracking/local/tissue_classifier.pyx
@@ -95,7 +95,78 @@ cdef class ThresholdTissueClassifier(TissueClassifier):
             return ENDPOINT
 
 
-cdef class ActTissueClassifier(TissueClassifier):
+cdef class ConstrainedTissueClassifier(TissueClassifier):
+    r"""
+    Abstract class that takes as input included and excluded tissue maps.
+    The 'include_map' defines when the streamline reached a 'valid' stopping
+    region (e.g. gray matter partial volume estimation (PVE) map) and the
+    'exclude_map' defines when the streamline reached an 'invalid' stopping
+    region (e.g. corticospinal fluid PVE map). The background of the anatomical
+    image should be added to the 'include_map' to keep streamlines exiting the
+    brain (e.g. through the brain stem).
+
+    cdef:
+        double interp_out_double[1]
+        double[:]  interp_out_view = interp_out_view
+        double[:, :, :] include_map, exclude_map
+
+    """
+    def __cinit__(self, include_map, exclude_map, *args, **kw):
+        self.interp_out_view = self.interp_out_double
+        self.include_map = np.asarray(include_map, 'float64')
+        self.exclude_map = np.asarray(exclude_map, 'float64')
+
+    @classmethod
+    def from_pve(klass, wm_map, gm_map, csf_map, **kw):
+        """ConstrainedTissueClassifier from partial volume fraction (PVE)
+        maps.
+
+        Parameters
+        ----------
+        wm_map : array
+            The partial volume fraction of white matter at each voxel.
+        gm_map : array
+            The partial volume fraction of gray matter at each voxel.
+        csf_map : array
+            The partial volume fraction of corticospinal fluid at each
+            voxel.
+
+        """
+        # include map = gray matter + image background
+        include_map = np.copy(gm_map)
+        include_map[(wm_map + gm_map + csf_map) == 0] = 1
+        # exclude map = csf
+        exclude_map = np.copy(csf_map)
+        return klass(include_map, exclude_map, **kw)
+
+    cpdef double get_exclude(self, double[::1] point):
+        if point.shape[0] != 3:
+            raise ValueError("Point has wrong shape")
+
+        return self.get_exclude_c(&point[0])
+
+    cdef double get_exclude_c(self, double* point):
+        exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
+                                                point, self.interp_out_view)
+        if exclude_err == -1:
+            return 0
+        return self.interp_out_view[0]
+
+    cpdef double get_include(self, double[::1] point):
+        if point.shape[0] != 3:
+            raise ValueError("Point has wrong shape")
+
+        return self.get_include_c(&point[0])
+
+    cdef double get_include_c(self, double* point):
+        exclude_err = trilinear_interpolate4d_c(self.include_map[..., None],
+                                                point, self.interp_out_view)
+        if exclude_err == -1:
+            return 0
+        return self.interp_out_view[0]
+
+
+cdef class ActTissueClassifier(ConstrainedTissueClassifier):
     r"""
     Anatomically-Constrained Tractography (ACT) stopping criteria from [1]_.
     This implements the use of partial volume fraction (PVE) maps to
@@ -154,3 +225,73 @@ cdef class ActTissueClassifier(TissueClassifier):
             return INVALIDPOINT
         else:
             return TRACKPOINT
+
+
+cdef class CmcTissueClassifier(ConstrainedTissueClassifier):
+    r"""
+    Continuous map criterion (CMC) stopping criteria from [1]_.
+    This implements the use of partial volume fraction (PVE) maps to
+    determine when the tracking stops.
+
+    cdef:
+        double interp_out_double[1]
+        double[:]  interp_out_view = interp_out_view
+        double[:, :, :] include_map, exclude_map
+        double step_size
+        double average_voxel_size
+        double correction_factor
+
+    References
+    ----------
+    .. [1] Girard, G., Whittingstall, K., Deriche, R., & Descoteaux, M.
+    "Towards quantitative connectivity analysis: reducing tractography biases."
+    NeuroImage, 98, 266–278, 2014.
+    """
+
+    def __cinit__(self, include_map, exclude_map, step_size, average_voxel_size):
+        self.step_size = step_size
+        self.average_voxel_size = average_voxel_size
+        self.correction_factor = step_size / average_voxel_size
+
+    cdef TissueClass check_point_c(self, double* point):
+        cdef:
+            double include_result, exclude_result
+            int include_err, exclude_err
+
+        include_err = trilinear_interpolate4d_c(self.include_map[..., None],
+                                                point, self.interp_out_view)
+        include_result = self.interp_out_view[0]
+
+        exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
+                                                point, self.interp_out_view)
+        exclude_result = self.interp_out_view[0]
+
+        if include_err == -1 or exclude_err == -1:
+            return OUTSIDEIMAGE
+        elif include_err == -2 or exclude_err == -2:
+            raise ValueError("Point has wrong shape")
+        elif include_err != 0:
+            # This should never happen
+            raise RuntimeError("Unexpected interpolation error " +
+                               "(include_map - code:%i)" % include_err)
+        elif exclude_err != 0:
+            # This should never happen
+            raise RuntimeError("Unexpected interpolation error " +
+                               "(exclude_map - code:%i)" % exclude_err)
+
+        # test if the tracking continues
+        if include_result + exclude_result <= 0:
+            return TRACKPOINT
+        num = max(0, (1 - include_result - exclude_result))
+        den = num + include_result + exclude_result
+        p = (num / den) ** self.correction_factor
+        if np.random.random() < p:
+            return TRACKPOINT
+
+        # test if the tracking stopped in the include tissue map
+        p = (include_result / (include_result + exclude_result))
+        if np.random.random() < p:
+            return ENDPOINT
+
+        # the tracking stopped in the exclude tissue map
+        return INVALIDPOINT

--- a/dipy/tracking/local/tissue_classifier.pyx
+++ b/dipy/tracking/local/tissue_classifier.pyx
@@ -148,7 +148,7 @@ cdef class ConstrainedTissueClassifier(TissueClassifier):
     cdef double get_exclude_c(self, double* point):
         exclude_err = trilinear_interpolate4d_c(self.exclude_map[..., None],
                                                 point, self.interp_out_view)
-        if exclude_err == -1:
+        if exclude_err != 0:
             return 0
         return self.interp_out_view[0]
 
@@ -161,7 +161,7 @@ cdef class ConstrainedTissueClassifier(TissueClassifier):
     cdef double get_include_c(self, double* point):
         exclude_err = trilinear_interpolate4d_c(self.include_map[..., None],
                                                 point, self.interp_out_view)
-        if exclude_err == -1:
+        if exclude_err != 0:
             return 0
         return self.interp_out_view[0]
 

--- a/doc/examples/particle_filtering_fiber_tracking.py
+++ b/doc/examples/particle_filtering_fiber_tracking.py
@@ -1,0 +1,137 @@
+"""
+=================================================
+Particle Filtering Tractography
+=================================================
+Particle Filtering Tractography (PFT) [Girard2014]_ uses tissue partial
+volume estimation (PVE) to reconstruct trajectories connecting the gray matter,
+and not incorrectly stopping in the white matter or in the corticospinal fluid.
+It relies on a tissue classifier that identifies the tissue where the streamline
+stopped. If the streamline correctly stopped in the gray matter, the trajectory
+is kept. If the streamline incorrecly stopped in the white matter or in the
+corticospinal fluid, PFT uses anatomical information to find an alternative
+streamline segment to extend the trajectory. When this segment is found,
+the tractography continues until the streamline correctly stops in the gray
+matter.
+
+PFT finds an alternative streamline segment whenever the tissue classifier
+returns a position classified as 'INVALIDPOINT'.
+
+This example is an extension of the
+:ref:`probabilistic_fiber_tracking` example. We begin by loading the
+data, fitting a Constrained Spherical Deconvolution (CSD) reconstruction
+model and creating the probabilistic direction getter.
+"""
+
+import numpy as np
+
+from dipy.data import (read_stanford_labels, default_sphere,
+                       read_stanford_pve_maps)
+from dipy.direction import ProbabilisticDirectionGetter
+from dipy.io.trackvis import save_trk
+from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
+                                   auto_response)
+from dipy.tracking.local import LocalTracking, ParticleFilteringTracking
+from dipy.tracking import utils
+from dipy.viz import fvtk
+from dipy.viz.colormap import line_colors
+
+
+ren = fvtk.ren()
+
+img_pve_csf, img_pve_gm, img_pve_wm = read_stanford_pve_maps()
+hardi_img, gtab, labels_img = read_stanford_labels()
+
+data = hardi_img.get_data()
+labels = labels_img.get_data()
+affine = hardi_img.get_affine()
+shape = labels.shape
+
+response, ratio = auto_response(gtab, data, roi_radius=10, fa_thr=0.7)
+csd_model = ConstrainedSphericalDeconvModel(gtab, response)
+csd_fit = csd_model.fit(data, mask=img_pve_wm.get_data())
+
+dg = ProbabilisticDirectionGetter.from_shcoeff(csd_fit.shm_coeff,
+                                               max_angle=20.,
+                                               sphere=default_sphere)
+
+
+"""
+CMC/ACT Tissue Classifiers
+---------------------
+Continuous map criterion (CMC) [Girard2014]_ and Anatomically-constrained
+tractography (ACT) [Smith2012]_ both uses PVEs information from
+anatomical images to determine when the tractography stops.
+Both tissue classifiers use a trilinear interpolation
+at the tracking position. CMC tissue classifier uses a probability derived from
+the PVE maps to determine if the streamline reaches a 'valid' or 'invalid' region.
+ACT uses a fixed threshold on the PVE maps. Both tissue classifiers can be used
+in conjunction with PFT. In this example, we used CMC.
+"""
+
+import matplotlib.pyplot as plt
+from dipy.tracking.local import CmcTissueClassifier
+
+voxel_size = np.average(img_pve_wm.get_header()['pixdim'][1:4])
+step_size = 0.2
+
+cmc_classifier = CmcTissueClassifier.from_pve(img_pve_wm.get_data(),
+                                              img_pve_gm.get_data(),
+                                              img_pve_csf.get_data(),
+                                              step_size=step_size,
+                                              average_voxel_size=voxel_size)
+
+# seeds are place in voxel of the corpus callosum containing only white matter
+seed_mask = labels == 2
+seed_mask[img_pve_wm.get_data() < 0.5] = 0
+seeds = utils.seeds_from_mask(seed_mask, density=2, affine=affine)
+
+# Particle Filtering Tractography
+pft_streamlines = ParticleFilteringTracking(dg,
+                                            cmc_classifier,
+                                            seeds,
+                                            affine,
+                                            max_cross=1,
+                                            step_size=step_size,
+                                            maxlen=1000,
+                                            pft_back_tracking_dist=2,
+                                            pft_front_tracking_dist=1,
+                                            particle_count=15,
+                                            return_all=False)
+streamlines = [s for s in pft_streamlines]
+save_trk("pft_streamline.trk", streamlines, affine, shape)
+
+
+fvtk.clear(ren)
+fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
+fvtk.record(ren, out_path='pft_streamlines.png', size=(600, 600))
+
+# Local Probabilistic Tractography
+local_prob_streamlines = LocalTracking(dg,
+                                       cmc_classifier,
+                                       seeds,
+                                       affine,
+                                       max_cross=1,
+                                       step_size=step_size,
+                                       maxlen=1000,
+                                       return_all=False)
+streamlines = [s for s in local_prob_streamlines]
+save_trk("local_prob_streamlines.trk", streamlines, affine, shape)
+
+fvtk.clear(ren)
+fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
+fvtk.record(ren, out_path='probabilistic_local_streamlines.png',
+            size=(600, 600))
+
+
+"""
+References
+----------
+.. [Girard2014] Girard, G., Whittingstall, K., Deriche, R., & Descoteaux, M.
+    Towards quantitative connectivity analysis: reducing tractography biases.
+    NeuroImage, 98, 266-278, 2014.
+
+.. [Smith2012] Smith, R. E., Tournier, J.-D., Calamante, F., & Connelly, A.
+    Anatomically-constrained tractography: Improved diffusion MRI
+    streamlines tractography through effective use of anatomical
+    information. NeuroImage, 63(3), 1924-1938, 2012.
+"""

--- a/doc/examples/particle_filtering_fiber_tracking.py
+++ b/doc/examples/particle_filtering_fiber_tracking.py
@@ -105,23 +105,37 @@ renderer.clear()
 renderer.add(actor.line(streamlines, line_colors(streamlines)))
 window.record(renderer, out_path='pft_streamlines.png', size=(600, 600))
 
+"""
+.. figure:: pft_streamlines.png
+ :align: center
+
+ **Particle Filtering Tractography**
+"""
+
 # Local Probabilistic Tractography
-local_prob_streamlines = LocalTracking(dg,
-                                       cmc_classifier,
-                                       seeds,
-                                       affine,
-                                       max_cross=1,
-                                       step_size=step_size,
-                                       maxlen=1000,
-                                       return_all=False)
-streamlines = [s for s in local_prob_streamlines]
-save_trk("local_prob_streamlines.trk", streamlines, affine, shape)
+probabilistic_streamlines = LocalTracking(dg,
+                                          cmc_classifier,
+                                          seeds,
+                                          affine,
+                                          max_cross=1,
+                                          step_size=step_size,
+                                          maxlen=1000,
+                                          return_all=False)
+probabilistic_streamlines = [s for s in probabilistic_streamlines]
+save_trk("probabilistic_streamlines.trk", probabilistic_streamlines, affine,
+         shape)
 
 renderer.clear()
 renderer.add(actor.line(streamlines, line_colors(streamlines)))
-window.record(renderer, out_path='probabilistic_local_streamlines.png',
+window.record(renderer, out_path='probabilistic_streamlines.png',
               size=(600, 600))
 
+"""
+.. figure:: probabilistic_streamlines.png
+ :align: center
+
+ **Probabilistic Tractography**
+"""
 
 """
 References

--- a/doc/examples/particle_filtering_fiber_tracking.py
+++ b/doc/examples/particle_filtering_fiber_tracking.py
@@ -68,8 +68,8 @@ region. ACT uses a fixed threshold on the PVE maps. Both tissue classifiers can
 be used in conjunction with PFT. In this example, we used CMC.
 """
 
-import matplotlib.pyplot as plt
 from dipy.tracking.local import CmcTissueClassifier
+from dipy.tracking.streamline import Streamlines
 
 voxel_size = np.average(img_pve_wm.get_header()['pixdim'][1:4])
 step_size = 0.2
@@ -86,18 +86,18 @@ seed_mask[img_pve_wm.get_data() < 0.5] = 0
 seeds = utils.seeds_from_mask(seed_mask, density=2, affine=affine)
 
 # Particle Filtering Tractography
-pft_streamlines = ParticleFilteringTracking(dg,
-                                            cmc_classifier,
-                                            seeds,
-                                            affine,
-                                            max_cross=1,
-                                            step_size=step_size,
-                                            maxlen=1000,
-                                            pft_back_tracking_dist=2,
-                                            pft_front_tracking_dist=1,
-                                            particle_count=15,
-                                            return_all=False)
-streamlines = [s for s in pft_streamlines]
+pft_streamline_generator = ParticleFilteringTracking(dg,
+                                                     cmc_classifier,
+                                                     seeds,
+                                                     affine,
+                                                     max_cross=1,
+                                                     step_size=step_size,
+                                                     maxlen=1000,
+                                                     pft_back_tracking_dist=2,
+                                                     pft_front_tracking_dist=1,
+                                                     particle_count=15,
+                                                     return_all=False)
+streamlines = Streamlines(pft_streamline_generator)
 save_trk("pft_streamline.trk", streamlines, affine, shape)
 
 
@@ -113,7 +113,7 @@ window.record(renderer, out_path='pft_streamlines.png', size=(600, 600))
 """
 
 # Local Probabilistic Tractography
-probabilistic_streamlines = LocalTracking(dg,
+prob_streamline_generator = LocalTracking(dg,
                                           cmc_classifier,
                                           seeds,
                                           affine,
@@ -121,9 +121,8 @@ probabilistic_streamlines = LocalTracking(dg,
                                           step_size=step_size,
                                           maxlen=1000,
                                           return_all=False)
-probabilistic_streamlines = [s for s in probabilistic_streamlines]
-save_trk("probabilistic_streamlines.trk", probabilistic_streamlines, affine,
-         shape)
+streamlines = Streamlines(prob_streamline_generator)
+save_trk("probabilistic_streamlines.trk", streamlines, affine, shape)
 
 renderer.clear()
 renderer.add(actor.line(streamlines, line_colors(streamlines)))

--- a/doc/examples/particle_filtering_fiber_tracking.py
+++ b/doc/examples/particle_filtering_fiber_tracking.py
@@ -5,13 +5,13 @@ Particle Filtering Tractography
 Particle Filtering Tractography (PFT) [Girard2014]_ uses tissue partial
 volume estimation (PVE) to reconstruct trajectories connecting the gray matter,
 and not incorrectly stopping in the white matter or in the corticospinal fluid.
-It relies on a tissue classifier that identifies the tissue where the streamline
-stopped. If the streamline correctly stopped in the gray matter, the trajectory
-is kept. If the streamline incorrecly stopped in the white matter or in the
-corticospinal fluid, PFT uses anatomical information to find an alternative
-streamline segment to extend the trajectory. When this segment is found,
-the tractography continues until the streamline correctly stops in the gray
-matter.
+It relies on a tissue classifier that identifies the tissue where the
+streamline stopped. If the streamline correctly stopped in the gray matter, the
+trajectory is kept. If the streamline incorrecly stopped in the white matter or
+in the corticospinal fluid, PFT uses anatomical information to find an
+alternative streamline segment to extend the trajectory. When this segment is
+found, the tractography continues until the streamline correctly stops in the
+gray matter.
 
 PFT finds an alternative streamline segment whenever the tissue classifier
 returns a position classified as 'INVALIDPOINT'.
@@ -32,11 +32,11 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response)
 from dipy.tracking.local import LocalTracking, ParticleFilteringTracking
 from dipy.tracking import utils
-from dipy.viz import fvtk
+from dipy.viz import window, actor
 from dipy.viz.colormap import line_colors
 
 
-ren = fvtk.ren()
+renderer = window.Renderer()
 
 img_pve_csf, img_pve_gm, img_pve_wm = read_stanford_pve_maps()
 hardi_img, gtab, labels_img = read_stanford_labels()
@@ -63,9 +63,9 @@ tractography (ACT) [Smith2012]_ both uses PVEs information from
 anatomical images to determine when the tractography stops.
 Both tissue classifiers use a trilinear interpolation
 at the tracking position. CMC tissue classifier uses a probability derived from
-the PVE maps to determine if the streamline reaches a 'valid' or 'invalid' region.
-ACT uses a fixed threshold on the PVE maps. Both tissue classifiers can be used
-in conjunction with PFT. In this example, we used CMC.
+the PVE maps to determine if the streamline reaches a 'valid' or 'invalid'
+region. ACT uses a fixed threshold on the PVE maps. Both tissue classifiers can
+be used in conjunction with PFT. In this example, we used CMC.
 """
 
 import matplotlib.pyplot as plt
@@ -101,9 +101,9 @@ streamlines = [s for s in pft_streamlines]
 save_trk("pft_streamline.trk", streamlines, affine, shape)
 
 
-fvtk.clear(ren)
-fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
-fvtk.record(ren, out_path='pft_streamlines.png', size=(600, 600))
+renderer.clear()
+renderer.add(actor.line(streamlines, line_colors(streamlines)))
+window.record(renderer, out_path='pft_streamlines.png', size=(600, 600))
 
 # Local Probabilistic Tractography
 local_prob_streamlines = LocalTracking(dg,
@@ -117,10 +117,10 @@ local_prob_streamlines = LocalTracking(dg,
 streamlines = [s for s in local_prob_streamlines]
 save_trk("local_prob_streamlines.trk", streamlines, affine, shape)
 
-fvtk.clear(ren)
-fvtk.add(ren, fvtk.line(streamlines, line_colors(streamlines)))
-fvtk.record(ren, out_path='probabilistic_local_streamlines.png',
-            size=(600, 600))
+renderer.clear()
+renderer.add(actor.line(streamlines, line_colors(streamlines)))
+window.record(renderer, out_path='probabilistic_local_streamlines.png',
+              size=(600, 600))
 
 
 """

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -42,6 +42,7 @@
  introduction_to_basic_tracking.py
  probabilistic_fiber_tracking.py
  deterministic_fiber_tracking.py
+ particle_filtering_fiber_tracking.py
  affine_registration_3d.py
  syn_registration_2d.py
  syn_registration_3d.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -138,6 +138,7 @@ Fiber tracking
 - :ref:`example_probabilistic_fiber_tracking`
 - :ref:`example_deterministic_fiber_tracking`
 - :ref:`example_tracking_tissue_classifier`
+- :ref:`example_particle_filtering_fiber_tracking`
 - :ref:`example_sfm_tracking`
 
 -------------------------------------


### PR DESCRIPTION
This PR replaces #1340, and follows the changes of PR #1342.

This PR add a new tissue classifier (CMC) and a new tractography algorithm (PFT). Both methods are described in [Girard et al., NImg, 2014].

CMC - new tissue Classifier. CmcTissueClassifier used probabilities and the tissue partial volume fraction maps to determine when the tracking stops. As it is very similar to ActTissueClassifier, both classes now extend an a new abstract class ConstrainedTissueClassifier.

PFT - new tractography method. ParticleFilteringTracking is inherited from the LocalTracking class. The particle filter is used to find a valid streamline path when the streamline being traced reach the state INVALIDPOINT.

An example is giving in doc/examples/particle_filtering_fiber_tracking.py


References
----------
Girard, G., Whittingstall, K., Deriche, R., & Descoteaux, M. Towards quantitative connectivity analysis: reducing tractography biases. NeuroImage, 98, 266-278, 2014.