### PR TITLE
Replacing major_version in viz.ui

### DIFF
--- a/dipy/viz/ui.py
+++ b/dipy/viz/ui.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from dipy.data import read_viz_icons
 from dipy.viz.interactor import CustomInteractorStyle
+from dipy.viz.utils import set_input
 
 from dipy.utils.optpkg import optional_package
 
@@ -15,7 +16,7 @@ vtk, have_vtk, setup_module = optional_package('vtk')
 
 if have_vtk:
     version = vtk.vtkVersion.GetVTKVersion()
-    major_version = vtk.vtkVersion.GetVTKMajorVersion()
+    VTK_MAJOR_VERSION = vtk.vtkVersion.GetVTKMajorVersion()
 
 TWO_PI = 2 * np.pi
 
@@ -356,10 +357,7 @@ class Button2D(UI):
         self.texture_polydata.GetPointData().SetTCoords(tc)
 
         texture_mapper = vtk.vtkPolyDataMapper2D()
-        if major_version <= 5:
-            texture_mapper.SetInput(self.texture_polydata)
-        else:
-            texture_mapper.SetInputData(self.texture_polydata)
+        texture_mapper = set_input(texture_mapper, self.texture_polydata)
 
         button = vtk.vtkTexturedActor2D()
         button.SetMapper(texture_mapper)
@@ -449,10 +447,7 @@ class Button2D(UI):
         ----------
         icon : imageDataGeometryFilter
         """
-        if major_version <= 5:
-            self.texture.SetInput(icon)
-        else:
-            self.texture.SetInputData(icon)
+        self.texture = set_input(self.texture, icon)
 
     def next_icon_name(self):
         """ Returns the next icon name while cycling through icons.
@@ -527,10 +522,7 @@ class Rectangle2D(UI):
 
         # Create a mapper and actor
         mapper = vtk.vtkPolyDataMapper2D()
-        if vtk.VTK_MAJOR_VERSION <= 5:
-            mapper.SetInput(self._polygonPolyData)
-        else:
-            mapper.SetInputData(self._polygonPolyData)
+        mapper = set_input(mapper, self._polygonPolyData)
 
         self.actor = vtk.vtkActor2D()
         self.actor.SetMapper(mapper)
@@ -676,7 +668,7 @@ class Disk2D(UI):
 
         # Mapper
         mapper = vtk.vtkPolyDataMapper2D()
-        mapper.SetInputConnection(self._disk.GetOutputPort())
+        mapper = set_input(mapper, self._disk.GetOutputPort())
 
         # Actor
         self.actor = vtk.vtkActor2D()
@@ -1280,7 +1272,7 @@ class TextBlock2D(UI):
             If None, there no background color.
             Otherwise, background color in RGB.
         """
-        if major_version < 7:
+        if VTK_MAJOR_VERSION < 7:
             if self._background is None:
                 return None
 
@@ -1304,13 +1296,13 @@ class TextBlock2D(UI):
 
         if color is None:
             # Remove background.
-            if major_version < 7:
+            if VTK_MAJOR_VERSION < 7:
                 self._background = None
             else:
                 self.actor.GetTextProperty().SetBackgroundOpacity(0.)
 
         else:
-            if major_version < 7:
+            if VTK_MAJOR_VERSION < 7:
                 self._background = vtk.vtkActor2D()
                 self._background.GetProperty().SetColor(*color)
                 self._background.GetProperty().SetOpacity(1)


### PR DESCRIPTION
This PR changes the variable `major_version` used to check the user's version of the vtk library.
When it need to be used to provide the input to the texture mapper, the `set_input` function from `viz.utils` has been used.
At other places, `major_version` has been replaced with `VTK_MAJOR_VERSION`.