### PR TITLE
Range slider element for viz.ui

### DIFF
--- a/dipy/viz/test.py
+++ b/dipy/viz/test.py
@@ -1,0 +1,6 @@
+import ui
+import window
+ls = ui.RangeSlider()
+sm=window.ShowManager(size=(600,600))
+sm.ren.add(ls)
+sm.start()

--- a/dipy/viz/test.py
+++ b/dipy/viz/test.py
@@ -1,6 +1,0 @@
-import ui
-import window
-ls = ui.RangeSlider()
-sm=window.ShowManager(size=(600,600))
-sm.ren.add(ls)
-sm.start()

--- a/dipy/viz/tests/test_ui.py
+++ b/dipy/viz/tests/test_ui.py
@@ -458,6 +458,36 @@ def test_ui_line_slider_2d(recording=False):
 
 @npt.dec.skipif(not have_vtk or skip_it)
 @xvfb_it
+def test_ui_line_double_slider_2d(interactive=False):
+    line_double_slider_2d_test = ui.LineDoubleSlider2D(
+        center=(300, 300), shape="disk", outer_radius=15, min_value=-10,
+        max_value=10, initial_values=(-10, 10))
+    npt.assert_equal(line_double_slider_2d_test.handles[0].size, (30, 30))
+    npt.assert_equal(line_double_slider_2d_test.left_disk_value, -10)
+    npt.assert_equal(line_double_slider_2d_test.right_disk_value, 10)
+
+    if interactive:
+        show_manager = window.ShowManager(size=(600, 600),
+                                          title="DIPY Line Double Slider")
+        show_manager.ren.add(line_double_slider_2d_test)
+        show_manager.start()
+
+    line_double_slider_2d_test = ui.LineDoubleSlider2D(
+        center=(300, 300), shape="square", handle_side=5,
+        initial_values=(50, 40))
+    npt.assert_equal(line_double_slider_2d_test.handles[0].size, (5, 5))
+    npt.assert_equal(line_double_slider_2d_test._values[0], 39)
+    npt.assert_equal(line_double_slider_2d_test.right_disk_value, 40)
+
+    if interactive:
+        show_manager = window.ShowManager(size=(600, 600),
+                                          title="DIPY Line Double Slider")
+        show_manager.ren.add(line_double_slider_2d_test)
+        show_manager.start()
+
+
+@npt.dec.skipif(not have_vtk or skip_it)
+@xvfb_it
 def test_ui_ring_slider_2d(recording=False):
     filename = "test_ui_ring_slider_2d"
     recording_filename = pjoin(DATA_DIR, filename + ".log.gz")
@@ -493,6 +523,18 @@ def test_ui_ring_slider_2d(recording=False):
         show_manager.play_events_from_file(recording_filename)
         expected = EventCounter.load(expected_events_counts_filename)
         event_counter.check_counts(expected)
+
+
+@npt.dec.skipif(not have_vtk or skip_it)
+@xvfb_it
+def test_ui_range_slider(interactive=False):
+    range_slider_test = ui.RangeSlider(shape="square")
+
+    if interactive:
+        show_manager = window.ShowManager(size=(600, 600),
+                                          title="DIPY Line Double Slider")
+        show_manager.ren.add(range_slider_test)
+        show_manager.start()
 
 
 @npt.dec.skipif(not have_vtk or skip_it)
@@ -575,8 +617,14 @@ if __name__ == "__main__":
     if len(sys.argv) <= 1 or sys.argv[1] == "test_ui_line_slider_2d":
         test_ui_line_slider_2d(recording=True)
 
+    if len(sys.argv) <= 1 or sys.argv[1] == "test_ui_line_double_slider_2d":
+        test_ui_line_double_slider_2d(interactive=False)
+
     if len(sys.argv) <= 1 or sys.argv[1] == "test_ui_ring_slider_2d":
         test_ui_ring_slider_2d(recording=True)
