### PR TITLE
Increase codecov tolerance

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+
+ignore:
+  - "*/benchmarks/*"
+  - "setup.py"
+  - "*/setup.py"
+
+coverage:
+  status:
+    project:
+      default:
+        # Drops on the order 0.01% are typical even when no change occurs
+        # Having this threshold set a little higher (0.1%) than that makes it 
+        # a little more tolerant to fluctuations
+        threshold: 0.1%

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,7 @@ script:
     - 'echo "backend : agg" > matplotlibrc'
     - if [ "${COVERAGE}" == "1" ]; then
       cp ../.coveragerc .;
+      cp ../.codecov.yml .;
       COVER_ARGS="--with-coverage --cover-package dipy";
       fi
     - nosetests --with-doctest --verbose $COVER_ARGS dipy


### PR DESCRIPTION
Drops on the order 0.01% are typical even when no change occurs. So, Having this threshold set a little higher (0.1%) than that makes it a little more tolerant to fluctuations.

