### PR TITLE
DOC: Fix duplicate link and AppVeyor badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@
 
 .. image:: https://img.shields.io/badge/License-BSD%203--Clause-blue.svg
   :target: https://github.com/nipy/dipy/blob/master/LICENSE
- 
-.. image:: https://ci.appveyor.com/api/projects/status/dipy
+
+.. image:: https://ci.appveyor.com/api/projects/status/github/nipy/dipy?branch=master&svg=true
   :target: https://ci.appveyor.com/project/nipy/dipy
 
 DIPY [DIPYREF]_ is a python library for analysis of MR diffusion imaging.
@@ -73,7 +73,7 @@ or using `conda`::
     conda install -c conda-forge dipy vtk
 
 For detailed installation instructions, including instructions for installing
-from source, please read our `documentation <http://nipy.org/dipy/installation.html>`_.
+from source, please read our `installation documentation <http://nipy.org/dipy/installation.html>`_.
 
 
 License


### PR DESCRIPTION
- Fix duplicate link to documentation and installation documentation.
- Fix AppVeyor CI badge.