+
+    if len(sys.argv) <= 1 or sys.argv[1] == "test_ui_range_slider":
+        test_ui_range_slider(interactive=False)
 
     if len(sys.argv) <= 1 or sys.argv[1] == "test_ui_listbox_2d":
         test_ui_listbox_2d(recording=True)

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1970,7 +1970,7 @@ class LineDoubleSlider2D(UI):
 
     """
     def __init__(self, line_width=5, inner_radius=0, outer_radius=10,
-                 handle_side = 20, center=(450, 300), length=200,
+                 handle_side=20, center=(450, 300), length=200,
                  initial_values=(0, 100), min_value=0, max_value=100,
                  font_size=16, text_template="{value:.1f}", shape="disk"):
         """
@@ -2057,9 +2057,9 @@ class LineDoubleSlider2D(UI):
         self.handles[1].color = (1, 1, 1)
 
         # Slider Text
-        self.text = [TextBlock2D(justification="center", 
+        self.text = [TextBlock2D(justification="center",
                                  vertical_justification="top"),
-                     TextBlock2D(justification="center", 
+                     TextBlock2D(justification="center",
                                  vertical_justification="top")
                      ]
 

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1714,6 +1714,10 @@ class LineSlider2D(UI):
     shape : string
         Describes the shape of the handle.
         Currently supports 'disk' and 'square'.
+    default_color : (float, float, float)
+        Color of the handle when in unpressed state.
+    active_color : (float, float, float)
+        Color of the handle when it is pressed.
     """
     def __init__(self, center=(0, 0),
                  initial_value=50, min_value=0, max_value=100,
@@ -1754,6 +1758,8 @@ class LineSlider2D(UI):
             Currently supports 'disk' and 'square'.
         """
         self.shape = shape
+        self.default_color = (1, 1, 1)
+        self.active_color = (0, 0, 1)
         super(LineSlider2D, self).__init__()
 
         self.track.width = length
@@ -1792,7 +1798,7 @@ class LineSlider2D(UI):
             self.handle = Disk2D(outer_radius=1)
         elif self.shape == "square":
             self.handle = Rectangle2D(size=(1, 1))
-        self.handle.color = (1, 1, 1)
+        self.handle.color = self.default_color
 
         # Slider Text
         self.text = TextBlock2D(justification="center",
@@ -1801,7 +1807,11 @@ class LineSlider2D(UI):
         # Add default events listener for this UI component.
         self.track.on_left_mouse_button_pressed = self.track_click_callback
         self.track.on_left_mouse_button_dragged = self.handle_move_callback
+        self.track.on_left_mouse_button_released = \
+            self.handle_release_callback
         self.handle.on_left_mouse_button_dragged = self.handle_move_callback
+        self.handle.on_left_mouse_button_released = \
+            self.handle_release_callback
 
     def _get_actors(self):
         """ Get the actors composing this UI component.
@@ -1939,8 +1949,23 @@ class LineSlider2D(UI):
             The picked actor
         slider : :class:`LineSlider2D`
         """
+        self.handle.color = self.active_color
         position = i_ren.event.position
         self.set_position(position)
+        i_ren.force_render()
+        i_ren.event.abort()  # Stop propagating the event.
+
+    def handle_release_callback(self, i_ren, vtkactor, slider):
+        """ Change color when handle is released.
+
+        Parameters
+        ----------
+        i_ren : :class:`CustomInteractorStyle`
+        vtkactor : :class:`vtkActor`
+            The picked actor
+        slider : :class:`LineSlider2D`
+        """
+        self.handle.color = self.default_color
         i_ren.force_render()
         i_ren.event.abort()  # Stop propagating the event.
 
@@ -1967,6 +1992,10 @@ class LineDoubleSlider2D(UI):
     shape : string
         Describes the shape of the handle.
         Currently supports 'disk' and 'square'.
+    default_color : (float, float, float)
+        Color of the handles when in unpressed state.
+    active_color : (float, float, float)
+        Color of the handles when they are pressed.
 
     """
     def __init__(self, line_width=5, inner_radius=0, outer_radius=10,
@@ -2007,6 +2036,8 @@ class LineDoubleSlider2D(UI):
 
         """
         self.shape = shape
+        self.default_color = (1, 1, 1)
+        self.active_color = (0, 0, 1)
         super(LineDoubleSlider2D, self).__init__()
 
         self.track.width = length
@@ -2053,8 +2084,8 @@ class LineDoubleSlider2D(UI):
         elif self.shape == "square":
             self.handles.append(Rectangle2D(size=(1, 1)))
             self.handles.append(Rectangle2D(size=(1, 1)))
-        self.handles[0].color = (1, 1, 1)
-        self.handles[1].color = (1, 1, 1)
+        self.handles[0].color = self.default_color
+        self.handles[1].color = self.default_color
 
         # Slider Text
         self.text = [TextBlock2D(justification="center",
@@ -2069,6 +2100,10 @@ class LineDoubleSlider2D(UI):
             self.handle_move_callback
         self.handles[1].on_left_mouse_button_dragged = \
             self.handle_move_callback
+        self.handles[0].on_left_mouse_button_released = \
+            self.handle_release_callback
+        self.handles[1].on_left_mouse_button_released = \
+            self.handle_release_callback
 
     def _get_actors(self):
         """ Get the actors composing this UI component.
@@ -2296,13 +2331,32 @@ class LineDoubleSlider2D(UI):
         i_ren : :class:`CustomInteractorStyle`
         vtkactor : :class:`vtkActor`
             The picked actor
-        slider : :class:`LineSlider2D`
+        slider : :class:`LineDoubleSlider2D`
         """
         position = i_ren.event.position
         if vtkactor == self.handles[0].actors[0]:
             self.set_position(position, 0)
+            self.handles[0].color = self.active_color
         elif vtkactor == self.handles[1].actors[0]:
             self.set_position(position, 1)
+            self.handles[1].color = self.active_color
+        i_ren.force_render()
+        i_ren.event.abort()  # Stop propagating the event.
+
+    def handle_release_callback(self, i_ren, vtkactor, slider):
+        """ Change color when handle is released.
+
+        Parameters
+        ----------
+        i_ren : :class:`CustomInteractorStyle`
+        vtkactor : :class:`vtkActor`
+            The picked actor
+        slider : :class:`LineDoubleSlider2D`
+        """
+        if vtkactor == self.handles[0].actors[0]:
+            self.handles[0].color = self.default_color
+        elif vtkactor == self.handles[1].actors[0]:
+            self.handles[1].color = self.default_color
         i_ren.force_render()
         i_ren.event.abort()  # Stop propagating the event.
 
@@ -2325,6 +2379,10 @@ class RingSlider2D(UI):
         The moving part of the slider.
     text : :class:`TextBlock2D`
         The text that shows percentage.
+    default_color : (float, float, float)
+        Color of the handle when in unpressed state.
+    active_color : (float, float, float)
+        Color of the handle when it is pressed.
     """
     def __init__(self, center=(0, 0),
                  initial_value=180, min_value=0, max_value=360,
@@ -2359,6 +2417,8 @@ class RingSlider2D(UI):
             If callable, this instance of `:class:RingSlider2D` will be
             passed as argument to the text template function.
         """
+        self.default_color = (1, 1, 1)
+        self.active_color = (0, 0, 1)
         super(RingSlider2D, self).__init__()
 
         self.track.inner_radius = slider_inner_radius
@@ -2390,7 +2450,7 @@ class RingSlider2D(UI):
 
         # Slider's handle.
         self.handle = Disk2D(outer_radius=1)
-        self.handle.color = (1, 1, 1)
+        self.handle.color = self.default_color
 
         # Slider Text
         self.text = TextBlock2D(justification="center",
@@ -2399,7 +2459,11 @@ class RingSlider2D(UI):
         # Add default events listener for this UI component.
         self.track.on_left_mouse_button_pressed = self.track_click_callback
         self.track.on_left_mouse_button_dragged = self.handle_move_callback
+        self.track.on_left_mouse_button_released = \
+            self.handle_release_callback
         self.handle.on_left_mouse_button_dragged = self.handle_move_callback
+        self.handle.on_left_mouse_button_released = \
+            self.handle_release_callback
 
     def _get_actors(self):
         """ Get the actors composing this UI component.
@@ -2539,7 +2603,22 @@ class RingSlider2D(UI):
         slider : :class:`RingSlider2D`
         """
         click_position = i_ren.event.position
+        self.handle.color = self.active_color
         self.move_handle(click_position=click_position)
+        i_ren.force_render()
+        i_ren.event.abort()  # Stop propagating the event.
+
+    def handle_release_callback(self, i_ren, obj, slider):
+        """ Change color when handle is released.
+
+        Parameters
+        ----------
+        i_ren : :class:`CustomInteractorStyle`
+        vtkactor : :class:`vtkActor`
+            The picked actor
+        slider : :class:`RingSlider2D`
+        """
+        self.handle.color = self.default_color
         i_ren.force_render()
         i_ren.event.abort()  # Stop propagating the event.
 
@@ -2684,10 +2763,14 @@ class RangeSlider(UI):
         """
         position = i_ren.event.position
         if obj == self.range_slider.handles[0].actors[0]:
+            self.range_slider.handles[0].color = \
+                self.range_slider.active_color
             self.range_slider.set_position(position, 0)
             self.value_slider.min_value = self.range_slider.left_disk_value
             self.value_slider.update()
         elif obj == self.range_slider.handles[1].actors[0]:
+            self.range_slider.handles[1].color = \
+                self.range_slider.active_color
             self.range_slider.set_position(position, 1)
             self.value_slider.max_value = self.range_slider.right_disk_value
             self.value_slider.update()

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1711,13 +1711,16 @@ class LineSlider2D(UI):
         The moving part of the slider.
     text : :class:`TextBlock2D`
         The text that shows percentage.
+    shape : string
+        Describes the shape of the handle.
+        Currently supports 'disk' and 'square'.
     """
     def __init__(self, center=(0, 0),
                  initial_value=50, min_value=0, max_value=100,
                  length=200, line_width=5,
-                 inner_radius=0, outer_radius=10,
+                 inner_radius=0, outer_radius=10, handle_side=20,
                  font_size=16,
-                 text_template="{value:.1f} ({ratio:.0%})"):
+                 text_template="{value:.1f} ({ratio:.0%})", shape="disk"):
         """
         Parameters
         ----------
@@ -1734,9 +1737,11 @@ class LineSlider2D(UI):
         line_width : int
             Width of the line on which the disk will slide.
         inner_radius : int
-            Inner radius of the slider's handle.
+            Inner radius of the handles (if disk).
         outer_radius : int
-            Outer radius of the slider's handle.
+            Outer radius of the handles (if disk).
+        handle_side : int
+            Side length of the handles (if sqaure).
         font_size : int
             Size of the text to display alongside the slider (pt).
         text_template : str, callable
@@ -1744,13 +1749,21 @@ class LineSlider2D(UI):
             replacement fields: `{value:}`, `{ratio:}`.
             If callable, this instance of `:class:LineSlider2D` will be
             passed as argument to the text template function.
+        shape : string
+            Describes the shape of the handle.
+            Currently supports 'disk' and 'square'.
         """
+        self.shape = shape
         super(LineSlider2D, self).__init__()
 
         self.track.width = length
         self.track.height = line_width
-        self.handle.inner_radius = inner_radius
-        self.handle.outer_radius = outer_radius
+        if shape == "disk":
+            self.handle.inner_radius = inner_radius
+            self.handle.outer_radius = outer_radius
+        elif shape == "square":
+            self.handle.width = handle_side
+            self.handle.height = handle_side
         self.center = center
 
         self.min_value = min_value
@@ -1775,7 +1788,10 @@ class LineSlider2D(UI):
         self.track.color = (1, 0, 0)
 
         # Slider's handle
-        self.handle = Disk2D(outer_radius=1)
+        if self.shape == "disk":
+            self.handle = Disk2D(outer_radius=1)
+        elif self.shape == "square":
+            self.handle = Rectangle2D(size=(1, 1))
         self.handle.color = (1, 1, 1)
 
         # Slider Text
@@ -1822,6 +1838,7 @@ class LineSlider2D(UI):
         # Offset the slider line height by half the slider line width.
         track_position[1] -= self.track.size[1] / 2.
         self.track.position = track_position
+        self.handle.position = self.handle.position.astype('float64')
         self.handle.position += coords - self.position
         # Position the text below the handle.
         self.text.position = (self.handle.center[0],
@@ -1947,21 +1964,26 @@ class LineDoubleSlider2D(UI):
         The moving slider disks.
     text : [:class:`TextBlock2D`, :class:`TextBlock2D`]
         The texts that show the values of the disks.
+    shape : string
+        Describes the shape of the handle.
+        Currently supports 'disk' and 'square'.
 
     """
     def __init__(self, line_width=5, inner_radius=0, outer_radius=10,
-                 center=(450, 300), length=200, initial_values=(0, 100),
-                 min_value=0, max_value=100, font_size=16,
-                 text_template="{value:.1f}"):
+                 handle_side = 20, center=(450, 300), length=200,
+                 initial_values=(0, 100), min_value=0, max_value=100,
+                 font_size=16, text_template="{value:.1f}", shape="disk"):
         """
         Parameters
         ----------
         line_width : int
             Width of the line on which the disk will slide.
         inner_radius : int
-            Inner radius of the handles.
+            Inner radius of the handles (if disk).
         outer_radius : int
-            Outer radius of the handles.
+            Outer radius of the handles (if disk).
+        handle_side : int
+            Side length of the handles (if sqaure).
         center : (float, float)
             Center of the slider.
         length : int
@@ -1979,17 +2001,27 @@ class LineDoubleSlider2D(UI):
             replacement fields: `{value:}`, `{ratio:}`.
             If callable, this instance of `:class:LineDoubleSlider2D` will be
             passed as argument to the text template function.
+        shape : string
+            Describes the shape of the handle.
+            Currently supports 'disk' and 'square'.
 
         """
+        self.shape = shape
         super(LineDoubleSlider2D, self).__init__()
 
         self.track.width = length
         self.track.height = line_width
         self.center = center
-        self.handles[0].inner_radius = inner_radius
-        self.handles[0].outer_radius = outer_radius
-        self.handles[1].inner_radius = inner_radius
-        self.handles[1].outer_radius = outer_radius
+        if shape == "disk":
+            self.handles[0].inner_radius = inner_radius
+            self.handles[0].outer_radius = outer_radius
+            self.handles[1].inner_radius = inner_radius
+            self.handles[1].outer_radius = outer_radius
+        elif shape == "square":
+            self.handles[0].width = handle_side
+            self.handles[0].height = handle_side
+            self.handles[1].width = handle_side
+            self.handles[1].height = handle_side
 
         self.min_value = min_value
         self.max_value = max_value
@@ -2015,15 +2047,21 @@ class LineDoubleSlider2D(UI):
 
         # Handles
         self.handles = []
-        self.handles.append(Disk2D(outer_radius=1))
-        self.handles.append(Disk2D(outer_radius=1))
+        if self.shape == "disk":
+            self.handles.append(Disk2D(outer_radius=1))
+            self.handles.append(Disk2D(outer_radius=1))
+        elif self.shape == "square":
+            self.handles.append(Rectangle2D(size=(1, 1)))
+            self.handles.append(Rectangle2D(size=(1, 1)))
         self.handles[0].color = (1, 1, 1)
         self.handles[1].color = (1, 1, 1)
 
         # Slider Text
-        display_text = TextBlock2D(justification="center",
-                                   vertical_justification="top")
-        self.text = [display_text, display_text]
+        self.text = [TextBlock2D(justification="center", 
+                                 vertical_justification="top"),
+                     TextBlock2D(justification="center", 
+                                 vertical_justification="top")
+                     ]
 
         # Add default events listener for this UI component.
         self.track.on_left_mouse_button_dragged = self.handle_move_callback
@@ -2071,6 +2109,8 @@ class LineDoubleSlider2D(UI):
         # Offset the slider line height by half the slider line width.
         track_position[1] -= self.track.size[1] / 2.
         self.track.position = track_position
+        self.handles[0].position = self.handles[0].position.astype('float64')
+        self.handles[1].position = self.handles[1].position.astype('float64')
         self.handles[0].position += coords - self.position
         self.handles[1].position += coords - self.position
         # Position the text below the handles.
@@ -2523,10 +2563,10 @@ class RangeSlider(UI):
 
     """
     def __init__(self, line_width=5, inner_radius=0, outer_radius=10,
-                 range_slider_center=(450, 400),
+                 handle_side=20, range_slider_center=(450, 400),
                  value_slider_center=(450, 300), length=200, min_value=0,
                  max_value=100, font_size=16, range_precision=1,
-                 value_precision=2):
+                 value_precision=2, shape="disk"):
         """
         Parameters
         ----------
@@ -2536,6 +2576,8 @@ class RangeSlider(UI):
             Inner radius of the handles.
         outer_radius : int
             Outer radius of the handles.
+        handle_side : int
+            Side length of the handles (if sqaure).
         range_slider_center : (float, float)
             Center of the LineDoubleSlider2D object.
         value_slider_center : (float, float)
@@ -2552,14 +2594,19 @@ class RangeSlider(UI):
             Number of decimal places to show the min and max values set.
         value_precision : int
             Number of decimal places to show the value set on slider.
+        shape : string
+            Describes the shape of the handle.
+            Currently supports 'disk' and 'square'.
         """
         self.min_value = min_value
         self.max_value = max_value
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
+        self.handle_side = handle_side
         self.length = length
         self.line_width = line_width
         self.font_size = font_size
+        self.shape = shape
 
         self.range_slider_text_template = \
             "{value:." + str(range_precision) + "f}"
@@ -2577,22 +2624,24 @@ class RangeSlider(UI):
             LineDoubleSlider2D(line_width=self.line_width,
                                inner_radius=self.inner_radius,
                                outer_radius=self.outer_radius,
+                               handle_side=self.handle_side,
                                center=self.range_slider_center,
                                length=self.length, min_value=self.min_value,
                                max_value=self.max_value,
                                initial_values=(self.min_value,
                                                self.max_value),
-                               font_size=self.font_size,
+                               font_size=self.font_size, shape=self.shape,
                                text_template=self.range_slider_text_template)
 
         self.value_slider = \
             LineSlider2D(line_width=self.line_width, length=self.length,
                          inner_radius=self.inner_radius,
                          outer_radius=self.outer_radius,
+                         handle_side=self.handle_side,
                          center=self.value_slider_center,
                          min_value=self.min_value, max_value=self.max_value,
                          initial_value=(self.min_value + self.max_value) / 2,
-                         font_size=self.font_size,
+                         font_size=self.font_size, shape=self.shape,
                          text_template=self.value_slider_text_template)
 
         # Add default events listener for this UI component.

--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -1990,7 +1990,7 @@ class LineDoubleSlider2D(UI):
         self.handles[0].outer_radius = outer_radius
         self.handles[1].inner_radius = inner_radius
         self.handles[1].outer_radius = outer_radius
-        
+
         self.min_value = min_value
         self.max_value = max_value
         self.text[0].font_size = font_size
@@ -2015,23 +2015,29 @@ class LineDoubleSlider2D(UI):
 
         # Handles
         self.handles = []
-        self.handles.append(Disk2D(outer_radius = 1))
-        self.handles.append(Disk2D(outer_radius = 1))
+        self.handles.append(Disk2D(outer_radius=1))
+        self.handles.append(Disk2D(outer_radius=1))
         self.handles[0].color = (1, 1, 1)
         self.handles[1].color = (1, 1, 1)
 
         # Slider Text
-        self.text = [TextBlock2D(justification="center", vertical_justification="top"), TextBlock2D(justification="center", vertical_justification="top")]
+        display_text = TextBlock2D(justification="center",
+                                   vertical_justification="top")
+        self.text = [display_text, display_text]
 
         # Add default events listener for this UI component.
         self.track.on_left_mouse_button_dragged = self.handle_move_callback
-        self.handles[0].on_left_mouse_button_dragged = self.handle_move_callback
-        self.handles[1].on_left_mouse_button_dragged = self.handle_move_callback
+        self.handles[0].on_left_mouse_button_dragged = \
+            self.handle_move_callback
+        self.handles[1].on_left_mouse_button_dragged = \
+            self.handle_move_callback
 
     def _get_actors(self):
         """ Get the actors composing this UI component.
         """
-        return self.track.actors + self.handles[0].actors + self.handles[1].actors + self.text[0].actors + self.text[1].actors
+        return (self.track.actors + self.handles[0].actors +
+                self.handles[1].actors + self.text[0].actors +
+                self.text[1].actors)
 
     def _add_to_renderer(self, ren):
         """ Add all subcomponents or VTK props that compose this UI component.
@@ -2069,9 +2075,9 @@ class LineDoubleSlider2D(UI):
         self.handles[1].position += coords - self.position
         # Position the text below the handles.
         self.text[0].position = (self.handles[0].center[0],
-                              self.handles[0].position[1] - 20)
+                                 self.handles[0].position[1] - 20)
         self.text[1].position = (self.handles[1].center[0],
-                              self.handles[1].position[1] - 20)
+                                 self.handles[1].position[1] - 20)
 
     @property
     def left_x_position(self):
@@ -2238,7 +2244,9 @@ class LineDoubleSlider2D(UI):
         text = self.format_text(disk_number)
         self.text[disk_number].message = text
 
-        self.text[disk_number].position = (self.handles[disk_number].center[0], self.text[disk_number].position[1])
+        self.text[disk_number].position = (
+            self.handles[disk_number].center[0],
+            self.text[disk_number].position[1])
 
     def handle_move_callback(self, i_ren, vtkactor, slider):
         """ Actual handle movement.
@@ -2252,9 +2260,9 @@ class LineDoubleSlider2D(UI):
         """
         position = i_ren.event.position
         if vtkactor == self.handles[0].actors[0]:
-            self.set_position(position,0)
+            self.set_position(position, 0)
         elif vtkactor == self.handles[1].actors[0]:
-            self.set_position(position,1)
+            self.set_position(position, 1)
         i_ren.force_render()
         i_ren.event.abort()  # Stop propagating the event.
 
@@ -2588,8 +2596,10 @@ class RangeSlider(UI):
                          text_template=self.value_slider_text_template)
 
         # Add default events listener for this UI component.
-        self.range_slider.handles[0].on_left_mouse_button_dragged = self.range_slider_handle_move_callback
-        self.range_slider.handles[1].on_left_mouse_button_dragged = self.range_slider_handle_move_callback
+        self.range_slider.handles[0].on_left_mouse_button_dragged = \
+            self.range_slider_handle_move_callback
+        self.range_slider.handles[1].on_left_mouse_button_dragged = \
+            self.range_slider_handle_move_callback
 
     def _get_actors(self):
         """ Get the actors composing this UI component.


### PR DESCRIPTION
This PR adds two elements to the viz.ui module.

LineDoubleSlider2D
-----------------
This element allows the user to have two handles on the same slider. These handles can slide on the track, while not crossing each other at any point.
This element is useful for setting a range for a parameter.
For example, in CT images, this can be used to select a mapping for some window of pixel values to values between 0-255.
![double slider](https://user-images.githubusercontent.com/24621165/41182915-73490710-6b95-11e8-88e7-8d8c27d2baf5.gif)

RangeSlider
---------------
This element uses a `LineDoubleSlider2D` to select a range which restricts a `LineSlider2D` to move within that range. This can be useful when a user wants to fine tune the value of a parameter by narrowing the permissible range for that parameter.
![rangeslider](https://user-images.githubusercontent.com/24621165/41183078-4424fd94-6b96-11e8-9220-5a3f7fdf0929.gif)

Shape of Handles
-----------------
This PR also gives the user an option to choose the shape of the handles of the sliders. Currently, `disk` and `square` are supported. This option is available in `LineSlider2D`, `LineDoubleSlider2D` and `RangeSlider`.