### PR TITLE
Fix for "DiskSlider does not rotate actor in opposite direction"

### DIFF
--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1921,7 +1921,7 @@ class DiskSlider2D(UI):
         self.center = np.array(position)
         self.min_value = min_value
         self.max_value = max_value
-
+        self.initial_value = initial_value
         self.slider_inner_radius = slider_inner_radius
         self.slider_outer_radius = slider_outer_radius
         self.handle_inner_radius = handle_inner_radius
@@ -1939,6 +1939,7 @@ class DiskSlider2D(UI):
 
         # By setting the value, it also updates everything.
         self.value = initial_value
+        self.pvalue = initial_value
         self.handle_events(None)
 
     def build_actors(self):
@@ -1988,6 +1989,14 @@ class DiskSlider2D(UI):
         self.ratio = (value - self.min_value) / value_range
 
     @property
+    def pvalue(self):
+        return self._pvalue
+
+    @pvalue.setter
+    def pvalue(self, pvalue):
+        self._pvalue=pvalue;
+
+    @property
     def ratio(self):
         return self._ratio
 
@@ -2021,8 +2030,11 @@ class DiskSlider2D(UI):
 
         # Compute the selected value considering min_value and max_value.
         value_range = self.max_value - self.min_value
+        try:
+            self._pvalue = self.value;
+        except:
+            self._pvalue = self.initial_value;
         self._value = self.min_value + self.ratio*value_range
-
         # Update text disk actor.
         x = self.slider_radius * np.cos(self.angle) + self.center[0]
         y = self.slider_radius * np.sin(self.angle) + self.center[1]

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1851,7 +1851,7 @@ class LineSlider2D(UI):
 
         """
         self.add_callback(self.slider_line, "LeftButtonPressEvent",
-                          self.line_click_callback)
+                          self.line_click_callback,1)
         self.add_callback(self.slider_disk, "LeftButtonPressEvent",
                           self.disk_press_callback)
         self.add_callback(self.slider_disk, "MouseMoveEvent",

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1994,7 +1994,7 @@ class DiskSlider2D(UI):
 
     @pvalue.setter
     def pvalue(self, pvalue):
-        self._pvalue=pvalue;
+        self._pvalue = pvalue
 
     @property
     def ratio(self):
@@ -2031,9 +2031,9 @@ class DiskSlider2D(UI):
         # Compute the selected value considering min_value and max_value.
         value_range = self.max_value - self.min_value
         try:
-            self._pvalue = self.value;
+            self._pvalue = self.value
         except:
-            self._pvalue = self.initial_value;
+            self._pvalue = self.initial_value
         self._value = self.min_value + self.ratio*value_range
         # Update text disk actor.
         x = self.slider_radius * np.cos(self.angle) + self.center[0]

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -143,12 +143,15 @@ def translate_green_cube(i_ren, obj, slider):
     value = slider.value
     cube_actor_2.SetPosition(value, 0, 0)
 
-
 line_slider = ui.LineSlider2D(initial_value=-2,
                               min_value=-5, max_value=5)
 
 line_slider.add_callback(line_slider.slider_disk,
                          "MouseMoveEvent",
+                         translate_green_cube)
+
+line_slider.add_callback(line_slider.slider_line,
+                         "LeftButtonPressEvent",
                          translate_green_cube)
 
 """

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -159,10 +159,11 @@ line_slider.add_callback(line_slider.slider_line,
 ==============
 """
 
-
 def rotate_red_cube(i_ren, obj, slider):
     angle = slider.value
-    cube_actor_1.RotateY(0.005 * angle)
+    previous_angle = slider.pvalue;
+    rotation_angle = angle - previous_angle
+    cube_actor_1.RotateY(rotation_angle)
 
 
 disk_slider = ui.DiskSlider2D()

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -161,7 +161,7 @@ line_slider.add_callback(line_slider.slider_line,
 
 def rotate_red_cube(i_ren, obj, slider):
     angle = slider.value
-    previous_angle = slider.pvalue;
+    previous_angle = slider.pvalue
     rotation_angle = angle - previous_angle
     cube_actor_1.RotateY(rotation_angle)
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from dipy.viz import fvtk
-r=fvtk.ren()
-l=fvtk.label(r,scale=(1,1,1),text='adsadsadsadsadsadasdsadsad')
-fvtk.add(r,l)
-fvtk.show(r)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from dipy.viz import fvtk
+r=fvtk.ren()
+l=fvtk.label(r,scale=(1,1,1),text='adsadsadsadsadsadasdsadsad')
+fvtk.add(r,l)
+fvtk.show(r)


### PR DESCRIPTION
This PR fixes issue #1458 
- The problem was that the actor was being rotated every-time by the angle between the line joining center of `base_disk` and `handle` and the horizontal axis. It should have been rotated by angle equal to the change in angle between the line and horizontal axis.
- To implement this, an attribute - `pvalue` was added to the `DiskSlider2D` class to store the previous value of rotation. This is used to calculate the angle by which the actor must be rotated.