### PR TITLE
BF: Avoid using memview in struct (Cython 0.28)

### DIFF
--- a/dipy/segment/benchmarks/bench_quickbundles.py
+++ b/dipy/segment/benchmarks/bench_quickbundles.py
@@ -33,15 +33,15 @@ class MDFpy(Metric):
         return shape1 == shape2
 
     def dist(self, features1, features2):
-        dist = np.sqrt(np.sum((features1-features2)**2, axis=1))
-        dist = np.sum(dist/len(features1))
+        dist = np.sqrt(np.sum((features1 - features2)**2, axis=1))
+        dist = np.sum(dist / len(features1))
         return dist
 
 
 def bench_quickbundles():
     dtype = "float32"
     repeat = 10
-    nb_points = 18
+    nb_points = 12
 
     streams, hdr = nib.trackvis.read(get_data('fornix'))
     fornix = [s[0].astype(dtype) for s in streams]
@@ -60,7 +60,7 @@ def bench_quickbundles():
 
     # The expected number of clusters of the fornix using threshold=10 is 4.
     threshold = 10.
-    expected_nb_clusters = 4*8
+    expected_nb_clusters = 4 * 8
 
     print("Timing QuickBundles 1.0 vs. 2.0")
 
@@ -75,7 +75,7 @@ def bench_quickbundles():
     qb2 = QB_New(threshold)
     qb2_time = measure("clusters = qb2.cluster(streamlines)", repeat)
     print("QuickBundles2 time: {0:.4}sec".format(qb2_time))
-    print("Speed up of {0}x".format(qb1_time/qb2_time))
+    print("Speed up of {0}x".format(qb1_time / qb2_time))
     clusters = qb2.cluster(streamlines)
     sizes2 = map(len, clusters)
     indices2 = map(lambda c: c.indices, clusters)
@@ -86,7 +86,7 @@ def bench_quickbundles():
     qb = QB_New(threshold, metric=MDFpy())
     qb3_time = measure("clusters = qb.cluster(streamlines)", repeat)
     print("QuickBundles2_python time: {0:.4}sec".format(qb3_time))
-    print("Speed up of {0}x".format(qb1_time/qb3_time))
+    print("Speed up of {0}x".format(qb1_time / qb3_time))
     clusters = qb.cluster(streamlines)
     sizes3 = map(len, clusters)
     indices3 = map(lambda c: c.indices, clusters)

--- a/dipy/segment/clustering_algorithms.pyx
+++ b/dipy/segment/clustering_algorithms.pyx
@@ -33,9 +33,11 @@ def clusters_centroid2clustermap_centroid(ClustersCentroid clusters_list):
     `ClusterMapCentroid` object
         Result of the clustering contained in a Python's object.
     """
+    cdef Data2D features
     clusters = ClusterMapCentroid()
     for i in range(clusters_list._nb_clusters):
-        centroid = np.asarray(<float[:clusters_list.centroids[i].features[0].shape[0], :clusters_list.centroids[i].features[0].shape[1]]> <float*> clusters_list.centroids[i].features[0]._data)
+        features = clusters_list.centroids[i].features[0]
+        centroid = np.asarray(<float[:features.shape[0], :features.shape[1]]> <float*> features._data)
         indices = np.asarray(<int[:clusters_list.clusters_size[i]]> clusters_list.clusters_indices[i]).tolist()
         clusters.add_cluster(ClusterCentroid(id=i, centroid=centroid, indices=indices))
 

--- a/dipy/segment/clustering_algorithms.pyx
+++ b/dipy/segment/clustering_algorithms.pyx
@@ -35,7 +35,7 @@ def clusters_centroid2clustermap_centroid(ClustersCentroid clusters_list):
     """
     clusters = ClusterMapCentroid()
     for i in range(clusters_list._nb_clusters):
-        centroid = np.asarray(clusters_list.centroids[i].features)
+        centroid = np.asarray(<float[:clusters_list.centroids[i].features[0].shape[0], :clusters_list.centroids[i].features[0].shape[1]]> <float*> clusters_list.centroids[i].features[0]._data)
         indices = np.asarray(<int[:clusters_list.clusters_size[i]]> clusters_list.clusters_indices[i]).tolist()
         clusters.add_cluster(ClusterCentroid(id=i, centroid=centroid, indices=indices))
 

--- a/dipy/segment/clusteringspeed.pxd
+++ b/dipy/segment/clusteringspeed.pxd
@@ -3,7 +3,7 @@ from metricspeed cimport Metric
 
 
 cdef struct Centroid:
