### PR TITLE
DOC: Fix bad hyperlink format to CONTRIBUTING.md from README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,4 +67,4 @@ Please see `LICENSE file <https://github.com/nipy/dipy/blob/master/LICENSE>`_.
 Contributing
 ============
 
-We welcome contributions from the community. Please read our `contributor guidelines <https://github.com/nipy/dipy/blob/master/CONTRIBUTING.md>`.
+We welcome contributions from the community. Please read our `Contributing guidelines <https://github.com/nipy/dipy/blob/master/CONTRIBUTING.md>`_.


### PR DESCRIPTION
Fix the format of the link to the `CONTRIBUTING.md` document from the
`README.rst` file.

Take advantage to change `contributor guidelines` for the common form
`Contributing guidelines`.