### PR TITLE
Show message if number of arguments mismatch between the doc string and the run method.

### DIFF
--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -112,20 +112,21 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         output_args = \
             self.add_argument_group('output arguments(optional)')
 
+        len_args = len(args)
+        len_defaults = len(defaults)
+
         #  This check simply shows a helpful message to the user if there
         #  is a mismatch in the number of arguments in the run method and
         #  the doc string. Doc string refers to the parameter help written
         # in the workflow python script.
 
-        if len(args) != len(self.doc):
+        if len_args != len(self.doc):
             print(self.prog+": Number of parameters in the doc string and "
                             "run method does not match. Please ensure that"
                             " the number of parameters in the run method is"
                             " the same as the doc string.")
             exit(1)
 
-        len_args = len(args)
-        len_defaults = len(defaults)
 
         for i, arg in enumerate(args):
             prefix = ''

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -109,9 +109,6 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
 
         args, defaults = get_args_default(workflow.run)
 
-        len_args = len(args)
-        len_defaults = len(defaults)
-
         output_args = \
             self.add_argument_group('output arguments(optional)')
 
@@ -133,9 +130,6 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
             is_optionnal = i >= len_args - len_defaults
             if is_optionnal:
                 prefix = '--'
-
-            print(i)
-            print(self.doc[i])
 
             typestr = self.doc[i][1]
             dtype, isnarg = self._select_dtype(typestr)

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -101,7 +101,7 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
             ref_text = [text if text else "\n" for text in npds['References']]
             ref_idx = self.epilog.find('References: \n') + len('References: \n')
             self.epilog = "{0}{1}\n{2}".format(self.epilog[:ref_idx],
-                                               ''.join([text for text in ref_text]),
+                                        ''.join([text for text in ref_text]),
                                                self.epilog[ref_idx:])
 
         self.outputs = [param for param in npds['Parameters'] if
@@ -121,10 +121,12 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         # in the workflow python script.
 
         if len_args != len(self.doc):
-            raise ValueError(self.prog+": Number of parameters in the"
-                            " doc string and run method does not match."
-                            " Please ensure that the number of parameters"
-                            " in the run method is same as the doc string.")
+            raise ValueError(
+                            self.prog +
+                            ": Number of parameters in the "
+                            "doc string and run method does not match. "
+                            "Please ensure that the number of parameters "
+                            "in the run method is same as the doc string.")
 
 
         for i, arg in enumerate(args):

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -101,32 +101,25 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
             ref_text = [text if text else "\n" for text in npds['References']]
             ref_idx = self.epilog.find('References: \n') + len('References: \n')
             self.epilog = "{0}{1}\n{2}".format(self.epilog[:ref_idx],
-                                        ''.join([text for text in ref_text]),
-                                               self.epilog[ref_idx:])
+                                               ''.join(ref_text),
+                                                self.epilog[ref_idx:])
 
         self.outputs = [param for param in npds['Parameters'] if
                         'out_' in param[0]]
 
         args, defaults = get_args_default(workflow.run)
 
-        output_args = \
-            self.add_argument_group('output arguments(optional)')
+        output_args = self.add_argument_group('output arguments(optional)')
 
         len_args = len(args)
         len_defaults = len(defaults)
 
-        #  This check simply shows a helpful message to the user if there
-        #  is a mismatch in the number of arguments in the run method and
-        #  the doc string. Doc string refers to the parameter help written
-        # in the workflow python script.
-
         if len_args != len(self.doc):
             raise ValueError(
-                            self.prog +
-                            ": Number of parameters in the "
-                            "doc string and run method does not match. "
-                            "Please ensure that the number of parameters "
-                            "in the run method is same as the doc string.")
+                    self.prog + ": Number of parameters in the "
+                    "doc string and run method does not match. "
+                    "Please ensure that the number of parameters "
+                    "in the run method is same as the doc string.")
 
 
         for i, arg in enumerate(args):

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -115,11 +115,27 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         output_args = \
             self.add_argument_group('output arguments(optional)')
 
+        #  This check simply shows a helpful message to the user if there
+        #  is a mismatch in the number of arguments in the run method and
+        #  the doc string. Doc string refers to the parameter help written
+        # in the workflow python script.
+
+        if len(args) != len(self.doc):
+            print(self.prog+": Number of parameters in the doc string and "
+                            "run method does not match. Please ensure that"
+                            " the number of parameters in the run method is"
+                            " the same as the doc string.")
+            exit(1)
+
+
         for i, arg in enumerate(args):
             prefix = ''
             is_optionnal = i >= len_args - len_defaults
             if is_optionnal:
                 prefix = '--'
+
+            print(i)
+            print(self.doc[i])
 
             typestr = self.doc[i][1]
             dtype, isnarg = self._select_dtype(typestr)
@@ -267,6 +283,9 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         """
         ns_args = self.parse_args(args, namespace)
         dct = vars(ns_args)
+
+
+        print(dct)
 
         return dict((k, v) for k, v in dct.items() if v is not None)
 

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -124,6 +124,8 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
                             " the same as the doc string.")
             exit(1)
 
+        len_args = len(args)
+        len_defaults = len(defaults)
 
         for i, arg in enumerate(args):
             prefix = ''
@@ -277,9 +279,6 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         """
         ns_args = self.parse_args(args, namespace)
         dct = vars(ns_args)
-
-
-        print(dct)
 
         return dict((k, v) for k, v in dct.items() if v is not None)
 

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -121,11 +121,10 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
         # in the workflow python script.
 
         if len_args != len(self.doc):
-            print(self.prog+": Number of parameters in the doc string and "
-                            "run method does not match. Please ensure that"
-                            " the number of parameters in the run method is"
-                            " the same as the doc string.")
-            exit(1)
+            raise ValueError(self.prog+": Number of parameters in the"
+                            " doc string and run method does not match."
+                            " Please ensure that the number of parameters"
+                            " in the run method is same as the doc string.")
 
 
         for i, arg in enumerate(args):

--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -102,7 +102,7 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
             ref_idx = self.epilog.find('References: \n') + len('References: \n')
             self.epilog = "{0}{1}\n{2}".format(self.epilog[:ref_idx],
                                                ''.join(ref_text),
-                                                self.epilog[ref_idx:])
+                                               self.epilog[ref_idx:])
 
         self.outputs = [param for param in npds['Parameters'] if
                         'out_' in param[0]]
@@ -120,7 +120,6 @@ class IntrospectiveArgumentParser(arg.ArgumentParser):
                     "doc string and run method does not match. "
                     "Please ensure that the number of parameters "
                     "in the run method is same as the doc string.")
-
 
         for i, arg in enumerate(args):
             prefix = ''


### PR DESCRIPTION
A simple check is implemented in the base.py script to display a message if the number of arguments in the doc string and the run method mismatches.
