### PR TITLE
Eigenvalue - eigenvector array compatibility check 

### DIFF
--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -926,6 +926,13 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
         Ellipsoid
     """
 
+    if not evals.shape == evecs.shape[:-1]:
+        e_s = "You provided an eigenvalues array with a shape"
+        e_s += "{0} for eigenvectors with".format(evals.shape)
+        e_s += "shape {0}. Please provide an eigenvector array".format(evecs.shape)
+        e_s += " that compatible with the eigenvalues array."
+        raise ValueError(e_s)
+
     if mask is None:
         mask = np.ones(evals.shape[:3], dtype=np.bool)
     else:

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -928,10 +928,11 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
 
     if not evals.shape == evecs.shape[:-1]:
         e_s = "You provided an eigenvalues array with a shape"
-        e_s += "{0} for eigenvectors with".format(evals.shape)
-        e_s += "shape {0}. Please provide an eigenvector array".format(evecs.shape)
-        e_s += " that compatible with the eigenvalues array."
-        raise ValueError(e_s)
+        e_s += " {0} for eigenvectors with".format(evals.shape)
+        e_s += " shape {0}. Please provide".format(evecs.shape)
+        e_s += " eigenvector and eigenvalue arrays"
+        e_s += " that have compatible dimensions."
+        raise RuntimeError(e_s)
 
     if mask is None:
         mask = np.ones(evals.shape[:3], dtype=np.bool)

--- a/dipy/viz/actor.py
+++ b/dipy/viz/actor.py
@@ -927,12 +927,11 @@ def tensor_slicer(evals, evecs, affine=None, mask=None, sphere=None, scale=2.2,
     """
 
     if not evals.shape == evecs.shape[:-1]:
-        e_s = "You provided an eigenvalues array with a shape"
-        e_s += " {0} for eigenvectors with".format(evals.shape)
-        e_s += " shape {0}. Please provide".format(evecs.shape)
-        e_s += " eigenvector and eigenvalue arrays"
-        e_s += " that have compatible dimensions."
-        raise RuntimeError(e_s)
+        raise RuntimeError(
+            "Eigenvalues shape {} is incompatible with eigenvectors' {}."
+            " Please provide eigenvalue and"
+            " eigenvector arrays that have compatible dimensions."
+            .format(evals.shape, evecs.shape))
 
     if mask is None:
         mask = np.ones(evals.shape[:3], dtype=np.bool)

--- a/dipy/viz/tests/test_actors.py
+++ b/dipy/viz/tests/test_actors.py
@@ -667,8 +667,9 @@ def test_tensor_slicer(interactive=False):
     mevecs = np.zeros((3, 2, 4, 3, 3))
 
     with npt.assert_raises(RuntimeError):
-        tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine, mask=mask,
-                                           scalar_colors=cfa, sphere=sphere, scale=.3)
+        tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine,
+                                           mask=mask, scalar_colors=cfa,
+                                           sphere=sphere, scale=.3)
 
 
 @npt.dec.skipif(not run_test)

--- a/dipy/viz/tests/test_actors.py
+++ b/dipy/viz/tests/test_actors.py
@@ -661,6 +661,15 @@ def test_tensor_slicer(interactive=False):
     if interactive:
         window.show(renderer, reset_camera=False)
 
+    # Test error handling of the method when
+    # incompatible dimension of mevals and evecs are passed.
+    mevals = np.zeros((3, 2, 3))
+    mevecs = np.zeros((3, 2, 4, 3, 3))
+
+    with npt.assert_raises(RuntimeError):
+        tensor_actor = actor.tensor_slicer(mevals, mevecs, affine=affine, mask=mask,
+                                           scalar_colors=cfa, sphere=sphere, scale=.3)
+
 
 @npt.dec.skipif(not run_test)
 @xvfb_it


### PR DESCRIPTION
If eigenvalues and aigenvector array shapes are not compatible, tensor_slicer actor does not give clear error message. In this PR, compatibility cheking of eigenvalue and eigenvector shapes is added.  It gives more clear error when shapes are not compatible.