-    Data2D features
+    Data2D* features
     int size
 
 

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -14,6 +14,8 @@ DTYPE = np.float32
 DEF BIGGEST_DOUBLE = 1.7976931348623157e+308  # np.finfo('f8').max
 DEF BIGGEST_INT = 2147483647  # np.iinfo('i4').max
 
+cdef Py_ssize_t sizeof_memviewslice = 2 * sizeof(cnp.npy_intp) + 3 * sizeof(cnp.npy_intp) * 8
+
 
 cdef class Clusters:
     """ Provides Cython functionalities to interact with clustering outputs.
@@ -114,10 +116,12 @@ cdef class ClustersCentroid(Clusters):
         """
         cdef cnp.npy_intp i
         for i in range(self._nb_clusters):
-            free(&(self.centroids[i].features[0, 0]))
-            free(&(self._updated_centroids[i].features[0, 0]))
-            self.centroids[i].features = None  # Necessary to decrease refcount
-            self._updated_centroids[i].features = None  # Necessary to decrease refcount
+            free(&(self.centroids[i].features[0][0, 0]))
+            free(&(self._updated_centroids[i].features[0][0, 0]))
+            self.centroids[i].features[0] = None  # Necessary to decrease refcount
+            self._updated_centroids[i].features[0] = None  # Necessary to decrease refcount
+            free(self.centroids[i].features)
+            free(self._updated_centroids[i].features)
 
         free(self.centroids)
         self.centroids = NULL
@@ -140,7 +144,7 @@ cdef class ClustersCentroid(Clusters):
         element : 2d array (float)
             Data of the element to assign.
         """
-        cdef Data2D updated_centroid = self._updated_centroids[id_cluster].features
+        cdef Data2D updated_centroid = self._updated_centroids[id_cluster].features[0]
         cdef cnp.npy_intp C = self.clusters_size[id_cluster]
         cdef cnp.npy_intp n, d
 
@@ -164,8 +168,8 @@ cdef class ClustersCentroid(Clusters):
         int
             Tells whether the centroid has changed or not, i.e. converged.
         """
-        cdef Data2D centroid = self.centroids[id_cluster].features
-        cdef Data2D updated_centroid = self._updated_centroids[id_cluster].features
+        cdef Data2D centroid = self.centroids[id_cluster].features[0]
+        cdef Data2D updated_centroid = self._updated_centroids[id_cluster].features[0]
         cdef cnp.npy_intp N = updated_centroid.shape[0], D = centroid.shape[1]
         cdef cnp.npy_intp n, d
         cdef int converged = 1
@@ -193,9 +197,42 @@ cdef class ClustersCentroid(Clusters):
         # Zero-initialize the new Centroid structure
         memset(&self._updated_centroids[self._nb_clusters], 0, sizeof(Centroid))
 
-        with gil:
-            self.centroids[self._nb_clusters].features = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]> calloc(self._centroid_shape.size, sizeof(float))
-            self._updated_centroids[self._nb_clusters].features = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]> calloc(self._centroid_shape.size, sizeof(float))
+        self.centroids[self._nb_clusters].features = <Data2D*> calloc(1, sizeof_memviewslice)
+        self._updated_centroids[self._nb_clusters].features = <Data2D*> calloc(1, sizeof_memviewslice)
+
+        self.centroids[self._nb_clusters].features[0].shape[0] = self._centroid_shape.dims[0]
+        self.centroids[self._nb_clusters].features[0].shape[1] = self._centroid_shape.dims[1]
+        self.centroids[self._nb_clusters].features[0].strides[0] = self._centroid_shape.dims[1] * sizeof(float)
+        self.centroids[self._nb_clusters].features[0].strides[1] = sizeof(float)
+        self.centroids[self._nb_clusters].features[0].suboffsets[0] = -1
+        self.centroids[self._nb_clusters].features[0].suboffsets[1] = -1
+        self.centroids[self._nb_clusters].features[0]._data = <char*> calloc(self._centroid_shape.size, sizeof(float))
+
+        self._updated_centroids[self._nb_clusters].features[0].shape[0] = self._centroid_shape.dims[0]
+        self._updated_centroids[self._nb_clusters].features[0].shape[1] = self._centroid_shape.dims[1]
+        self._updated_centroids[self._nb_clusters].features[0].strides[0] = self._centroid_shape.dims[1] * sizeof(float)
+        self._updated_centroids[self._nb_clusters].features[0].strides[1] = sizeof(float)
+        self._updated_centroids[self._nb_clusters].features[0].suboffsets[0] = -1
+        self._updated_centroids[self._nb_clusters].features[0].suboffsets[1] = -1
+        self._updated_centroids[self._nb_clusters].features[0]._data = <char*> calloc(self._centroid_shape.size, sizeof(float))
+
+        # cdef Data2D tmp
+        # with gil:
+        #     print("centroid created")
+            # print(self.centroids[self._nb_clusters].features[0].shape)
+            # print(self.centroids[self._nb_clusters].features[0]._data)
+            # print(type(self.centroids[self._nb_clusters].features[0]))
+            # print(type(self.centroids[self._nb_clusters].features[0].data))
+            # self.centroids[self._nb_clusters].features[0].data = <float*> calloc(self._centroid_shape.size, sizeof(float))
+            # self._updated_centroids[self._nb_clusters].features[0].data = <float*> calloc(self._centroid_shape.size, sizeof(float))
+            # self.centroids[self._nb_clusters].features[0] = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]> calloc(self._centroid_shape.size, sizeof(float))
+            # self._updated_centroids[self._nb_clusters].features[0] = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]> calloc(self._centroid_shape.size, sizeof(float))
+
+            # tmp = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]*> calloc(self._centroid_shape.size, sizeof(float))
+        #     print(tmp.strides)
+        #     print(tmp.suboffsets)
+        # #     self.centroids[self._nb_clusters].features = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]*> calloc(self._centroid_shape.size, sizeof(float))
+        # #     self._updated_centroids[self._nb_clusters].features = <float[:self._centroid_shape.dims[0], :self._centroid_shape.dims[1]]*> calloc(self._centroid_shape.size, sizeof(float))
 
         return Clusters.c_create_cluster(self)
 
