### PR TITLE
Typo in release notes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -85,5 +85,5 @@ David Hunt <davhunt@indiana.edu> davhunt <davhunt@indiana.edu>
 Parichit Sharma <parichitsharma08@gmail.com> Parichit Sharma <schmuck@149-161-162-17.dhcp-bl.indiana.edu>
 Chandan Gangwar <chandan.gangwar0411@gmail.com>
 Naveen Kumarmarri <naveenkumarmarri6014@gmail.com>
-Jacob Wasserthal <j.wasserthal@dkfz.de>
+Jakob Wasserthal <j.wasserthal@dkfz.de>
 Shreyas Fadnavis <shreyasfadnavis@gmail.com>

--- a/AUTHOR
+++ b/AUTHOR
@@ -88,5 +88,5 @@ Daniel Enrico Cahall <danielenricocahall@gmail.com>
 Jon Mendoza <mrfox321@gmail.com>
 Sagun Pai <sagung.pai@gmail.com>
 Javier Guaje <guaje@users.noreply.github.com>
-Jacob Wasserthal <j.wasserthal@dkfz.de>
+Jakob Wasserthal <j.wasserthal@dkfz.de>
 Himanshu Mishra <himanshu2014iit@gmail.com>

--- a/doc/release0.15.rst
+++ b/doc/release0.15.rst
@@ -37,7 +37,7 @@ The following 30 authors contributed 676 commits.
 * Daniel Enrico Cahall
 * David Hunt
 * Francois Rheault
-* Jacob Wasserthal
+* Jakob Wasserthal
 
 
 We closed a total of 287 issues, 93 pull requests and 194 regular issues;


### PR DESCRIPTION
Sorry for only noticing this now. I do believe @wasserth spells his name with a "K": https://www.dkfz.de/en/mic/team/people/Jakob_Wasserthal.html