### PR TITLE
Flow csd sh order

### DIFF
--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -521,7 +521,7 @@ class ReconstCSDFlow(Workflow):
             mask_vol = nib.load(maskfile).get_data().astype(np.bool)
 
             n_params = ((sh_order + 1) * (sh_order + 2)) / 2
-            if data.shape[-1] < no_params:
+            if data.shape[-1] < n_params:
                 raise ValueError(
                     'You need at least {0} unique DWI volumes to '
                     'compute fiber odfs. You currently have: {1}'

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -520,14 +520,12 @@ class ReconstCSDFlow(Workflow):
                                   atol=bvecs_tol)
             mask_vol = nib.load(maskfile).get_data().astype(np.bool)
 
-            sh_order = 8
-            if data.shape[-1] < 15:
+            n_params = ((sh_order + 1) * (sh_order + 2)) / 2
+            if data.shape[-1] < no_params:
                 raise ValueError(
-                    'You need at least 15 unique DWI volumes to '
-                    'compute fiber odfs. You currently have: {0}'
-                    ' DWI volumes.'.format(data.shape[-1]))
-            elif data.shape[-1] < 30:
-                sh_order = 6
+                    'You need at least {0} unique DWI volumes to '
+                    'compute fiber odfs. You currently have: {1}'
+                    ' DWI volumes.'.format(n_params, data.shape[-1]))
 
             if frf is None:
                 logging.info('Computing response function')

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -36,81 +36,82 @@ def reconst_flow_core(flow):
         nib.save(mask_img, mask_path)
 
         reconst_flow = flow()
-        sh_order = 8
-        reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
-                        sh_order=sh_order,
-                        out_dir=out_dir, extract_pam_values=True)
-
-        gfa_path = reconst_flow.last_generated_outputs['out_gfa']
-        gfa_data = nib.load(gfa_path).get_data()
-        assert_equal(gfa_data.shape, volume.shape[:-1])
-
-        peaks_dir_path = reconst_flow.last_generated_outputs['out_peaks_dir']
-        peaks_dir_data = nib.load(peaks_dir_path).get_data()
-        assert_equal(peaks_dir_data.shape[-1], 15)
-        assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
-
-        peaks_idx_path = \
-            reconst_flow.last_generated_outputs['out_peaks_indices']
-        peaks_idx_data = nib.load(peaks_idx_path).get_data()
-        assert_equal(peaks_idx_data.shape[-1], 5)
-        assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
-
-        peaks_vals_path = \
-            reconst_flow.last_generated_outputs['out_peaks_values']
-        peaks_vals_data = nib.load(peaks_vals_path).get_data()
-        assert_equal(peaks_vals_data.shape[-1], 5)
-        assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
-
-        shm_path = reconst_flow.last_generated_outputs['out_shm']
-        shm_data = nib.load(shm_path).get_data()
-        # Test that the number of coefficients is what you would expect
-        # given the order of the sh basis:
-        assert_equal(shm_data.shape[-1],
-                        sph_harm_ind_list(sh_order)[0].shape[0])
-        assert_equal(shm_data.shape[:-1], volume.shape[:-1])
-
-        pam = load_peaks(reconst_flow.last_generated_outputs['out_pam'])
-        npt.assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape),
-                            peaks_dir_data)
-        npt.assert_allclose(pam.peak_values, peaks_vals_data)
-        npt.assert_allclose(pam.peak_indices, peaks_idx_data)
-        npt.assert_allclose(pam.shm_coeff, shm_data)
-        npt.assert_allclose(pam.gfa, gfa_data)
-
-        bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
-        bvals[0] = 5.
-        bvecs = generate_bvecs(len(bvals))
-
-        tmp_bval_path = pjoin(out_dir, "tmp.bval")
-        tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
-        np.savetxt(tmp_bval_path, bvals)
-        np.savetxt(tmp_bvec_path, bvecs.T)
-        reconst_flow._force_overwrite = True
-        with npt.assert_raises(BaseException):
-            npt.assert_warns(UserWarning, reconst_flow.run, data_path,
-                             tmp_bval_path, tmp_bvec_path, mask_path,
-                             out_dir=out_dir, extract_pam_values=True)
-
-        if flow.get_short_name() == 'csd':
-
-            reconst_flow = flow()
-            reconst_flow._force_overwrite = True
+        for sh_order in [4, 6, 8]:
             reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
