### PR TITLE
DOC: Use the correct punctuation marks for `et al.`.

### DIFF
--- a/dipy/reconst/dsi.py
+++ b/dipy/reconst/dsi.py
@@ -32,7 +32,7 @@ class DiffusionSpectrumModel(OdfModel, Cache):
         where $\mathbf{r}$ is the displacement vector and $\mathbf{q}$ is the
         wavector which corresponds to different gradient directions. Method
         used to calculate the ODFs. Here we implement the method proposed by
-        Wedeen et. al [1]_.
+        Wedeen et al. [1]_.
 
         The main assumption for this model is fast gradient switching and that
         the acquisition gradients will sit on a keyhole Cartesian grid in
@@ -58,10 +58,10 @@ class DiffusionSpectrumModel(OdfModel, Cache):
 
         References
         ----------
-        .. [1]  Wedeen V.J et. al, "Mapping Complex Tissue Architecture With
+        .. [1]  Wedeen V.J et al., "Mapping Complex Tissue Architecture With
         Diffusion Spectrum Magnetic Resonance Imaging", MRM 2005.
 
-        .. [2] Canales-Rodriguez E.J et. al, "Deconvolution in Diffusion
+        .. [2] Canales-Rodriguez E.J et al., "Deconvolution in Diffusion
         Spectrum Imaging", Neuroimage, 2010.
 
         .. [3] Garyfallidis E, "Towards an accurate brain tractography", PhD
@@ -217,13 +217,13 @@ class DiffusionSpectrumFit(OdfFit):
 
         References
         ----------
-        .. [1] Descoteaux M. et. al, "Multiple q-shell diffusion propagator
+        .. [1] Descoteaux M. et al., "Multiple q-shell diffusion propagator
         imaging", Medical Image Analysis, vol 15, No. 4, p. 603-621, 2011.
 
         .. [2] Tuch D.S., "Diffusion MRI of Complex Tissue Structure",
          PhD Thesis, 2002.
 
-        .. [3] Wu Y. et. al, "Computation of Diffusion Function Measures
+        .. [3] Wu Y. et al., "Computation of Diffusion Function Measures
         in q -Space Using Magnetic Resonance Hybrid Diffusion Imaging",
         IEEE TRANSACTIONS ON MEDICAL IMAGING, vol. 27, No. 6, p. 858-865, 2008
 
@@ -246,7 +246,7 @@ class DiffusionSpectrumFit(OdfFit):
                 \end{equation}
 
         where $\hat{\mathbf{r}}$ is a point in the 3D Propagator space
-        (see Wu et. al [1]_).
+        (see Wu et al. [1]_).
 
         Parameters
         ----------
@@ -261,7 +261,7 @@ class DiffusionSpectrumFit(OdfFit):
 
         References
         ----------
