### PR TITLE
BF: fix bug in example of streamline_tools.py

### DIFF
--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -237,7 +237,7 @@ lr_sf_trk = utils.move_streamlines(lr_superiorfrontal_track,
 lr_sf_trk = Streamlines(lr_sf_trk)
 
 # Save streamlines
-save_trk("lr-superiorfrontal.trk", lr_sf_trk, shape=shape, vox_size=voxel_size)
+save_trk("lr-superiorfrontal.trk", lr_sf_trk, shape=shape, vox_size=voxel_size, affine=affine)
 
 """
 Let's take a moment here to consider the representation of streamlines used in


### PR DESCRIPTION
This is to fix the bug in example of streamline_tools.py:

>  TypeError: save_trk() missing 1 required positional argument: 'affine'

The modification is just adding the argument 'affine=affine' to 'save_trk()'.