### PR TITLE
Raise Error when MDFmetric is used in QB or QBX

### DIFF
--- a/dipy/segment/clustering.py
+++ b/dipy/segment/clustering.py
@@ -6,6 +6,7 @@ from abc import ABCMeta, abstractmethod
 from dipy.segment.metric import Metric
 from dipy.segment.metric import ResampleFeature
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
+from dipy.segment.metric import MinimumAverageDirectFlipMetric
 
 
 class Identity:
@@ -475,6 +476,9 @@ class QuickBundles(Clustering):
         self.threshold = threshold
         self.max_nb_clusters = max_nb_clusters
 
+        if isinstance(metric, MinimumAverageDirectFlipMetric):
+            raise ValueError("Use AveragePointwiseEuclideanMetric instead")
+
         if isinstance(metric, Metric):
             self.metric = metric
         elif metric == "MDF_12points":
@@ -538,6 +542,9 @@ class QuickBundlesX(Clustering):
     """
     def __init__(self, thresholds, metric="MDF_12points"):
         self.thresholds = thresholds
+        
+        if isinstance(metric, MinimumAverageDirectFlipMetric):
+            raise ValueError("Use AveragePointwiseEuclideanMetric instead")
 
         if isinstance(metric, Metric):
             self.metric = metric

--- a/dipy/segment/tests/test_qbx.py
+++ b/dipy/segment/tests/test_qbx.py
@@ -1,11 +1,12 @@
 import itertools
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_equal,
+from numpy.testing import (assert_array_equal, assert_equal, assert_raises,
                            assert_array_almost_equal, run_module_suite)
 
-from dipy.segment.clustering import QuickBundlesX
+from dipy.segment.clustering import QuickBundlesX, QuickBundles
 from dipy.segment.featurespeed import ResampleFeature
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
+from dipy.segment.metric import MinimumAverageDirectFlipMetric
 from dipy.tracking.streamline import set_number_of_points
 from dipy.data import get_data
 import nibabel.trackvis as tv
@@ -203,6 +204,16 @@ def test_circle_parallel_fornix():
     
     clusters = tree.get_clusters(1)
     assert_equal(len(clusters), 100)
+
+
+def test_raise_mdf():
+    
+    thresholds = [1, 0.1]
+    
+    metric = MinimumAverageDirectFlipMetric()
+
+    assert_raises(ValueError, QuickBundlesX, thresholds, metric=metric)
+    assert_raises(ValueError, QuickBundles, thresholds[1], metric=metric)
 
 
 if __name__ == '__main__':

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -117,11 +117,6 @@ print("Cluster sizes:", map(len, clusters))
 
     Cluster sizes: [64, 191, 44, 1]
 
-.. _clustering-examples-MinimumAverageDirectFlipMetric:
-
-::
-
-.. _clustering-examples-MinimumAverageDirectFlipMetric:
 
 Cosine Metric
 =============

--- a/doc/examples/segment_clustering_metrics.py
+++ b/doc/examples/segment_clustering_metrics.py
@@ -119,41 +119,7 @@ print("Cluster sizes:", map(len, clusters))
 
 .. _clustering-examples-MinimumAverageDirectFlipMetric:
 
-Minimum Average Direct Flip Metric (MDF)
-========================================
-**What:** It is the metric used in the QuickBundles algorithm [Garyfallidis12]_.
-Instances of `MinimumAverageDirectFlipMetric` first compute the
-direct distance *d1* by taking the average of the pointwise
-Euclidean distances between two sequences *of same length*. Reverse
-one of the two sequences and compute the flip distance *d2* using the same
-approach as for *d1*. Then, return the minimum between *d1* and *d2*.
-
-**When:** This metric mainly exists because it is used internally by
-`AveragePointwiseEuclideanMetric`.
-
-**Note:** Inputs must be sequences of same length.
-"""
-
-from dipy.segment.metric import MinimumAverageDirectFlipMetric
-
-# Get some streamlines.
-streamlines = get_streamlines()  # Previously defined.
-
-# Make sure our streamlines have the same number of points.
-from dipy.tracking.streamline import set_number_of_points
-streamlines = set_number_of_points(streamlines, nb_points=20)
-
-# Create the instance of `MinimumAverageDirectFlipMetric` to use.
-metric = MinimumAverageDirectFlipMetric()
-d = metric.dist(streamlines[0], streamlines[1])
-
-print("MDF distance between the first two streamlines: ", d)
-
-"""
-
 ::
-
-    MDF distance between the first two streamlines: 11.681308709622542
 
 .. _clustering-examples-MinimumAverageDirectFlipMetric:
 


### PR DESCRIPTION
…Actually the AveragePointwiseEuclideanMetric has the correct behavior of the MDF metric as explained in the QuickBundles paper.  @MarcCote this one is for you to check.