### PR TITLE
STYLE: Honor 'descoteaux'and 'tournier' SH basis naming.

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -423,10 +423,11 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
     sh_order : int, optional
         Maximum SH order in the SH fit.  For `sh_order`, there will be
         ``(sh_order + 1) * (sh_order + 2) / 2`` SH coefficients (default 8).
-    sh_basis_type : {None, 'mrtrix', 'fibernav'}
-        ``None`` for the default dipy basis which is the fibernav basis,
-        ``mrtrix`` for the MRtrix basis, and
-        ``fibernav`` for the FiberNavigator basis
+    sh_basis_type : {None, 'tournier07', 'descoteaux07'}
+        ``None`` for the default DIPY basis,
+        ``tournier07`` for the Tournier 2007 [2]_ basis, and
+        ``descoteaux07`` for the Descoteaux 2007 [1]_ basis
+        (``None`` defaults to ``descoteaux07``).
     sh_smooth : float, optional
         Lambda-regularization in the SH fit (default 0.0).
     npeaks : int
@@ -450,6 +451,17 @@ def peaks_from_model(model, data, sphere, relative_peak_threshold,
     pam : PeaksAndMetrics
         An object with ``gfa``, ``peak_directions``, ``peak_values``,
         ``peak_indices``, ``odf``, ``shm_coeffs`` as attributes
+
+    References
+    ----------
+    .. [1] Descoteaux, M., Angelino, E., Fitzgibbons, S. and Deriche, R.
+           Regularized, Fast, and Robust Analytical Q-ball Imaging.
+           Magn. Reson. Med. 2007;58:497-510.
+    .. [2] Tournier J.D., Calamante F. and Connelly A. Robust determination
+           of the fibre orientation distribution in diffusion MRI:
+           Non-negativity constrained super-resolved spherical deconvolution.
+           NeuroImage. 2007;35(4):1459-1472.
+
     """
     if return_sh and (B is None or invB is None):
         B, invB = sh_to_sf_matrix(

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -702,8 +702,12 @@ def odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15., sh_order=8,
         array of odfs expressed as spherical harmonics coefficients
     sphere : Sphere
         sphere used to build the regularization matrix
-    basis : {None, 'mrtrix', 'fibernav'}
-        different spherical harmonic basis. None is the fibernav basis as well.
+    basis : {None, 'tournier07', 'descoteaux07'}
+        different spherical harmonic basis:
+        ``None`` for the default DIPY basis,
+        ``tournier07`` for the Tournier 2007 [4]_ basis, and
+        ``descoteaux07`` for the Descoteaux 2007 [3]_ basis
+        (``None`` defaults to ``descoteaux07``).
     ratio : float,
         ratio of the smallest vs the largest eigenvalue of the single prolate
         tensor response function (:math:`\frac{\lambda_2}{\lambda_1}`)
@@ -737,8 +741,14 @@ def odf_sh_to_sharp(odfs_sh, sphere, basis=None, ratio=3 / 15., sh_order=8,
     .. [2] Descoteaux, M., et al. IEEE TMI 2009. Deterministic and
            Probabilistic Tractography Based on Complex Fibre Orientation
            Distributions
-    .. [3] Descoteaux, M, et al. MRM 2007. Fast, Regularized and Analytical
-           Q-Ball Imaging
+    .. [3] Descoteaux, M., Angelino, E., Fitzgibbons, S. and Deriche, R.
+           Regularized, Fast, and Robust Analytical Q-ball Imaging.
+           Magn. Reson. Med. 2007;58:497-510.
+    .. [4] Tournier J.D., Calamante F. and Connelly A. Robust determination
+           of the fibre orientation distribution in diffusion MRI:
+           Non-negativity constrained super-resolved spherical deconvolution.
+           NeuroImage. 2007;35(4):1459-1472.
+
     """
     r, theta, phi = cart2sphere(sphere.x, sphere.y, sphere.z)
     real_sym_sh = sph_harm_lookup[basis]

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -106,16 +106,16 @@ def test_real_sym_sh_mrtrix():
 
 def test_real_sym_sh_basis():
     # This test should do for now
-    # The mrtrix basis should be the same as re-ordering and re-scaling the
-    # fibernav basis
+    # The tournier07 basis should be the same as re-ordering and re-scaling the
+    # descoteaux07 basis
     new_order = [0, 5, 4, 3, 2, 1, 14, 13, 12, 11, 10, 9, 8, 7, 6]
     sphere = hemi_icosahedron.subdivide(2)
     basis, m, n = real_sym_sh_mrtrix(4, sphere.theta, sphere.phi)
     expected = basis[:, new_order]
     expected *= np.where(m == 0, 1., np.sqrt(2))
 
-    fibernav_basis, m, n = real_sym_sh_basis(4, sphere.theta, sphere.phi)
-    assert_array_almost_equal(fibernav_basis, expected)
+    descoteaux07_basis, m, n = real_sym_sh_basis(4, sphere.theta, sphere.phi)
+    assert_array_almost_equal(descoteaux07_basis, expected)
 
 
 def test_smooth_pinv():
@@ -360,13 +360,29 @@ def test_sf_to_sh():
     odf2 = sh_to_sf(odf_sh, sphere, 8)
     assert_array_almost_equal(odf, odf2, 2)
 
-    odf_sh = sf_to_sh(odf, sphere, 8, "mrtrix")
-    odf2 = sh_to_sf(odf_sh, sphere, 8, "mrtrix")
+    odf_sh = sf_to_sh(odf, sphere, 8, "tournier07")
+    odf2 = sh_to_sf(odf_sh, sphere, 8, "tournier07")
     assert_array_almost_equal(odf, odf2, 2)
 
-    odf_sh = sf_to_sh(odf, sphere, 8, "fibernav")
-    odf2 = sh_to_sf(odf_sh, sphere, 8, "fibernav")
+    # Test the basis naming deprecation
+    with warnings.catch_warnings(record=True) as w:
+        odf_sh_mrtrix = sf_to_sh(odf, sphere, 8, "mrtrix")
+        odf2_mrtrix = sh_to_sf(odf_sh, sphere, 8, "mrtrix")
+        assert_array_almost_equal(odf, odf2_mrtrix, 2)
+        assert len(w) != 0
+        assert issubclass(w[-1].category, DeprecationWarning)
+
+    odf_sh = sf_to_sh(odf, sphere, 8, "descoteaux07")
+    odf2 = sh_to_sf(odf_sh, sphere, 8, "descoteaux07")
     assert_array_almost_equal(odf, odf2, 2)
+
+    # Test the basis naming deprecation
+    with warnings.catch_warnings(record=True) as w:
+        odf_sh_fibernav = sf_to_sh(odf, sphere, 8, "fibernav")
+        odf2_fibernav = sh_to_sf(odf_sh_fibernav, sphere, 8, "fibernav")
+        assert_array_almost_equal(odf, odf2_fibernav, 2)
+        assert len(w) != 0
+        assert issubclass(w[-1].category, DeprecationWarning)
 
     # 2D case
     odf2d = np.vstack((odf2, odf))


### PR DESCRIPTION
Honor the authors in the naming for SH basis choice: replace and deprecate
`fibernav` and `mrtrix` and use `descoteaux07` and `tournier07` instead.

The change includes:
- Using the author's name rather than the software/implementation's.
- Testing that the deprecation warning is effectively exercised.
- Adding the necesary references.