-        .. [1] Wu Y. et. al, "Hybrid diffusion imaging", NeuroImage, vol 36,
+        .. [1] Wu Y. et al., "Hybrid diffusion imaging", NeuroImage, vol 36,
         p. 617-629, 2007.
 
         """
@@ -536,10 +536,10 @@ class DiffusionSpectrumDeconvModel(DiffusionSpectrumModel):
 
         References
         ----------
-        .. [1] Canales-Rodriguez E.J et. al, "Deconvolution in Diffusion
+        .. [1] Canales-Rodriguez E.J et al., "Deconvolution in Diffusion
         Spectrum Imaging", Neuroimage, 2010.
 
-        .. [2] Biggs David S.C. et. al, "Acceleration of Iterative Image
+        .. [2] Biggs David S.C. et al., "Acceleration of Iterative Image
         Restoration Algorithms", Applied Optics, vol. 36, No. 8, p. 1766-1775,
         1997.
 
@@ -626,7 +626,7 @@ def LR_deconv(prop, psf, numit=5, acc_factor=1):
 
     References
     ----------
-    .. [1] Biggs David S.C. et. al, "Acceleration of Iterative Image
+    .. [1] Biggs David S.C. et al., "Acceleration of Iterative Image
        Restoration Algorithms", Applied Optics, vol. 36, No. 8, p. 1766-1775,
        1997.
 

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -31,11 +31,11 @@ class ForecastModel(OdfModel, Cache):
            Using High Angular Resolution Diffusion Imaging", Magnetic
            Resonance in Medicine, 2005.
 
-    .. [2] Kaden E. et. al, "Quantitative Mapping of the Per-Axon Diffusion 
+    .. [2] Kaden E. et al., "Quantitative Mapping of the Per-Axon Diffusion 
            Coefficients in Brain White Matter", Magnetic Resonance in 
            Medicine, 2016.
 
-    .. [3] Zucchelli E. et. al, "A generalized SMT-based framework for
+    .. [3] Zucchelli E. et al., "A generalized SMT-based framework for
            Diffusion MRI microstructural model estimation", MICCAI Workshop
            on Computational DIFFUSION MRI (CDMRI), 2017.
     Notes
@@ -96,11 +96,11 @@ class ForecastModel(OdfModel, Cache):
                Using High Angular Resolution Diffusion Imaging", Magnetic
                Resonance in Medicine, 2005.
 
-        .. [2] Kaden E. et. al, "Quantitative Mapping of the Per-Axon Diffusion 
+        .. [2] Kaden E. et al., "Quantitative Mapping of the Per-Axon Diffusion 
                Coefficients in Brain White Matter", Magnetic Resonance in 
                Medicine, 2016.
 
-        .. [3] Zucchelli M. et. al, "A generalized SMT-based framework for
+        .. [3] Zucchelli M. et al., "A generalized SMT-based framework for
                Diffusion MRI microstructural model estimation", MICCAI Workshop
                on Computational DIFFUSION MRI (CDMRI), 2017.
 

--- a/dipy/reconst/gqi.py
+++ b/dipy/reconst/gqi.py
@@ -33,7 +33,7 @@ class GeneralizedQSamplingModel(OdfModel, Cache):
 
         References
         ----------
-        .. [1] Yeh F-C et. al, "Generalized Q-Sampling Imaging", IEEE TMI, 2010
+        .. [1] Yeh F-C et al., "Generalized Q-Sampling Imaging", IEEE TMI, 2010
 
         .. [2] Garyfallidis E, "Towards an accurate brain tractography", PhD
         thesis, University of Cambridge, 2012.
@@ -167,7 +167,7 @@ def squared_radial_component(x, tol=0.01):
 def npa(self, odf, width=5):
     """ non-parametric anisotropy
 
-    Nimmo-Smith et. al  ISMRM 2011
+    Nimmo-Smith et al.  ISMRM 2011
     """
     # odf = self.odf(s)
     t0, t1, t2 = triple_odf_maxima(self.odf_vertices, odf, width)

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -39,15 +39,15 @@ class MapmriModel(ReconstModel, Cache):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
            diffusion imaging method for mapping tissue microstructure",
            NeuroImage, 2013.
 
-    .. [2] Ozarslan E. et. al, "Simple harmonic oscillator based reconstruction
+    .. [2] Ozarslan E. et al., "Simple harmonic oscillator based reconstruction
            and estimation for one-dimensional q-space magnetic resonance
            1D-SHORE)", eapoc Intl Soc Mag Reson Med, vol. 16, p. 35., 2008.
 
-    .. [3] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
+    .. [3] Merlet S. et al., "Continuous diffusion signal, EAP and ODF
            estimation via Compressive Sensing in diffusion MRI", Medical
            Image Analysis, 2013.
 
@@ -172,16 +172,16 @@ class MapmriModel(ReconstModel, Cache):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
                diffusion imaging method for mapping tissue microstructure",
                NeuroImage, 2013.
 
-        .. [2] Ozarslan E. et. al, "Simple harmonic oscillator based
+        .. [2] Ozarslan E. et al., "Simple harmonic oscillator based
                reconstruction and estimation for one-dimensional q-space
                magnetic resonance 1D-SHORE)", eapoc Intl Soc Mag Reson Med,
                vol. 16, p. 35., 2008.
 
-        .. [3] Ozarslan E. et. al, "Simple harmonic oscillator based
+        .. [3] Ozarslan E. et al., "Simple harmonic oscillator based
                reconstruction and estimation for three-dimensional q-space
                mri", ISMRM 2009.
 
@@ -189,7 +189,7 @@ class MapmriModel(ReconstModel, Cache):
                using Laplacian-regularized MAP-MRI and its application to HCP
                data." NeuroImage (2016).
 
-        .. [5] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
+        .. [5] Merlet S. et al., "Continuous diffusion signal, EAP and ODF
                estimation via Compressive Sensing in diffusion MRI", Medical
                Image Analysis, 2013.
 
@@ -497,7 +497,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
         """
