### PR TITLE
Parallelized affine registration

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -440,7 +440,7 @@ class AffineMap(object):
 
 class MutualInformationMetric(object):
 
-    def __init__(self, nbins=32, sampling_proportion=None):
+    def __init__(self, nbins=32, sampling_proportion=None, num_threads=None):
         r""" Initializes an instance of the Mutual Information metric
 
         This class implements the methods required by Optimizer to drive the
@@ -460,6 +460,9 @@ class MutualInformationMetric(object):
             then sparse sampling is used, where `sampling_proportion`
             specifies the proportion of voxels to be used. The default is
             None.
+        num_threads : int
+            Number of threads. If None (default) then all available threads
+            will be used.
 
         Notes
         -----
@@ -475,6 +478,7 @@ class MutualInformationMetric(object):
         self.sampling_proportion = sampling_proportion
         self.metric_val = None
         self.metric_grad = None
+        self.num_threads = num_threads
 
     def setup(self, transform, static, moving, static_grid2world=None,
               moving_grid2world=None, starting_affine=None):
@@ -653,7 +657,7 @@ class MutualInformationMetric(object):
                                             self.moving_world2grid,
                                             self.moving_spacing,
                                             self.static.shape,
-                                            grid_to_world)
+                                            grid_to_world, self.num_threads)
                 # The Jacobian must be evaluated at the pre-aligned points
                 H.update_gradient_dense(
                     params,

--- a/dipy/align/transforms.pxd
+++ b/dipy/align/transforms.pxd
@@ -3,6 +3,7 @@ cdef class Transform:
         int number_of_parameters
         int dim
     cdef int _jacobian(self, double[:] theta, double[:] x, double[:, :] J)nogil
+    cdef int _jacobian_c(self, double[:] theta, double *x, double *J) nogil
     cdef void _get_identity_parameters(self, double[:] theta) nogil
     cdef void _param_to_matrix(self, double[:] theta, double[:, :] T)nogil
     

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -3502,15 +3502,33 @@ def gradient(img, img_world2grid, img_spacing, out_shape,
         out_grid2world = out_grid2world.astype(np.float64)
     # Select joint density gradient 2D or 3D
     if dim == 2:
-        _gradient_2d[cython.double](img, img_world2grid, img_spacing,
-                                    out_grid2world, out, inside)
-    elif dim == 3:
-        if num_threads is None:
-            _gradient_3d[cython.double](img, img_world2grid, img_spacing,
+        if img.dtype == np.float32:
+            _gradient_2d[cython.float](img, img_world2grid, img_spacing,
+                                       out_grid2world, out, inside)
+        elif img.dtype == np.float64:
+            _gradient_2d[cython.double](img, img_world2grid, img_spacing,
                                         out_grid2world, out, inside)
         else:
-            _gradient_3d[cython.double](img, img_world2grid, img_spacing,
-                                        out_grid2world, out, inside, num_threads)
+            raise ValueError('Image dtype must be floating point')
+    elif dim == 3:
+        if num_threads is None:
+            if img.dtype == np.float32:
+                _gradient_3d[cython.float](img, img_world2grid, img_spacing,
+                                            out_grid2world, out, inside)
+            elif img.dtype == np.float64:
+                _gradient_3d[cython.double](img, img_world2grid, img_spacing,
+                                            out_grid2world, out, inside)
+            else:
+                raise ValueError('Image dtype must be floating point')
+        else:
+            if img.dtype == np.float32:
+                _gradient_3d[cython.float](img, img_world2grid, img_spacing,
+                                            out_grid2world, out, inside, num_threads)
+            elif img.dtype == np.float64:
+                _gradient_3d[cython.double](img, img_world2grid, img_spacing,
+                                            out_grid2world, out, inside, num_threads)
+            else:
+                raise ValueError('Image dtype must be floating point')
     else:
         raise ValueError('Undefined gradient for image dimension %d' % (dim,))
     return np.asarray(out), np.asarray(inside)
@@ -3553,9 +3571,23 @@ def sparse_gradient(img, img_world2grid, img_spacing, sample_points):
         img_spacing = img_spacing.astype(np.float64)
     # Select joint density gradient 2D or 3D
     if dim == 2:
-        _sparse_gradient_2d[cython.double](img, img_world2grid, img_spacing,
-                                           sample_points, out, inside)
+        if img.dtype == np.float32:
+            _sparse_gradient_2d[cython.float](img, img_world2grid, img_spacing,
+                                              sample_points, out, inside)
+        elif img.dtype == np.float64:
+            _sparse_gradient_2d[cython.double](img, img_world2grid, img_spacing,
+                                               sample_points, out, inside)
+        else:
+            raise ValueError('Image dtype must be floating point')
+    elif dim == 3:
+        if img.dtype == np.float32:
+            _sparse_gradient_3d[cython.float](img, img_world2grid, img_spacing,
+                                              sample_points, out, inside)
+        elif img.dtype == np.float64:
+            _sparse_gradient_3d[cython.double](img, img_world2grid, img_spacing,
+                                               sample_points, out, inside)
+        else:
+            raise ValueError('Image dtype must be floating point')
     else:
-        _sparse_gradient_3d[cython.double](img, img_world2grid, img_spacing,
-                                           sample_points, out, inside)
+        raise ValueError('Undefined gradient for image dimension %d' % (dim,))
     return np.asarray(out), np.asarray(inside)

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -8,6 +8,7 @@ cimport numpy as cnp
 cimport cython
 from .fused_types cimport floating, number
 
+from cython.parallel import prange
 
 cdef extern from "dpy_math.h" nogil:
     double floor(double)
@@ -3063,6 +3064,95 @@ def create_sphere(cnp.npy_intp nslices, cnp.npy_intp nrows,
     return np.asarray(s)
 
 
+cdef void _gradient_3d_fun(floating[:, :, :] img, double[:, :] img_world2grid,
+                           double[:] img_spacing, double[:, :] out_grid2world,
+                           floating[:, :, :, :] out, int[:, :, :] inside,
+                           int k, double *h) nogil:
+    r""" Gradient of a 3D image in physical space coordinates
+
+    Each grid cell (i, j, k) in the sampling grid (determined by
+    out.shape) is mapped to its corresponding physical point (x, y, z) by
+    multiplying out_grid2world (its grid-to-space transform) by (i, j, k),
+    then the image is interpolated, at
+
+    P1=(x + h, y, z), Q1=(x - h, y, z)
+    P2=(x, y + h, z), Q2=(x, y - h, z)
+    P3=(x, y, z + h), Q3=(x, y, z - h)
+
+    (by mapping Pi and Qi to the grid using img_world2grid: the inverse of the
+    grid-to-space transform of img). The displacement parameter h is of
+    magnitude 0.5 (in physical space units), therefore the approximated partial
+    derivatives are given by the difference between the image interpolated at
+    Pi and Qi.
+
+    Parameters
+    ----------
+    img : array, shape (S, R, C)
+        the input volume whose gradient will be computed
+    img_world2grid : array, shape (4, 4)
+        the space-to-grid transform matrix associated to img
+    img_spacing : array, shape (3,)
+        the spacing between voxels (voxel size along each axis) of the input
+        volume
+    out_grid2world : array, shape (4, 4)
+        the grid-to-space transform associated to the sampling grid
+    out : array, shape (S', R', C', 3)
+        the buffer in which to store the image gradient
+    inside : array, shape (S', R', C')
+        the buffer in which to store the flags indicating whether the sample
+        point lies inside (=1) or outside (=0) the image grid
+    """
+    cdef:
+        int nrows = out.shape[1]
+        int ncols = out.shape[2]
+        int i, j, in_flag, p
+        double tmp, x[3], dx[3], q[3]
+
+    for i in range(nrows):
+        for j in range(ncols):
+            inside[k, i, j] = 1
+            # Compute coordinates of index (k, i, j) in physical space
+            x[0] = _apply_affine_3d_x0(k, i, j, 1, out_grid2world)
+            x[1] = _apply_affine_3d_x1(k, i, j, 1, out_grid2world)
+            x[2] = _apply_affine_3d_x2(k, i, j, 1, out_grid2world)
+            for p in range(3):
+                dx[p] = x[p]
+            for p in range(3):
+                # Compute coordinates of point dx on img's grid
+                dx[p] = x[p] - h[p]
+                q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                           img_world2grid)
+                q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                           img_world2grid)
+                q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                           img_world2grid)
+                # Interpolate img at q
+                in_flag = _interpolate_scalar_3d[floating](img, q[0],
+                    q[1], q[2], &out[k, i, j, p])
+                if in_flag == 0:
+                    out[k, i, j, p] = 0
+                    inside[k, i, j] = 0
+                    continue
+                tmp = out[k, i, j, p]
+                # Compute coordinates of point dx on img's grid
+                dx[p] = x[p] + h[p]
+                q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
+                                           img_world2grid)
+                q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
+                                           img_world2grid)
+                q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
+                                           img_world2grid)
+                # Interpolate img at q
+                in_flag = _interpolate_scalar_3d[floating](img, q[0],
+                    q[1], q[2], &out[k, i, j, p])
+                if in_flag == 0:
+                    out[k, i, j, p] = 0
+                    inside[k, i, j] = 0
+                    continue
+                out[k, i, j, p] = (out[k, i, j, p] - tmp) / img_spacing[p]
+                dx[p] = x[p]
+
+
 cdef void _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
                  double[:] img_spacing, double[:, :] out_grid2world,
                  floating[:, :, :, :] out, int[:, :, :] inside) nogil:
@@ -3101,59 +3191,15 @@ cdef void _gradient_3d(floating[:, :, :] img, double[:, :] img_world2grid,
         point lies inside (=1) or outside (=0) the image grid
     """
     cdef:
-        int nslices = out.shape[0]
-        int nrows = out.shape[1]
-        int ncols = out.shape[2]
-        int i, j, k, in_flag, p
-        double tmp, x[3], dx[3], h[3], q[3]
+        int nslices = out.shape[0], k
+        double h[3]
 
     h[0] = 0.5 * img_spacing[0]
     h[1] = 0.5 * img_spacing[1]
     h[2] = 0.5 * img_spacing[2]
-    for k in range(nslices):
-        for i in range(nrows):
-            for j in range(ncols):
-                inside[k, i, j] = 1
-                # Compute coordinates of index (k, i, j) in physical space
-                x[0] = _apply_affine_3d_x0(k, i, j, 1, out_grid2world)
-                x[1] = _apply_affine_3d_x1(k, i, j, 1, out_grid2world)
-                x[2] = _apply_affine_3d_x2(k, i, j, 1, out_grid2world)
-                for p in range(3):
-                    dx[p] = x[p]
-                for p in range(3):
-                    # Compute coordinates of point dx on img's grid
-                    dx[p] = x[p] - h[p]
-                    q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                               img_world2grid)
-                    q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                               img_world2grid)
-                    q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                               img_world2grid)
-                    # Interpolate img at q
-                    in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                        q[1], q[2], &out[k, i, j, p])
-                    if in_flag == 0:
-                        out[k, i, j, p] = 0
-                        inside[k, i, j] = 0
-                        continue
-                    tmp = out[k, i, j, p]
-                    # Compute coordinates of point dx on img's grid
-                    dx[p] = x[p] + h[p]
-                    q[0] = _apply_affine_3d_x0(dx[0], dx[1], dx[2], 1,
-                                               img_world2grid)
-                    q[1] = _apply_affine_3d_x1(dx[0], dx[1], dx[2], 1,
-                                               img_world2grid)
-                    q[2] = _apply_affine_3d_x2(dx[0], dx[1], dx[2], 1,
-                                               img_world2grid)
-                    # Interpolate img at q
-                    in_flag = _interpolate_scalar_3d[floating](img, q[0],
-                        q[1], q[2], &out[k, i, j, p])
-                    if in_flag == 0:
-                        out[k, i, j, p] = 0
-                        inside[k, i, j] = 0
-                        continue
-                    out[k, i, j, p] = (out[k, i, j, p] - tmp) / img_spacing[p]
-                    dx[p] = x[p]
+    for k in prange(nslices):
+        _gradient_3d_fun(img, img_world2grid, img_spacing, out_grid2world,
+                         out, inside, k, h)
 
 
 cdef void _sparse_gradient_3d(floating[:, :, :] img,


### PR DESCRIPTION
Parallelized affine registration using prange and local function.
1. cythonized \_gradient_* and \_sparse_gradient_* in vector_fields.pyx;
2. typed and made nogil on \_compute_pdfs_* and \_joint_pdf_gradient_* in parzenhist.pyx;
3. parallelize \_gradient_3d using prange and local function.

To specify number of threads, add num_threads when initializing MutualInformationMetric:
> metric = MutualInformationMetric(nbins, sampling_prop, num_threads=4)