### PR TITLE
BF: fix bug in example of sfm_reconst.py

### DIFF
--- a/doc/examples/sfm_reconst.py
+++ b/doc/examples/sfm_reconst.py
@@ -117,7 +117,7 @@ model on the sphere, and plot it.
 sf_fit = sf_model.fit(data_small)
 sf_odf = sf_fit.odf(sphere)
 
-fodf_spheres = actor.odf_slicer(sf_odf, sphere=sphere, scale=1.3, colormap='plasma')
+fodf_spheres = actor.odf_slicer(sf_odf, sphere=sphere, scale=0.8, colormap='plasma')
 
 ren = window.Renderer()
 ren.add(fodf_spheres)
@@ -140,7 +140,7 @@ sf_peaks = dpp.peaks_from_model(sf_model,
 
 
 window.clear(ren)
-fodf_peaks = actor.peak_slicer(sf_peaks.peak_dirs, sf_peaks.peak_values, scale=1.3)
+fodf_peaks = actor.peak_slicer(sf_peaks.peak_dirs, sf_peaks.peak_values)
 ren.add(fodf_peaks)
 
 print('Saving illustration as sf_peaks.png')


### PR DESCRIPTION
This is to fix the bug in example of sfm_reconst.py:

    TypeError: peak_slicer() got an unexpected keyword argument ‘scale’

The modifications are:
1. reduce the parameter 'scale' to 'actor.odf_slicer()' because it's too large in 'sf_both.png';
2. remove unexpected argument ‘scale' when calling 'actor.peak_slicer()'.