### PR TITLE
BF: fix bug in example of fiber_to_bundle_coherence.py

### DIFF
--- a/doc/examples/fiber_to_bundle_coherence.py
+++ b/doc/examples/fiber_to_bundle_coherence.py
@@ -161,7 +161,11 @@ mask_lgn[35-rad:35+rad, 42-rad:42+rad, 28-rad:28+rad] = True
 filtered_fibers2 = utils.near_roi(streamlines, mask_lgn, tol=1.8,
                                   affine=affine)
 
-streamlines = Streamlines(filtered_fibers2)
+sfil = []
+for i in range(len(streamlines)):
+    if filtered_fibers2[i]:
+        sfil.append(streamlines[i])
+streamlines = Streamlines(sfil)
 
 """
 Inspired by [Rodrigues2010]_, a lookup-table is created, containing rotated


### PR DESCRIPTION
The last modification of fiber_to_bundle_coherence.py make this error:

    File "~/dipy/dipy/tracking/streamline.py", line 150, in <listcomp>
        n_elements = np.sum([len(e) for e in elements])
    TypeError: object of type 'numpy.bool_' has no len()

So to fix the bug, I just changed back to where it was.