### PR TITLE
[MRG] Default colormap changed in examples

### DIFF
--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -91,7 +91,7 @@ from dipy.sims.voxel import single_tensor_odf
 response_odf = single_tensor_odf(sphere.vertices, evals, evecs)
 # transform our data from 1D to 4D
 response_odf = response_odf[None, None, None, :]
-response_actor = actor.odf_slicer(response_odf, sphere=sphere, colormap='jet')
+response_actor = actor.odf_slicer(response_odf, sphere=sphere, colormap='plasma')
 ren.add(response_actor)
 print('Saving illustration as csd_response.png')
 window.record(ren, out_path='csd_response.png', size=(200, 200))
@@ -151,7 +151,7 @@ like  a pancake:
 """
 
 response_signal = response.on_sphere(sphere)
-response_actor = actor.odf_slicer(response_signal, sphere=sphere, colormap='jet')
+response_actor = actor.odf_slicer(response_signal, sphere=sphere, colormap='plasma')
 
 ren = window.Renderer()
 
@@ -196,7 +196,7 @@ csd_odf = csd_fit.odf(sphere)
 Here we visualize only a 30x30 region.
 """
 
-fodf_spheres = actor.odf_slicer(csd_odf, sphere=sphere, scale=1.3, norm=False, colormap='jet')
+fodf_spheres = actor.odf_slicer(csd_odf, sphere=sphere, scale=1.3, norm=False, colormap='plasma')
 
 ren.add(fodf_spheres)
 

--- a/doc/examples/reconst_dsid.py
+++ b/doc/examples/reconst_dsid.py
@@ -75,7 +75,7 @@ ren = window.Renderer()
 
 # concatenate data as 4D array
 odfs = np.vstack((odf_gt, dsi_odf, dsid_odf))[:, None, None]
-odf_actor = actor.odf_slicer(odfs, sphere=sphere, scale=0.5, colormap='jet')
+odf_actor = actor.odf_slicer(odfs, sphere=sphere, scale=0.5, colormap='plasma')
 
 odf_actor.display(y=0)
 odf_actor.RotateX(90)

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -390,7 +390,7 @@ Display the ODFs.
 interactive = False
 
 r = window.Renderer()
-sfu = actor.odf_slicer(odf, sphere=sphere, colormap='jet', scale=0.5)
+sfu = actor.odf_slicer(odf, sphere=sphere, colormap='plasma', scale=0.5)
 sfu.display(y=0)
 r.add(sfu)
 window.record(r, out_path='odfs.png', size=(600, 600))

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -86,7 +86,7 @@ Display the ODFs
 interactive = False
 
 ren = window.Renderer()
-sfu = actor.odf_slicer(odf[:, None, :], sphere=sphere, colormap='jet', scale=0.5)
+sfu = actor.odf_slicer(odf[:, None, :], sphere=sphere, colormap='plasma', scale=0.5)
 sfu.RotateX(-90)
 sfu.display(y=0)
 ren.add(sfu)

--- a/doc/examples/sfm_reconst.py
+++ b/doc/examples/sfm_reconst.py
@@ -117,7 +117,7 @@ model on the sphere, and plot it.
 sf_fit = sf_model.fit(data_small)
 sf_odf = sf_fit.odf(sphere)
 
-fodf_spheres = actor.odf_slicer(sf_odf, sphere=sphere, scale=1.3, colormap='jet')
+fodf_spheres = actor.odf_slicer(sf_odf, sphere=sphere, scale=1.3, colormap='plasma')
 
 ren = window.Renderer()
 ren.add(fodf_spheres)

--- a/doc/examples/simulate_multi_tensor.py
+++ b/doc/examples/simulate_multi_tensor.py
@@ -92,7 +92,7 @@ interactive = False
 
 ren = window.Renderer()
 
-odf_actor = actor.odf_slicer(odf[None, None, None, :], sphere=sphere, colormap='jet')
+odf_actor = actor.odf_slicer(odf[None, None, None, :], sphere=sphere, colormap='plasma')
 odf_actor.RotateX(90)
 
 ren.add(odf_actor)


### PR DESCRIPTION
Fixes #1403 

An even better thing to do will be to not replace `jet` with `plasma` but to remove it altogether. This will ensure the example always loads the default colormap.
Suggestions and review please.