### PR TITLE
Re-entering conflict-free typos from deleted PR 1331

### DIFF
--- a/doc/examples/combined_workflow_creation.py
+++ b/doc/examples/combined_workflow_creation.py
@@ -138,11 +138,3 @@ with the parameters and see the results::
 .. include:: ../links_names.inc
 
 """
-
-
-
-
-
-
-
-

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -78,7 +78,7 @@ fvtk.record(ren, out_path='full_sphere.png', size=(300, 300))
 
    Full sphere.
 
-It is time to create the Gradients. For this reason we will need to use the
+It is time to create the Gradients. For this purpose we will use the
 function ``gradient_table`` and fill it with the ``hsph_updated`` vectors that 
 we created above.
 """
@@ -98,7 +98,7 @@ bvecs = np.vstack((vertices, vertices))
 bvals = np.hstack((1000 * values, 2500 * values))
 
 """
-We can also add some b0s. Let's add one in the beginning and one at the end.
+We can also add some b0s. Let's add one at the beginning and one at the end.
 """
 
 bvecs = np.insert(bvecs, (0, bvecs.shape[0]), np.array([0, 0, 0]), axis=0)
@@ -159,8 +159,8 @@ gtab = gradient_table(bvals, bvecs)
 fvtk.rm_all(ren)
 
 """
-We can also visualize the gradients. Let's color with blue the first shell and
-with cyan the second shell.
+We can also visualize the gradients. Let's color the first shell blue and
+the second shell cyan.
 """
 
 colors_b1000 = fvtk.colors.blue * np.ones(vertices.shape)
@@ -190,4 +190,3 @@ References
 .. include:: ../links_names.inc
 
 """
-

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -126,4 +126,3 @@ References
 
 
 """
-

--- a/doc/examples/workflow_creation.py
+++ b/doc/examples/workflow_creation.py
@@ -125,11 +125,3 @@ Now call it for real with a text file::
 .. include:: ../links_names.inc
 
 """
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I believe these are all the corrections that are left that were not addressed by the documentation in the current master branch.  I am not able to run `make` on this, as that seems to want to download data and run dypy.  If there is a way to make _just_ the documentation and you can send me instructions and/or a link to the instructions for making just the docs, then I will be happy to give it a try.

Sorry for all the hassle this has caused.