### PR TITLE
workflows : warn user for strange b0 threshold 

### DIFF
--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -118,7 +118,11 @@ class ReconstMAPMRIFlow(Workflow):
             data = img.get_data()
             affine = img.affine
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
-
+            if b0_threshold < bvals.min():
+                logging.warning("b0_threshold (value: {0}) is too low,"
+                                "increase your b0_threshold. It should higher "
+                                "than the first b0 value ({1})."
+                                .format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals=bvals, bvecs=bvecs,
                                   small_delta=small_delta,
                                   big_delta=big_delta,
@@ -507,6 +511,11 @@ class ReconstCSDFlow(Workflow):
             affine = img.affine
 
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
+            if b0_threshold < bvals.min():
+                logging.warning("b0_threshold (value: {0}) is too low,"
+                                "increase your b0_threshold. It should higher "
+                                "than the first b0 value ({1})."
+                                .format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold,
                                   atol=bvecs_tol)
             mask_vol = nib.load(maskfile).get_data().astype(np.bool)
@@ -666,6 +675,11 @@ class ReconstCSAFlow(Workflow):
             affine = vol.affine
 
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
+            if b0_threshold < bvals.min():
+                logging.warning("b0_threshold (value: {0}) is too low,"
+                                "increase your b0_threshold. It should higher "
+                                "than the first b0 value ({1})."
+                                .format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs,
                                   b0_threshold=b0_threshold, atol=bvecs_tol)
             mask_vol = nib.load(maskfile).get_data().astype(np.bool)
@@ -902,8 +916,12 @@ class ReconstDkiFlow(Workflow):
     def get_fitted_tensor(self, data, mask, bval, bvec, b0_threshold=0):
         logging.info('Diffusion kurtosis estimation...')
         bvals, bvecs = read_bvals_bvecs(bval, bvec)
+        if b0_threshold < bvals.min():
+            logging.warning("b0_threshold (value: {0}) is too low,"
+                            "increase your b0_threshold. It should higher "
+                            "than the first b0 value ({1})."
+                            .format(b0_threshold, bvals.min()))
         gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold)
-
         dkmodel = self.get_dki_model(gtab)
         dkfit = dkmodel.fit(data, mask)
 

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import os.path
 from ast import literal_eval
+from warnings import warn
 
 import nibabel as nib
 
@@ -119,10 +120,9 @@ class ReconstMAPMRIFlow(Workflow):
             affine = img.affine
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
             if b0_threshold < bvals.min():
