### PR TITLE
Adding python 3.7 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
 
 matrix:
   include:


### PR DESCRIPTION
Just adding a new Travis matrix because of python 3.7 release (June 2018)