-                             out_dir=out_dir, frf=[15, 5, 5])
-            reconst_flow = flow()
+                            sh_order=sh_order,
+                            out_dir=out_dir, extract_pam_values=True)
+
+            gfa_path = reconst_flow.last_generated_outputs['out_gfa']
+            gfa_data = nib.load(gfa_path).get_data()
+            assert_equal(gfa_data.shape, volume.shape[:-1])
+
+            peaks_dir_path =\
+                 reconst_flow.last_generated_outputs['out_peaks_dir']
+            peaks_dir_data = nib.load(peaks_dir_path).get_data()
+            assert_equal(peaks_dir_data.shape[-1], 15)
+            assert_equal(peaks_dir_data.shape[:-1], volume.shape[:-1])
+
+            peaks_idx_path = \
+                reconst_flow.last_generated_outputs['out_peaks_indices']
+            peaks_idx_data = nib.load(peaks_idx_path).get_data()
+            assert_equal(peaks_idx_data.shape[-1], 5)
+            assert_equal(peaks_idx_data.shape[:-1], volume.shape[:-1])
+
+            peaks_vals_path = \
+                reconst_flow.last_generated_outputs['out_peaks_values']
+            peaks_vals_data = nib.load(peaks_vals_path).get_data()
+            assert_equal(peaks_vals_data.shape[-1], 5)
+            assert_equal(peaks_vals_data.shape[:-1], volume.shape[:-1])
+
+            shm_path = reconst_flow.last_generated_outputs['out_shm']
+            shm_data = nib.load(shm_path).get_data()
+            # Test that the number of coefficients is what you would expect
+            # given the order of the sh basis:
+            assert_equal(shm_data.shape[-1],
+                            sph_harm_ind_list(sh_order)[0].shape[0])
+            assert_equal(shm_data.shape[:-1], volume.shape[:-1])
+
+            pam = load_peaks(reconst_flow.last_generated_outputs['out_pam'])
+            npt.assert_allclose(pam.peak_dirs.reshape(peaks_dir_data.shape),
+                                peaks_dir_data)
+            npt.assert_allclose(pam.peak_values, peaks_vals_data)
+            npt.assert_allclose(pam.peak_indices, peaks_idx_data)
+            npt.assert_allclose(pam.shm_coeff, shm_data)
+            npt.assert_allclose(pam.gfa, gfa_data)
+
+            bvals, bvecs = read_bvals_bvecs(bval_path, bvec_path)
+            bvals[0] = 5.
+            bvecs = generate_bvecs(len(bvals))
+
+            tmp_bval_path = pjoin(out_dir, "tmp.bval")
+            tmp_bvec_path = pjoin(out_dir, "tmp.bvec")
+            np.savetxt(tmp_bval_path, bvals)
+            np.savetxt(tmp_bvec_path, bvecs.T)
             reconst_flow._force_overwrite = True
-            reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
-                             out_dir=out_dir, frf='15, 5, 5')
-            reconst_flow = flow()
-            reconst_flow._force_overwrite = True
-            reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
-                             out_dir=out_dir, frf=None)
-            reconst_flow2 = flow()
-            reconst_flow2._force_overwrite = True
-            reconst_flow2.run(data_path, bval_path, bvec_path, mask_path,
-                              out_dir=out_dir, frf=None,
-                              roi_center=[10, 10, 10])
+            with npt.assert_raises(BaseException):
+                npt.assert_warns(UserWarning, reconst_flow.run, data_path,
+                                tmp_bval_path, tmp_bvec_path, mask_path,
+                                out_dir=out_dir, extract_pam_values=True)
+
+            if flow.get_short_name() == 'csd':
+
+                reconst_flow = flow()
+                reconst_flow._force_overwrite = True
+                reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
+                                out_dir=out_dir, frf=[15, 5, 5])
+                reconst_flow = flow()
+                reconst_flow._force_overwrite = True
+                reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
+                                out_dir=out_dir, frf='15, 5, 5')
+                reconst_flow = flow()
+                reconst_flow._force_overwrite = True
+                reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
+                                out_dir=out_dir, frf=None)
+                reconst_flow2 = flow()
+                reconst_flow2._force_overwrite = True
+                reconst_flow2.run(data_path, bval_path, bvec_path, mask_path,
+                                out_dir=out_dir, frf=None,
+                                roi_center=[10, 10, 10])
 
 
 if __name__ == '__main__':

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -37,9 +37,18 @@ def reconst_flow_core(flow):
 
         reconst_flow = flow()
         for sh_order in [4, 6, 8]:
-            reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
-                            sh_order=sh_order,
-                            out_dir=out_dir, extract_pam_values=True)
+            if flow.get_short_name() == 'csd':
+
+                reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
+                                sh_order=sh_order,
+                                out_dir=out_dir, extract_pam_values=True)
+
+            elif flow.get_short_name() == 'csa':
+
+                reconst_flow.run(data_path, bval_path, bvec_path, mask_path,
+                                sh_order=sh_order,
+                                odf_to_sh_order=sh_order,
+                                out_dir=out_dir, extract_pam_values=True)
 
             gfa_path = reconst_flow.last_generated_outputs['out_gfa']
             gfa_data = nib.load(gfa_path).get_data()
@@ -68,7 +77,7 @@ def reconst_flow_core(flow):
             # Test that the number of coefficients is what you would expect
             # given the order of the sh basis:
             assert_equal(shm_data.shape[-1],
-                            sph_harm_ind_list(sh_order)[0].shape[0])
+                         sph_harm_ind_list(sh_order)[0].shape[0])
             assert_equal(shm_data.shape[:-1], volume.shape[:-1])
 
             pam = load_peaks(reconst_flow.last_generated_outputs['out_pam'])


### PR DESCRIPTION
In using the CSD workflow, I discovered that changing the `sh_order` input parameter doesn't seem to do anything. Tracking this down [in the code](https://github.com/nipy/dipy/blob/master/dipy/workflows/reconst.py#L523), I see that it was hard-coded as `sh_order = 8`. This PR changes that and also adds some testing around that. It also more flexibly checks the inputs, so that we are not making assumptions about the input data.
