### PR TITLE
[Fix] workflow variable string

### DIFF
--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -174,8 +174,8 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
 
         if nb_positional_variable > 1:
             raise ValueError(self.prog + " : All positional arguments present"
-                             " are gathered into a list. It doesn’t make much"
-                             " sense to have more than one positional"
+                             " are gathered into a list. It does not make"
+                             "much sense to have more than one positional"
                              " argument with 'variable string' as dtype."
                              " Please, ensure that 'variable (type)'"
                              " appears only once as a positional argument."

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -36,7 +36,9 @@ class IoInfoFlow(Workflow):
 
         np.set_printoptions(3, suppress=True)
 
-        for input_path in input_files:
+        io_it = self.get_io_iterator()
+
+        for input_path in io_it:
             logging.info('------------------------------------------')
             logging.info('Looking at {0}'.format(input_path))
             logging.info('------------------------------------------')

--- a/dipy/workflows/multi_io.py
+++ b/dipy/workflows/multi_io.py
@@ -219,7 +219,7 @@ class IOIterator(object):
         for inp in self.input_args:
             if type(inp) == str:
                 self.inputs.append(sorted(glob(inp)))
-            if type(inp) == list:
+            if type(inp) == list and all(isinstance(s, str) for s in inp):
                 nested = [sorted(glob(i)) for i in inp if isinstance(i, str)]
                 self.inputs.append(list(itertools.chain.from_iterable(nested)))
 

--- a/dipy/workflows/tests/workflow_tests_utils.py
+++ b/dipy/workflows/tests/workflow_tests_utils.py
@@ -111,6 +111,61 @@ class TestFlow(Workflow):
         out_dir : string
             output directory (default '')
         """
-        return positional_str, positional_bool, positional_int,\
-               positional_float, optional_str, optional_bool,\
-               optional_int, optional_float, optional_float_2
+        return (positional_str, positional_bool, positional_int,
+                positional_float, optional_str, optional_bool,
+                optional_int, optional_float, optional_float_2)
+
+
+class TestVariableTypeWorkflow(Workflow):
+
+    @classmethod
+    def get_short_name(cls):
+        return 'tvtwf'
+
+    def run(self, positional_variable_str, positional_int,
+            out_dir=''):
+        """ Workflow used to test variable string in general.
+
+        Parameters
+        ----------
+        positional_variable_str : variable string
+            fake input string param
+        positional_variable_int : int
+            fake positional param (default 2)
+        out_dir : string
+            fake output directory (default '')
+        """
+        result = []
+        io_it = self.get_io_iterator()
+
+        for variable1 in io_it:
+            result.append(variable1)
+        return result, positional_variable_str, positional_int
+
+
+class TestVariableTypeErrorWorkflow(Workflow):
+
+    @classmethod
+    def get_short_name(cls):
+        return 'tvtwfe'
+
+    def run(self, positional_variable_str, positional_variable_int,
+            out_dir=''):
+        """ Workflow used to test variable string error.
+
+        Parameters
+        ----------
+        positional_variable_str : variable string
+            fake input string param
+        positional_variable_int : variable int
+            fake positional param (default 2)
+        out_dir : string
+            fake output directory (default '')
+        """
+        result = []
+        io_it = self.get_io_iterator()
+
+        for variable1, variable2 in io_it:
+            result.append((variable1, variable2))
+
+        return result

--- a/doc/examples/gradients_spheres.py
+++ b/doc/examples/gradients_spheres.py
@@ -74,7 +74,7 @@ We can also create a sphere from the hemisphere and show it in the following way
 sph = Sphere(xyz=np.vstack((hsph_updated.vertices, -hsph_updated.vertices)))
 
 window.rm_all(ren)
-ren.add(actor.point(sph.vertices, actor.colors.green, point_radius=0.05))
+ren.add(actor.point(sph.vertices, window.colors.green, point_radius=0.05))
 
 print('Saving illustration as full_sphere.png')
 window.record(ren, out_path='full_sphere.png', size=(300, 300))


### PR DESCRIPTION
The aim of this PR is to fix #1338.

This allows `variable string` type for `self.get_io_iterator()` function