@@ -232,7 +269,7 @@ cdef class QuickBundles(object):
         nearest_cluster.dist = BIGGEST_DOUBLE
 
         for k in range(self.clusters.c_size()):
-            dist = self.metric.c_dist(self.clusters.centroids[k].features, features)
+            dist = self.metric.c_dist(self.clusters.centroids[k].features[0], features)
 
             # Keep track of the nearest cluster
             if dist < nearest_cluster.dist:

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -54,7 +54,9 @@ cdef class Metric(object):
     cdef double c_dist(Metric self, Data2D features1, Data2D features2) nogil except -1:
         """ Cython version of `Metric.dist`. """
         with gil:
-            return self.dist(np.asarray(features1), np.asarray(features2))
+            _features1 = np.asarray(<float[:features1.shape[0], :features1.shape[1]]> <float*> features1._data)
+            _features2 = np.asarray(<float[:features2.shape[0], :features2.shape[1]]> <float*> features2._data)
+            return self.dist(_features1, _features2)
 
     cpdef are_compatible(Metric self, shape1, shape2):
         """ Checks if features can be used by `metric.dist` based on their shape.

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -151,6 +151,41 @@ def test_quickbundles_streamlines():
         assert_equal(clusters.centroids[0].dtype, np.float32)
 
 
+def test_quickbundles_with_python_metric():
+
+    class MDFpy(dipymetric.Metric):
+        def are_compatible(self, shape1, shape2):
+            return shape1 == shape2
+
+        def dist(self, features1, features2):
+            dist = np.sqrt(np.sum((features1 - features2)**2, axis=1))
+            dist = np.sum(dist / len(features1))
+            return dist
+
+    rdata = streamline_utils.set_number_of_points(data, 10)
+    qb = QuickBundles(threshold=2 * threshold, metric=MDFpy())
+
+    clusters = qb.cluster(rdata)
+    # By default `refdata` refers to data being clustered.
+    assert_equal(clusters.refdata, rdata)
+    # Set `refdata` to return indices instead of actual data points.
+    clusters.refdata = None
+    assert_array_equal(list(itertools.chain(*clusters)),
+                       list(itertools.chain(*clusters_truth)))
+
+    # Cluster read-only data
+    for datum in rdata:
+        datum.setflags(write=False)
+
+    clusters = qb.cluster(rdata)
+
+    # Cluster data with different dtype (should be converted into float32)
+    for datatype in [np.float64, np.int32, np.int64]:
+        newdata = [datum.astype(datatype) for datum in rdata]
+        clusters = qb.cluster(newdata)
+        assert_equal(clusters.centroids[0].dtype, np.float32)
+
+
 def test_quickbundles_with_not_order_invariant_metric():
     metric = dipymetric.AveragePointwiseEuclideanMetric()
     qb = QuickBundles(threshold=np.inf, metric=metric)


### PR DESCRIPTION
Replace memview's object in Centroid struct with a memview pointer.
Added a unit test that uses a Python metric with QuickBundles clustering.
Fixed bench_streamlines.py script.

@skoudoro we can drop this PR in favor of #1434 since you already made the necessary modification (and it is much cleaner than what I have). However, you might want to use the fixed `bench_streamlines.py` script, the unit test `test_quickbundles_with_python_metric` in `test_quickbundles.py` and the fix in `metricspeed.pyx`