### PR TITLE
Fix for "DiskSlider does not rotate actor in opposite direction"

### DIFF
--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1882,6 +1882,8 @@ class DiskSlider2D(UI):
         Inner radius of the slider's handle.
     previous_value: float
         Value of Rotation of the actor before the current value.
+    initial_value: float
+        Initial Value of Rotation of the actor assigned on creation of object.
 
     """
     def __init__(self, position=(0, 0),

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1921,7 +1921,7 @@ class DiskSlider2D(UI):
         self.center = np.array(position)
         self.min_value = min_value
         self.max_value = max_value
-
+        self.initial_value = initial_value
         self.slider_inner_radius = slider_inner_radius
         self.slider_outer_radius = slider_outer_radius
         self.handle_inner_radius = handle_inner_radius
@@ -1939,6 +1939,7 @@ class DiskSlider2D(UI):
 
         # By setting the value, it also updates everything.
         self.value = initial_value
+        self.pvalue = initial_value
         self.handle_events(None)
 
     def build_actors(self):
@@ -1988,6 +1989,14 @@ class DiskSlider2D(UI):
         self.ratio = (value - self.min_value) / value_range
 
     @property
+    def pvalue(self):
+        return self._pvalue
+
+    @pvalue.setter
+    def pvalue(self, pvalue):
+        self._pvalue = pvalue
+
+    @property
     def ratio(self):
         return self._ratio
 
@@ -2021,6 +2030,10 @@ class DiskSlider2D(UI):
 
         # Compute the selected value considering min_value and max_value.
         value_range = self.max_value - self.min_value
+        try:
+            self._pvalue = self.value
+        except:
+            self._pvalue = self.initial_value
         self._value = self.min_value + self.ratio*value_range
 
         # Update text disk actor.

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1880,6 +1880,8 @@ class DiskSlider2D(UI):
         Outer radius of the slider's handle.
     handle_inner_radius: int
         Inner radius of the slider's handle.
+    previous_value: float
+        Value of Rotation of the actor before the current value.
 
     """
     def __init__(self, position=(0, 0),
@@ -1939,7 +1941,7 @@ class DiskSlider2D(UI):
 
         # By setting the value, it also updates everything.
         self.value = initial_value
-        self.pvalue = initial_value
+        self.previous_value = initial_value
         self.handle_events(None)
 
     def build_actors(self):
@@ -1989,12 +1991,12 @@ class DiskSlider2D(UI):
         self.ratio = (value - self.min_value) / value_range
 
     @property
-    def pvalue(self):
-        return self._pvalue
+    def previous_value(self):
+        return self._previous_value
 
-    @pvalue.setter
-    def pvalue(self, pvalue):
-        self._pvalue = pvalue
+    @previous_value.setter
+    def previous_value(self, previous_value):
+        self._previous_value = previous_value
 
     @property
     def ratio(self):
@@ -2031,9 +2033,9 @@ class DiskSlider2D(UI):
         # Compute the selected value considering min_value and max_value.
         value_range = self.max_value - self.min_value
         try:
-            self._pvalue = self.value
+            self._previous_value = self.value
         except:
-            self._pvalue = self.initial_value
+            self._previous_value = self.initial_value
         self._value = self.min_value + self.ratio*value_range
 
         # Update text disk actor.

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -159,7 +159,7 @@ line_slider.add_callback(line_slider.slider_disk,
 
 def rotate_red_cube(i_ren, obj, slider):
     angle = slider.value
-    previous_angle = slider.pvalue
+    previous_angle = slider.previous_value
     rotation_angle = angle - previous_angle
     cube_actor_1.RotateY(rotation_angle)
 

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -159,7 +159,9 @@ line_slider.add_callback(line_slider.slider_disk,
 
 def rotate_red_cube(i_ren, obj, slider):
     angle = slider.value
-    cube_actor_1.RotateY(0.005 * angle)
+    previous_angle = slider.pvalue
+    rotation_angle = angle - previous_angle
+    cube_actor_1.RotateY(rotation_angle)
 
 
 disk_slider = ui.DiskSlider2D()


### PR DESCRIPTION
This PR fixes issue #1458 
- The problem was that the actor was being rotated every-time by the angle between the line joining center of `base_disk` and `handle` and the horizontal axis. It should have been rotated by angle equal to the change in angle between the line and horizontal axis.
- To implement this, an attribute - `pvalue` was added to the `DiskSlider2D` class to store the previous value of rotation. This is used to calculate the angle by which the actor must be rotated.