### PR TITLE
Fix surface rendering bugs in VTK8

### DIFF
--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -445,7 +445,11 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
     poly_mapper.ScalarVisibilityOn()
     poly_mapper.SetScalarModeToUsePointFieldData()
     poly_mapper.SelectColorArray("Colors")
-    poly_mapper.GlobalImmediateModeRenderingOn()
+
+    # Enable only for OpenGL1 rendering backend
+    if vtk.VTK_MAJOR_VERSION <= 6:
+        poly_mapper.GlobalImmediateModeRenderingOn()
+
     poly_mapper.Update()
 
     # Color Scale with a lookup table
@@ -465,10 +469,14 @@ def streamtube(lines, colors=None, opacity=1, linewidth=0.1, tube_sides=9,
         actor = vtk.vtkActor()
 
     actor.SetMapper(poly_mapper)
-    actor.GetProperty().SetAmbient(0.1)
-    actor.GetProperty().SetDiffuse(0.15)
-    actor.GetProperty().SetSpecular(0.05)
-    actor.GetProperty().SetSpecularPower(6)
+
+    # Use different defaults for OpenGL1 rendering backend
+    if vtk.VTK_MAJOR_VERSION <= 6:
+        actor.GetProperty().SetAmbient(0.1)
+        actor.GetProperty().SetDiffuse(0.15)
+        actor.GetProperty().SetSpecular(0.05)
+        actor.GetProperty().SetSpecularPower(6)
+
     actor.GetProperty().SetInterpolationToPhong()
     actor.GetProperty().BackfaceCullingOn()
     actor.GetProperty().SetOpacity(opacity)

--- a/dipy/viz/utils.py
+++ b/dipy/viz/utils.py
@@ -435,7 +435,7 @@ def get_polymapper_from_polydata(polydata):
     return poly_mapper
 
 
-def get_actor_from_polymapper(poly_mapper, light=(0.1, 0.15, 0.05)):
+def get_actor_from_polymapper(poly_mapper):
     """ get vtkActor from a vtkPolyDataMapper
 
     Parameters
@@ -448,14 +448,15 @@ def get_actor_from_polymapper(poly_mapper, light=(0.1, 0.15, 0.05)):
     """
     actor = vtk.vtkActor()
     actor.SetMapper(poly_mapper)
-    # actor.GetProperty().SetRepresentationToWireframe()
     actor.GetProperty().BackfaceCullingOn()
     actor.GetProperty().SetInterpolationToPhong()
-    # actor.GetProperty().SetInterpolationToFlat()
 
-    actor.GetProperty().SetAmbient(light[0])  # .3
-    actor.GetProperty().SetDiffuse(light[1])  # .3
-    actor.GetProperty().SetSpecular(light[2])  # .3
+    # Use different defaults for OpenGL1 rendering backend
+    if vtk.VTK_MAJOR_VERSION <= 6:
+        actor.GetProperty().SetAmbient(0.1)
+        actor.GetProperty().SetDiffuse(0.15)
+        actor.GetProperty().SetSpecular(0.05)
+
     return actor
 
 


### PR DESCRIPTION
Update some defaults and remove a deprecated feature for the new OpenGL2 rendering backend in VTK7+. 

Also removed an unused `light` parameter that is missing from the doc string.

This PR fixes #1490 and replaces #1481.