### PR TITLE
BF: fix bug in example of segment_quickbundles.py

### DIFF
--- a/doc/examples/segment_quickbundles.py
+++ b/doc/examples/segment_quickbundles.py
@@ -30,7 +30,7 @@ Load fornix streamlines.
 
 streams, hdr = tv.read(fname)
 
-streamlines = Streamlines(streams)
+streamlines = [i[0] for i in streams]
 
 """
 Perform QuickBundles clustering using the MDF metric and a 10mm distance


### PR DESCRIPTION
The last modification of segment_quickbundles.py makes this error:

    File "dipy/segment/clustering_algorithms.pyx", line 108, in 
    dipy.segment.clustering_algorithms.quickbundles
    ValueError: setting an array element with a sequence.

So to fix the bug, I just changed back to where it was. 
Then it turns to the attribute error of VTK 8.1:

    "~/dipy/dipy/viz/actor.py", line 448, in streamtube
    poly_mapper.GlobalImmediateModeRenderingOn()
    AttributeError: 'vtkRenderingOpenGL2Python.vtkOpenGLPolyDataMapper' object 
    has no attribute 'GlobalImmediateModeRenderingOn'

And I checked that the PR #1493 solves this problem. The resulting pictures look good.