### PR TITLE
Showing help when no input parameters are given and suppress warnings for cmds

### DIFF
--- a/bin/dipy_info
+++ b/bin/dipy_info
@@ -2,8 +2,8 @@
 
 from __future__ import division, print_function
 
-from dipy.workflows.io import IoInfoFlow
 from dipy.workflows.flow_runner import run_flow
+from dipy.workflows.io import IoInfoFlow
 
 if __name__ == "__main__":
     run_flow(IoInfoFlow())

--- a/bin/dipy_nlmeans
+++ b/bin/dipy_nlmeans
@@ -2,8 +2,9 @@
 
 from __future__ import division, print_function
 
-from dipy.workflows.denoise import NLMeansFlow
 from dipy.workflows.flow_runner import run_flow
+from dipy.workflows.denoise import NLMeansFlow
+
 
 if __name__ == "__main__":
     run_flow(NLMeansFlow())

--- a/bin/dipy_reslice
+++ b/bin/dipy_reslice
@@ -2,8 +2,9 @@
 
 from __future__ import division, print_function
 
-from dipy.workflows.align import ResliceFlow
 from dipy.workflows.flow_runner import run_flow
+from dipy.workflows.align import ResliceFlow
+
 
 if __name__ == "__main__":
     run_flow(ResliceFlow())

--- a/dipy/fixes/argparse.py
+++ b/dipy/fixes/argparse.py
@@ -1911,8 +1911,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         if positionals:
             #  printing user friendly help message to tell about missing
             #  arguments.
-            print("Too few arguments. Program", self.prog, "expects arguments"
-                    ". Type", self.prog, "-h for help.\n")
+            print("Too few arguments: Program", self.prog,
+                  "expects arguments.\n\nType", self.prog,
+                  "-h for help.\n")
             self.error(_('too few arguments'))
 
         # make sure all required actions were present

--- a/dipy/fixes/argparse.py
+++ b/dipy/fixes/argparse.py
@@ -1909,6 +1909,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         # if we didn't use all the Positional objects, there were too few
         # arg strings supplied.
         if positionals:
+            #  printing user friendly help message to tell about missing
+            #  arguments.
+            print("Too few arguments. Program", self.prog, "expects arguments"
+                    ". Type", self.prog, "-h for help.\n")
             self.error(_('too few arguments'))
 
         # make sure all required actions were present

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -266,11 +266,12 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         as a workflow's run method arguments.
 
         The function simply exits with a help message if no arguments were
-        provided by the user.
+        provided by the user. It checks to see if the args is None or not.
         """
 
-        if len(sys.argv) <= 1:
-            print("Program", sys.argv[0], "expects arguments. Type", sys.argv[0], "-h for help.")
+        if args is None:
+            print("Program", self.prog, "expects arguments. Type", self.prog,
+                  "-h for help.")
             exit(1)
 
         ns_args = self.parse_args(args, namespace)

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -264,11 +264,13 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
     def get_flow_args(self, args=None, namespace=None):
         """ Returns the parsed arguments as a dictionary that will be used
         as a workflow's run method arguments.
+
+        The function simply exits with a help message if no arguments were
+        provided by the user.
         """
 
-        #Checking if the required arguments have been provided by the user or not.
         if len(sys.argv) <= 1:
-            print("Program",sys.argv[0],"expects arguments. Type", sys.argv[0],"-h for help.")
+            print("Program", sys.argv[0], "expects arguments. Type", sys.argv[0], "-h for help.")
             exit(1)
 
         ns_args = self.parse_args(args, namespace)

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -268,7 +268,7 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
 
         #Checking if the required arguments have been provided by the user or not.
         if len(sys.argv) <= 1:
-            print("Program ",sys.argv[0],"expects arguments. Type", sys.argv[0],"-h for help with arguments.")
+            print("Program",sys.argv[0],"expects arguments. Type", sys.argv[0],"-h for help.")
             exit(1)
 
         ns_args = self.parse_args(args, namespace)

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -265,6 +265,12 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         """ Returns the parsed arguments as a dictionary that will be used
         as a workflow's run method arguments.
         """
+
+        #Checking if the required arguments have been provided by the user or not.
+        if len(sys.argv) <= 1:
+            print("Program ",sys.argv[0],"expects arguments. Type", sys.argv[0],"-h for help with arguments.")
+            exit(1)
+
         ns_args = self.parse_args(args, namespace)
         dct = vars(ns_args)
 

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -264,19 +264,10 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
     def get_flow_args(self, args=None, namespace=None):
         """ Returns the parsed arguments as a dictionary that will be used
         as a workflow's run method arguments.
-
-        The function simply exits with a help message if no arguments were
-        provided by the user. It checks to see if the args is None or not.
         """
-
-        if args is None:
-            print("Program", self.prog, "expects arguments. Type", self.prog,
-                  "-h for help.")
-            exit(1)
 
         ns_args = self.parse_args(args, namespace)
         dct = vars(ns_args)
-
         return dict((k, v) for k, v in dct.items() if v is not None)
 
     def update_argument(self, *args, **kargs):

--- a/dipy/workflows/flow_runner.py
+++ b/dipy/workflows/flow_runner.py
@@ -1,5 +1,10 @@
 from __future__ import division, print_function, absolute_import
 
+#  Disabling the FutureWarning from h5py below.
+#  This disables the FutureWarning warning for all the workflows.
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
 import logging
 
 from dipy.utils.six import iteritems


### PR DESCRIPTION
This change is made in the base.py file to check if the user has provided any arguments or not.

Currently, if the workflows are run without any parameters then there is no help message to prompt the user of what went wrong.

Added the check and put an appropriate error message.