### PR TITLE
Fix the relative SF threshold Issue

### DIFF
--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -102,8 +102,9 @@ cdef class BaseDirectionGetter(DirectionGetter):
         pmf = self.pmf_gen.get_pmf_c(point)
         _len = pmf.shape[0]
         max_pmf = np.max(pmf)
+        relative_pmf_threshold = self.pmf_threshold*max_pmf
         for i in range(_len):
-            if pmf[i] < self.pmf_threshold*max_pmf:
+            if pmf[i] < relative_pmf_threshold:
                 pmf[i] = 0.0
         return pmf
 

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -98,11 +98,12 @@ cdef class BaseDirectionGetter(DirectionGetter):
         cdef:
             size_t _len, i
             double[:] pmf
+            double relative_pmf_threshold
 
         pmf = self.pmf_gen.get_pmf_c(point)
         _len = pmf.shape[0]
-        max_pmf = np.max(pmf)
-        relative_pmf_threshold = self.pmf_threshold*max_pmf
+
+        relative_pmf_threshold = self.pmf_threshold*np.max(pmf)
         for i in range(_len):
             if pmf[i] < relative_pmf_threshold:
                 pmf[i] = 0.0

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -98,14 +98,14 @@ cdef class BaseDirectionGetter(DirectionGetter):
         cdef:
             size_t _len, i
             double[:] pmf
-            double relative_pmf_threshold
+            double absolute_pmf_threshold
 
         pmf = self.pmf_gen.get_pmf_c(point)
         _len = pmf.shape[0]
 
-        relative_pmf_threshold = self.pmf_threshold*np.max(pmf)
+        absolute_pmf_threshold = self.pmf_threshold*np.max(pmf)
         for i in range(_len):
-            if pmf[i] < relative_pmf_threshold:
+            if pmf[i] < absolute_pmf_threshold:
                 pmf[i] = 0.0
         return pmf
 

--- a/dipy/direction/closest_peak_direction_getter.pyx
+++ b/dipy/direction/closest_peak_direction_getter.pyx
@@ -101,8 +101,9 @@ cdef class BaseDirectionGetter(DirectionGetter):
 
         pmf = self.pmf_gen.get_pmf_c(point)
         _len = pmf.shape[0]
+        max_pmf = np.max(pmf)
         for i in range(_len):
-            if pmf[i] < self.pmf_threshold:
+            if pmf[i] < self.pmf_threshold*max_pmf:
                 pmf[i] = 0.0
         return pmf
 

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -36,7 +36,7 @@ class LocalTracking(object):
 
     def __init__(self, direction_getter, tissue_classifier, seeds, affine,
                  step_size, max_cross=None, maxlen=500, fixedstep=True,
-                 return_all=False):
+                 return_all=True):
         """Creates streamlines by using local fiber-tracking.
 
         Parameters

--- a/dipy/tracking/local/localtracking.py
+++ b/dipy/tracking/local/localtracking.py
@@ -36,7 +36,7 @@ class LocalTracking(object):
 
     def __init__(self, direction_getter, tissue_classifier, seeds, affine,
                  step_size, max_cross=None, maxlen=500, fixedstep=True,
-                 return_all=True):
+                 return_all=False):
         """Creates streamlines by using local fiber-tracking.
 
         Parameters

--- a/dipy/tracking/local/tests/test_tracking.py
+++ b/dipy/tracking/local/tests/test_tracking.py
@@ -213,9 +213,10 @@ def test_probabilistic_odf_weighted_tracker():
     for sl in streamlines:
         npt.assert_(np.allclose(sl, expected[1]))
 
-    # The first path is not possible if pmf_threshold > 0.4
-    dg = ProbabilisticDirectionGetter.from_pmf(pmf, 90, sphere,
-                                               pmf_threshold=0.5)
+    # The first path is not possible if pmf_threshold > 0.67
+    # 0.4/0.6 < 2/3, multiplying the pmf should not change the ratio
+    dg = ProbabilisticDirectionGetter.from_pmf(10*pmf, 90, sphere,
+                                               pmf_threshold=0.67)
     streamlines = LocalTracking(dg, tc, seeds, np.eye(4), 1.)
 
     for sl in streamlines:
@@ -239,6 +240,7 @@ def test_probabilistic_odf_weighted_tracker():
         npt.assert_(np.all((s + 0.5).astype(int) < mask.shape))
     # Test that the number of streamline return with return_all=True equal the
     # number of seeds places
+
     npt.assert_(np.array([len(streamlines) == len(seeds)]))
 
 
@@ -438,11 +440,11 @@ def test_maximum_deterministic_tracker():
         npt.assert_(np.allclose(sl, expected[1]))
 
     # Both path are not possible if 90 degree turns are exclude and
-    # if pmf_threhold is larger than 0.4. Streamlines should stop at
-    # the crossing
-
-    dg = DeterministicMaximumDirectionGetter.from_pmf(pmf, 80, sphere,
-                                                      pmf_threshold=0.5)
+    # if pmf_threshold is larger than 0.67. Streamlines should stop at
+    # the crossing.
+    # 0.4/0.6 < 2/3, multiplying the pmf should not change the ratio
+    dg = DeterministicMaximumDirectionGetter.from_pmf(10*pmf, 80, sphere,
+                                                      pmf_threshold=0.67)
     streamlines = LocalTracking(dg, tc, seeds, np.eye(4), 1.)
 
     for sl in streamlines:


### PR DESCRIPTION
Following the 4D interpolation and the fit, the amplitude of the values on the sphere are not always between 0 and 1, they can be very large or very small. Right after, a condition using a threshold (between 0 and 1) is performed.
The values on the sphere need to be scaled between 0 and 1 before applying the threshold.

As mentionned in #1582 , without this a simple linear scaling of the same FODf affect the tracking (ranging from a complete absence of streamlines to a broad tracking where most direction are acceptable)