@@ -527,7 +527,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -556,7 +556,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -608,7 +608,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -659,7 +659,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -775,7 +775,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -803,7 +803,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -843,7 +843,7 @@ class MapmriFit(ReconstFit):
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
 
@@ -976,7 +976,7 @@ def isotropic_scale_factor(mu_squared):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1003,7 +1003,7 @@ def mapmri_index_matrix(radial_order):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1031,7 +1031,7 @@ def b_mat(index_matrix):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1063,7 +1063,7 @@ def b_mat_isotropic(index_matrix):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1090,7 +1090,7 @@ def mapmri_phi_1d(n, q, mu):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1120,7 +1120,7 @@ def mapmri_phi_matrix(radial_order, mu, q_gradients):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1169,7 +1169,7 @@ def mapmri_psi_1d(n, x, mu):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1196,7 +1196,7 @@ def mapmri_psi_matrix(radial_order, mu, rgrad):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1244,7 +1244,7 @@ def mapmri_odf_matrix(radial_order, mu, s, vertices):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1280,7 +1280,7 @@ def _odf_cfunc(n1, n2, n3, a, b, g, s):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1321,7 +1321,7 @@ def mapmri_isotropic_phi_matrix(radial_order, mu, q):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1361,7 +1361,7 @@ def mapmri_isotropic_radial_signal_basis(j, l, mu, qval):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1437,7 +1437,7 @@ def mapmri_isotropic_psi_matrix(radial_order, mu, rgrad):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1479,7 +1479,7 @@ def mapmri_isotropic_radial_pdf_basis(j, l, mu, r):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """
@@ -1570,7 +1570,7 @@ def mapmri_isotropic_odf_matrix(radial_order, mu, s, vertices):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
 
@@ -1628,7 +1628,7 @@ def mapmri_isotropic_odf_sh_matrix(radial_order, mu, s):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
 
@@ -1731,7 +1731,7 @@ def mapmri_isotropic_index_matrix(radial_order):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
     diffusion imaging method for mapping tissue microstructure",
     NeuroImage, 2013.
     """

--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -2,13 +2,13 @@
 
 References
 ----------
-Aganj, I., et. al. 2009. ODF Reconstruction in Q-Ball Imaging With Solid
+Aganj, I., et al. 2009. ODF Reconstruction in Q-Ball Imaging With Solid
     Angle Consideration.
-Descoteaux, M., et. al. 2007. Regularized, fast, and robust analytical
+Descoteaux, M., et al. 2007. Regularized, fast, and robust analytical
     Q-ball imaging.
-Tristan-Vega, A., et. al. 2010. A new methodology for estimation of fiber
+Tristan-Vega, A., et al. 2010. A new methodology for estimation of fiber
     populations in white matter of the brain with Funk-Radon transform.
-Tristan-Vega, A., et. al. 2009. Estimation of fiber orientation probability
+Tristan-Vega, A., et al. 2009. Estimation of fiber orientation probability
     density functions in high angular resolution diffusion imaging.
 
 
@@ -640,7 +640,7 @@ class CsaOdfModel(QballBaseModel):
 
     References
     ----------
-    .. [1] Aganj, I., et. al. 2009. ODF Reconstruction in Q-Ball Imaging With
+    .. [1] Aganj, I., et al. 2009. ODF Reconstruction in Q-Ball Imaging With
            Solid Angle Consideration.
     """
     min = .001
@@ -671,10 +671,10 @@ class OpdtModel(QballBaseModel):
 
     References
     ----------
-    .. [1] Tristan-Vega, A., et. al. 2010. A new methodology for estimation of
+    .. [1] Tristan-Vega, A., et al. 2010. A new methodology for estimation of
            fiber populations in white matter of the brain with Funk-Radon
            transform.
-    .. [2] Tristan-Vega, A., et. al. 2009. Estimation of fiber orientation
+    .. [2] Tristan-Vega, A., et al. 2009. Estimation of fiber orientation
            probability density functions in high angular resolution diffusion
            imaging.
     """
@@ -703,7 +703,7 @@ class QballModel(QballBaseModel):
 
     References
     ----------
