### PR TITLE
actor.slicer.copy() copies opacity set via actor.slicer.opacity() #1438

### DIFF
--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -175,7 +175,7 @@ def slicer(data, affine=None, value_range=None, opacity=1.,
             im_actor = ImageActor()
             im_actor.input_connection(self.output)
             im_actor.SetDisplayExtent(*self.GetDisplayExtent())
-            im_actor.opacity(opacity)
+            im_actor.opacity(self.GetOpacity())
             im_actor.tolerance(picking_tol)
             if interpolation == 'nearest':
                 im_actor.SetInterpolate(False)

--- a/dipy/viz/tests/test_actors.py
+++ b/dipy/viz/tests/test_actors.py
@@ -103,12 +103,15 @@ def test_slicer():
                                       value_range=(0., 1.))
     renderer.clear()
     slicer_lut = actor.slicer(data, lookup_colormap=lut)
-
     slicer_lut.display(10, None, None)
     slicer_lut.display(None, 10, None)
     slicer_lut.display(None, None, 10)
+    slicer_lut.opacity(0.5)
 
     slicer_lut2 = slicer_lut.copy()
+    npt.assert_equal(slicer_lut2.GetOpacity(),0.5);
+    slicer_lut.opacity(1)
+    slicer_lut2.opacity(1)
     slicer_lut2.display(None, None, 10)
     renderer.add(slicer_lut2)
 

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -102,7 +102,6 @@ We can add additonal slicers by copying the original and adjusting the
 """
 
 image_actor_x = image_actor_z.copy()
-image_actor_x.opacity(slicer_opacity)
 x_midpoint = int(np.round(shape[0] / 2))
 image_actor_x.display_extent(x_midpoint,
                              x_midpoint, 0,
@@ -111,7 +110,6 @@ image_actor_x.display_extent(x_midpoint,
                              shape[2] - 1)
 
 image_actor_y = image_actor_z.copy()
-image_actor_y.opacity(slicer_opacity)
 y_midpoint = int(np.round(shape[1] / 2))
 image_actor_y.display_extent(0,
                              shape[0] - 1,


### PR DESCRIPTION
This PR fixes #1438 
**Changes:**
- In `copy` function of `actor.py`, ` im_actor.opacity(opacity)` changed to `im_actor.opacity(self.GetOpacity())`. 
- `viz-advanced.py` no longer needs to use `image_actor_x.opacity(slicer_opacity)` to copy opacity of image_actor_z to image_actor_x
- Tests added.