### PR TITLE
Update the default out_strategy to create the output in the current working directory

### DIFF
--- a/dipy/workflows/flow_runner.py
+++ b/dipy/workflows/flow_runner.py
@@ -31,7 +31,7 @@ def run_flow(flow):
                         help='Force overwriting output files.')
 
     parser.add_argument('--out_strat', action='store', dest='out_strat',
-                        metavar='string', required=False, default='append',
+                        metavar='string', required=False, default='absolute',
                         help='Strategy to manage output creation.')
 
     parser.add_argument('--mix_names', dest='mix_names',

--- a/dipy/workflows/multi_io.py
+++ b/dipy/workflows/multi_io.py
@@ -23,7 +23,7 @@ def slash_to_under(dir_str):
     return ''.join(dir_str.replace('/', '_'))
 
 
-def connect_output_paths(inputs, out_dir, out_files, output_strategy='append',
+def connect_output_paths(inputs, out_dir, out_files, output_strategy='absolute',
                          mix_names=True):
     """ Generates a list of output files paths based on input files and
     output strategies.
@@ -119,7 +119,7 @@ def basename_without_extension(fname):
     return result
 
 
-def io_iterator(inputs, out_dir, fnames, output_strategy='append',
+def io_iterator(inputs, out_dir, fnames, output_strategy='absolute',
                 mix_names=False, out_keys=None):
     """ Creates an IOIterator from the parameters.
 
@@ -150,7 +150,7 @@ def io_iterator(inputs, out_dir, fnames, output_strategy='append',
     return io_it
 
 
-def io_iterator_(frame, fnc, output_strategy='append', mix_names=False):
+def io_iterator_(frame, fnc, output_strategy='absolute', mix_names=False):
     """ Creates an IOIterator using introspection.
 
     Parameters
@@ -206,7 +206,7 @@ class IOIterator(object):
     outputs which can come from long lists of multiple or single inputs.
     """
 
-    def __init__(self, output_strategy='append', mix_names=False):
+    def __init__(self, output_strategy='absolute', mix_names=False):
         self.output_strategy = output_strategy
         self.mix_names = mix_names
         self.inputs = []

--- a/dipy/workflows/workflow.py
+++ b/dipy/workflows/workflow.py
@@ -8,7 +8,7 @@ from dipy.workflows.multi_io import io_iterator_
 
 
 class Workflow(object):
-    def __init__(self, output_strategy='append', mix_names=False,
+    def __init__(self, output_strategy='absolute', mix_names=False,
                  force=False, skip=False):
         """ The basic workflow object.
 


### PR DESCRIPTION
1) Changed the files to use 'absolute' as the default value.
2) Tested the change with a manual workflow and a image registration workflow
and the output is now created in the current working directory.