### PR TITLE
BF: fix bug in example of reconst_csd.py

### DIFF
--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -151,6 +151,8 @@ like  a pancake:
 """
 
 response_signal = response.on_sphere(sphere)
+# transform our data from 1D to 4D
+response_signal = response_signal[None, None, None, :]
 response_actor = actor.odf_slicer(response_signal, sphere=sphere, colormap='plasma')
 
 ren = window.Renderer()
@@ -196,7 +198,7 @@ csd_odf = csd_fit.odf(sphere)
 Here we visualize only a 30x30 region.
 """
 
-fodf_spheres = actor.odf_slicer(csd_odf, sphere=sphere, scale=1.3, norm=False, colormap='plasma')
+fodf_spheres = actor.odf_slicer(csd_odf, sphere=sphere, scale=0.9, norm=False, colormap='plasma')
 
 ren.add(fodf_spheres)
 
@@ -225,7 +227,7 @@ csd_peaks = peaks_from_model(model=csd_model,
                              parallel=True)
 
 window.clear(ren)
-fodf_peaks = actor.peak_slicer(csd_peaks.peak_dirs, csd_peaks.peak_values, scale=1.3)
+fodf_peaks = actor.peak_slicer(csd_peaks.peak_dirs, csd_peaks.peak_values)
 ren.add(fodf_peaks)
 
 print('Saving illustration as csd_peaks.png')


### PR DESCRIPTION
This is to fix the bugs in example of reconst_csd.py:

    File “~/dipy/dipy/viz/actor.py", line 717, in odf_slicer
        (szx, szy, szz) = odfs.shape[:3]
    ValueError: not enough values to unpack (expected 3, got 1)

and

    TypeError: peak_slicer() got an unexpected keyword argument ‘scale’

The modifications are:
1. change image data 'response_signal' from 1D to 4D before calling to 'actor.odf_slicer()';
2. reduce the parameter 'scale' to 'actor.odf_slicer()' because it's too large in 'csd_odfs.png';
3. remove unexpected argument ‘scale' when calling 'actor.peak_slicer()'.