-    .. [1] Descoteaux, M., et. al. 2007. Regularized, fast, and robust
+    .. [1] Descoteaux, M., et al. 2007. Regularized, fast, and robust
            analytical Q-ball imaging.
     """
 

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -41,22 +41,22 @@ class ShoreModel(Cache):
 
     References
     ----------
-    .. [1] Ozarslan E. et. al, "Simple harmonic oscillator based reconstruction
+    .. [1] Ozarslan E. et al., "Simple harmonic oscillator based reconstruction
            and estimation for one-dimensional q-space magnetic resonance
            1D-SHORE)", eapoc Intl Soc Mag Reson Med, vol. 16, p. 35., 2008.
 
-    .. [2] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
+    .. [2] Merlet S. et al., "Continuous diffusion signal, EAP and ODF
            estimation via Compressive Sensing in diffusion MRI", Medical
            Image Analysis, 2013.
 
-    .. [3] Rathi Y. et. al, "Sparse multi-shell diffusion imaging", MICCAI,
+    .. [3] Rathi Y. et al., "Sparse multi-shell diffusion imaging", MICCAI,
            2011.
 
-    .. [4] Cheng J. et. al, "Theoretical Analysis and eapactical Insights on
+    .. [4] Cheng J. et al., "Theoretical Analysis and eapactical Insights on
            EAP Estimation via a Unified HARDI Framework", MICCAI workshop on
            Computational Diffusion MRI, 2011.
 
-    .. [5] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+    .. [5] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
            diffusion imaging method for mapping tissue microstructure",
            NeuroImage, 2013.
 
@@ -412,7 +412,7 @@ class ShoreFit():
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
         """
@@ -432,7 +432,7 @@ class ShoreFit():
 
         References
         ----------
-        .. [1] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A novel
+        .. [1] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A novel
         diffusion imaging method for mapping tissue microstructure",
         NeuroImage, 2013.
         """
@@ -458,11 +458,11 @@ class ShoreFit():
                 \end{equation}
 
         where $\hat{\mathbf{r}}$ is a point in the 3D propagator space (see Wu
-        et. al [1]_).
+        et al. [1]_).
 
         References
         ----------
-        .. [1] Wu Y. et. al, "Hybrid diffusion imaging", NeuroImage, vol 36,
+        .. [1] Wu Y. et al., "Hybrid diffusion imaging", NeuroImage, vol 36,
         p. 617-629, 2007.
         """
         msd = 0
@@ -526,7 +526,7 @@ def shore_matrix(radial_order, zeta, gtab, tau=1 / (4 * np.pi ** 2)):
 
     References
     ----------
-    .. [1] Merlet S. et. al, "Continuous diffusion signal, EAP and
+    .. [1] Merlet S. et al., "Continuous diffusion signal, EAP and
     ODF estimation via Compressive Sensing in diffusion MRI", Medical
     Image Analysis, 2013.
 
@@ -576,7 +576,7 @@ def shore_matrix_pdf(radial_order, zeta, rtab):
 
     References
     ----------
-    .. [1] Merlet S. et. al, "Continuous diffusion signal, EAP and
+    .. [1] Merlet S. et al., "Continuous diffusion signal, EAP and
     ODF estimation via Compressive Sensing in diffusion MRI", Medical
     Image Analysis, 2013.
     """
@@ -620,7 +620,7 @@ def shore_matrix_odf(radial_order, zeta, sphere_vertices):
 
     References
     ----------
-    .. [1] Merlet S. et. al, "Continuous diffusion signal, EAP and
+    .. [1] Merlet S. et al., "Continuous diffusion signal, EAP and
     ODF estimation via Compressive Sensing in diffusion MRI", Medical
     Image Analysis, 2013.
     """

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -652,7 +652,7 @@ class ReconstCSAFlow(Workflow):
 
         References
         ----------
-        .. [1] Aganj, I., et. al. 2009. ODF Reconstruction in Q-Ball Imaging
+        .. [1] Aganj, I., et al. 2009. ODF Reconstruction in Q-Ball Imaging
            with Solid Angle Consideration.
         """
         io_it = self.get_io_iterator()

--- a/doc/examples/bundle_registration.py
+++ b/doc/examples/bundle_registration.py
@@ -89,10 +89,10 @@ show_both_bundles([cb_subj1, cb_subj2_aligned],
 As you can see the two cingulum bundles are well aligned although they contain
 many streamlines of different length and shape.
 
-.. [Garyfallidis15] Garyfallidis et. al, "Robust and efficient linear
+.. [Garyfallidis15] Garyfallidis et al., "Robust and efficient linear
                     registration of white-matter fascicles in the space
                     of streamlines", Neuroimage, 117:124-140, 2015.
-.. [Garyfallidis14] Garyfallidis et. al, "Direct native-space fiber bundle
+.. [Garyfallidis14] Garyfallidis et al., "Direct native-space fiber bundle
                     alignment for group comparisons", ISMRM, 2014.
 
 """

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -4,7 +4,7 @@ Parallel reconstruction using Q-Ball
 ====================================
 
 We show an example of parallel reconstruction using a Q-Ball Constant Solid
