### PR TITLE
Fix for "Sliders in examples don't react properly to clicks"

### DIFF
--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1851,7 +1851,7 @@ class LineSlider2D(UI):
 
         """
         self.add_callback(self.slider_line, "LeftButtonPressEvent",
-                          self.line_click_callback)
+                          self.line_click_callback,1)
         self.add_callback(self.slider_disk, "LeftButtonPressEvent",
                           self.disk_press_callback)
         self.add_callback(self.slider_disk, "MouseMoveEvent",

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -143,12 +143,15 @@ def translate_green_cube(i_ren, obj, slider):
     value = slider.value
     cube_actor_2.SetPosition(value, 0, 0)
 
-
 line_slider = ui.LineSlider2D(initial_value=-2,
                               min_value=-5, max_value=5)
 
 line_slider.add_callback(line_slider.slider_disk,
                          "MouseMoveEvent",
+                         translate_green_cube)
+
+line_slider.add_callback(line_slider.slider_line,
+                         "LeftButtonPressEvent",
                          translate_green_cube)
 
 """

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from dipy.viz import fvtk
+r=fvtk.ren()
+l=fvtk.label(r,scale=(1,1,1),text='adsadsadsadsadsadasdsadsad')
+fvtk.add(r,l)
+fvtk.show(r)


### PR DESCRIPTION
This PR fixes issue #1454 
- A callback was added to call `translate_green_cube` on `"LeftButtonPressEvent"`. 
- Priority given to ` self.line_click_callback` in `ui.py` to ensure that the position of disk gets updated before moving the cube.
