### PR TITLE
Fix for "Sliders in examples don't react properly to clicks"

### DIFF
--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1851,7 +1851,7 @@ class LineSlider2D(UI):
 
         """
         self.add_callback(self.slider_line, "LeftButtonPressEvent",
-                          self.line_click_callback)
+                          self.line_click_callback,1)
         self.add_callback(self.slider_disk, "LeftButtonPressEvent",
                           self.disk_press_callback)
         self.add_callback(self.slider_disk, "MouseMoveEvent",

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1851,7 +1851,7 @@ class LineSlider2D(UI):
 
         """
         self.add_callback(self.slider_line, "LeftButtonPressEvent",
-                          self.line_click_callback,1)
+                          self.line_click_callback, 1)
         self.add_callback(self.slider_disk, "LeftButtonPressEvent",
                           self.disk_press_callback)
         self.add_callback(self.slider_disk, "MouseMoveEvent",
@@ -2123,7 +2123,7 @@ class DiskSlider2D(UI):
 
         """
         self.add_callback(self.base_disk, "LeftButtonPressEvent",
-                          self.base_disk_click_callback)
+                          self.base_disk_click_callback, 1)
         self.add_callback(self.handle, "LeftButtonPressEvent",
                           self.handle_press_callback)
         self.add_callback(self.base_disk, "MouseMoveEvent",

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -197,16 +197,30 @@ def change_opacity(i_ren, obj, slider):
 line_slider_z.add_callback(line_slider_z.slider_disk,
                            "MouseMoveEvent",
                            change_slice_z)
+line_slider_z.add_callback(line_slider_z.slider_line,
+                           "LeftButtonPressEvent",
+                           change_slice_z)
+
 line_slider_x.add_callback(line_slider_x.slider_disk,
                            "MouseMoveEvent",
                            change_slice_x)
+line_slider_x.add_callback(line_slider_x.slider_line,
+                           "LeftButtonPressEvent",
+                           change_slice_x)
+
 line_slider_y.add_callback(line_slider_y.slider_disk,
                            "MouseMoveEvent",
                            change_slice_y)
+line_slider_y.add_callback(line_slider_y.slider_line,
+                           "LeftButtonPressEvent",
+                           change_slice_y)
+
 opacity_slider.add_callback(opacity_slider.slider_disk,
                             "MouseMoveEvent",
                             change_opacity)
-
+opacity_slider.add_callback(opacity_slider.slider_line,
+                           "LeftButtonPressEvent",
+                           change_opacity)
 """
 We'll also create text labels to identify the sliders.
 """

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -171,6 +171,9 @@ disk_slider.add_callback(disk_slider.handle,
                          "MouseMoveEvent",
                          rotate_red_cube)
 
+disk_slider.add_callback(disk_slider.base_disk,
+                         "LeftButtonPressEvent",
+                         rotate_red_cube)
 """
 2D File Select Menu
 ==============

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -143,12 +143,15 @@ def translate_green_cube(i_ren, obj, slider):
     value = slider.value
     cube_actor_2.SetPosition(value, 0, 0)
 
-
 line_slider = ui.LineSlider2D(initial_value=-2,
                               min_value=-5, max_value=5)
 
 line_slider.add_callback(line_slider.slider_disk,
                          "MouseMoveEvent",
+                         translate_green_cube)
+
+line_slider.add_callback(line_slider.slider_line,
+                         "LeftButtonPressEvent",
                          translate_green_cube)
 
 """

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from dipy.viz import fvtk
-r=fvtk.ren()
-l=fvtk.label(r,scale=(1,1,1),text='adsadsadsadsadsadasdsadsad')
-fvtk.add(r,l)
-fvtk.show(r)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from dipy.viz import fvtk
+r=fvtk.ren()
+l=fvtk.label(r,scale=(1,1,1),text='adsadsadsadsadsadasdsadsad')
+fvtk.add(r,l)
+fvtk.show(r)


### PR DESCRIPTION
This PR fixes issue #1454 
- A callback was added to call `translate_green_cube` on `"LeftButtonPressEvent"`. 
- Priority given to ` self.line_click_callback` in `ui.py` to ensure that the position of disk gets updated before moving the cube.