-Angle model (see Aganj et. al (MRM 2010)) and `peaks_from_model`.
+Angle model (see Aganj et al. (MRM 2010)) and `peaks_from_model`.
 
 Import modules, fetch and read data, and compute the mask.
 """

--- a/doc/examples/reconst_dsi_metrics.py
+++ b/doc/examples/reconst_dsi_metrics.py
@@ -149,7 +149,7 @@ plt.savefig('msd.png')
 
    Mean square displacement.
 
-.. [Descoteaux2011] Descoteaux M. et. al , "Multiple q-shell diffusion
+.. [Descoteaux2011] Descoteaux M. et al., "Multiple q-shell diffusion
    propagator imaging", Medical Image Analysis, vol 15, no 4, p. 603-621,
    2011.
 

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -133,11 +133,11 @@ window.record(ren, out_path='fODFs.png', size=(600, 600), magnification=4)
        Using High Angular Resolution Diffusion Imaging", Magnetic
        Resonance in Medicine, 2005.
 
-.. [Kaden2016] Kaden E. et. al, "Quantitative Mapping of the Per-Axon Diffusion
+.. [Kaden2016] Kaden E. et al., "Quantitative Mapping of the Per-Axon Diffusion
        Coefficients in Brain White Matter", Magnetic Resonance in
        Medicine, 2016.
 
-.. [Zucchelli2017] Zucchelli E. et. al, "A generalized SMT-based framework for
+.. [Zucchelli2017] Zucchelli E. et al., "A generalized SMT-based framework for
        Diffusion MRI microstructural model estimation", MICCAI Workshop
        on Computational DIFFUSION MRI (CDMRI), 2017.
 .. include:: ../links_names.inc

--- a/doc/examples/reconst_mapmri.py
+++ b/doc/examples/reconst_mapmri.py
@@ -406,7 +406,7 @@ if interactive:
 References
 ----------
 
-.. [Ozarslan2013] Ozarslan E. et. al, "Mean apparent propagator (MAP) MRI: A
+.. [Ozarslan2013] Ozarslan E. et al., "Mean apparent propagator (MAP) MRI: A
    novel diffusion imaging method for mapping tissue microstructure",
    NeuroImage, 2013.
 

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -103,11 +103,11 @@ if interactive:
 References
 ----------
 
-.. [Merlet2013] Merlet S. et. al, "Continuous diffusion signal, EAP and ODF
+.. [Merlet2013] Merlet S. et al., "Continuous diffusion signal, EAP and ODF
    estimation via Compressive Sensing in diffusion MRI", Medical Image
    Analysis, 2013.
 
-.. [Cheng2011] Cheng J. et. al, "Theoretical Analysis and Pratical Insights on
+.. [Cheng2011] Cheng J. et al., "Theoretical Analysis and Pratical Insights on
    EAP Estimation via Unified HARDI Framework", MICCAI workshop on
    Computational Diffusion MRI, 2011.
 

--- a/doc/examples/reconst_shore_metrics.py
+++ b/doc/examples/reconst_shore_metrics.py
@@ -115,14 +115,14 @@ plt.savefig('SHORE_maps.png')
 References
 ----------
 
-.. [Descoteaux2011] Descoteaux M. et. al , "Multiple q-shell diffusion
+.. [Descoteaux2011] Descoteaux M. et al., "Multiple q-shell diffusion
    propagator imaging", Medical Image Analysis, vol 15, No. 4, p. 603-621,
    2011.
 
-.. [Wu2007] Wu Y. et. al, "Hybrid diffusion imaging", NeuroImage, vol 36, p.
+.. [Wu2007] Wu Y. et al., "Hybrid diffusion imaging", NeuroImage, vol 36, p.
    617-629, 2007.
 
-.. [Wu2008] Wu Y. et. al, "Computation of Diffusion Function Measures in
+.. [Wu2008] Wu Y. et al., "Computation of Diffusion Function Measures in
    q-Space Using Magnetic Resonance Hybrid Diffusion Imaging", IEEE
    TRANSACTIONS ON MEDICAL IMAGING, vol. 27, No. 6, p. 858-865, 2008.
 


### PR DESCRIPTION
Change `et. al` for `et al.`.