-                logging.warning("b0_threshold (value: {0}) is too low,"
-                                "increase your b0_threshold. It should higher "
-                                "than the first b0 value ({1})."
-                                .format(b0_threshold, bvals.min()))
+                warn("b0_threshold (value: {0}) is too low, increase your "
+                     "b0_threshold. It should higher than the first b0 value "
+                     "({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals=bvals, bvecs=bvecs,
                                   small_delta=small_delta,
                                   big_delta=big_delta,
@@ -511,11 +511,11 @@ class ReconstCSDFlow(Workflow):
             affine = img.affine
 
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
+            print(b0_threshold, bvals.min())
             if b0_threshold < bvals.min():
-                logging.warning("b0_threshold (value: {0}) is too low,"
-                                "increase your b0_threshold. It should higher "
-                                "than the first b0 value ({1})."
-                                .format(b0_threshold, bvals.min()))
+                warn("b0_threshold (value: {0}) is too low, increase your "
+                     "b0_threshold. It should higher than the first b0 value "
+                     "({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold,
                                   atol=bvecs_tol)
             mask_vol = nib.load(maskfile).get_data().astype(np.bool)
@@ -676,10 +676,9 @@ class ReconstCSAFlow(Workflow):
 
             bvals, bvecs = read_bvals_bvecs(bval, bvec)
             if b0_threshold < bvals.min():
-                logging.warning("b0_threshold (value: {0}) is too low,"
-                                "increase your b0_threshold. It should higher "
-                                "than the first b0 value ({1})."
-                                .format(b0_threshold, bvals.min()))
+                warn("b0_threshold (value: {0}) is too low, increase your "
+                     "b0_threshold. It should higher than the first b0 value "
+                     "({1}).".format(b0_threshold, bvals.min()))
             gtab = gradient_table(bvals, bvecs,
                                   b0_threshold=b0_threshold, atol=bvecs_tol)
             mask_vol = nib.load(maskfile).get_data().astype(np.bool)
@@ -917,10 +916,10 @@ class ReconstDkiFlow(Workflow):
         logging.info('Diffusion kurtosis estimation...')
         bvals, bvecs = read_bvals_bvecs(bval, bvec)
         if b0_threshold < bvals.min():
-            logging.warning("b0_threshold (value: {0}) is too low,"
-                            "increase your b0_threshold. It should higher "
-                            "than the first b0 value ({1})."
-                            .format(b0_threshold, bvals.min()))
+            warn("b0_threshold (value: {0}) is too low, increase your "
+                 "b0_threshold. It should higher than the first b0 value "
+                 "({1}).".format(b0_threshold, bvals.min()))
+
         gtab = gradient_table(bvals, bvecs, b0_threshold=b0_threshold)
         dkmodel = self.get_dki_model(gtab)
         dkfit = dkmodel.fit(data, mask)

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -1,4 +1,4 @@
-from os.path import join
+from os.path import join as pjoin
 
 import nibabel as nib
 from nibabel.tmpdirs import TemporaryDirectory
@@ -6,8 +6,11 @@ from nibabel.tmpdirs import TemporaryDirectory
 import numpy as np
 
 from nose.tools import assert_true, assert_equal
+import numpy.testing as npt
 
 from dipy.data import get_data
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.core.gradients import generate_bvecs
 from dipy.workflows.reconst import ReconstDkiFlow
 
 
@@ -18,7 +21,7 @@ def test_reconst_dki():
         volume = vol_img.get_data()
         mask = np.ones_like(volume[:, :, :, 0])
         mask_img = nib.Nifti1Image(mask.astype(np.uint8), vol_img.affine)
-        mask_path = join(out_dir, 'tmp_mask.nii.gz')
+        mask_path = pjoin(out_dir, 'tmp_mask.nii.gz')
         nib.save(mask_img, mask_path)
 
         dki_flow = ReconstDkiFlow()
@@ -87,6 +90,20 @@ def test_reconst_dki():
         evals_data = nib.load(evals_path).get_data()
         assert_equal(evals_data.shape[-1], 3)
         assert_equal(evals_data.shape[:-1], volume.shape[:-1])
+
+        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+        bvals[0] = 5.
+        bvecs = generate_bvecs(len(bvals))
+
+        tmp_bval_path = pjoin(out_dir, "tmp.bval")
+        tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
+        np.savetxt(tmp_bval_path, bvals)
+        np.savetxt(tmp_bvec_path, bvecs.T)
+        dki_flow._force_overwrite = True
+        with npt.assert_raises(BaseException):
+            npt.assert_warns(UserWarning, dki_flow.run, data_path,
+                             tmp_bval_path, tmp_bvec_path, mask_path,
+                             out_dir=out_dir)
 
 
 if __name__ == '__main__':

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -100,10 +100,9 @@ def test_reconst_dki():
         np.savetxt(tmp_bval_path, bvals)
         np.savetxt(tmp_bvec_path, bvecs.T)
         dki_flow._force_overwrite = True
-        with npt.assert_raises(BaseException):
-            npt.assert_warns(UserWarning, dki_flow.run, data_path,
-                             tmp_bval_path, tmp_bvec_path, mask_path,
-                             out_dir=out_dir)
+        npt.assert_warns(UserWarning, dki_flow.run, data_path,
+                         tmp_bval_path, tmp_bvec_path, mask_path,
+                         out_dir=out_dir)
 
 
 if __name__ == '__main__':

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -1,4 +1,4 @@
-from os.path import join
+from os.path import join as pjoin
 
 import nibabel as nib
 from nibabel.tmpdirs import TemporaryDirectory
@@ -6,9 +6,12 @@ from nibabel.tmpdirs import TemporaryDirectory
 import numpy as np
 
 from nose.tools import eq_
+import numpy.testing as npt
 from dipy.reconst import mapmri
 
 from dipy.data import get_data
+from dipy.io.gradients import read_bvals_bvecs
+from dipy.core.gradients import generate_bvecs
 from dipy.workflows.reconst import ReconstMAPMRIFlow
 
 
@@ -78,6 +81,19 @@ def reconst_mmri_core(flow, lap, pos):
         perng_data = nib.load(perng).get_data()
         eq_(perng_data.shape, volume.shape[:-1])
 
+        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+        bvals[0] = 5.
+        bvecs = generate_bvecs(len(bvals))
+        tmp_bval_path = pjoin(out_dir, "tmp.bval")
+        tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
+        np.savetxt(tmp_bval_path, bvals)
+        np.savetxt(tmp_bvec_path, bvecs.T)
+        mmri_flow._force_overwrite = True
+        with npt.assert_raises(BaseException):
+            npt.assert_warns(UserWarning, mmri_flow.run, data_path,
+                             tmp_bval_path, tmp_bvec_path, small_delta=0.0129,
+                             big_delta=0.0218, laplacian=lap,
+                             positivity=pos, out_dir=out_dir)
 
 if __name__ == '__main__':
     test_reconst_mmri_laplacian()


### PR DESCRIPTION
I just added a warning when b0 threshold is smaller than all b-values.

I had to duplicate the code many times. It is not the first time. This means a new PR is needed to create a parent class (ReconstWorkflow) and avoid the redundancy.

