### PR TITLE
DOC: Use triple double-quoted strings for docstrings.

### DIFF
--- a/dipy/align/imaffine.py
+++ b/dipy/align/imaffine.py
@@ -955,7 +955,7 @@ class AffineRegistration(object):
     def optimize(self, static, moving, transform, params0,
                  static_grid2world=None, moving_grid2world=None,
                  starting_affine=None):
-        r''' Starts the optimization process
+        r""" Starts the optimization process
 
         Parameters
         ----------
@@ -998,7 +998,7 @@ class AffineRegistration(object):
         -------
         affine_map : instance of AffineMap
             the affine resulting affine transformation
-        '''
+        """
         self._init_optimizer(static, moving, transform, params0,
                              static_grid2world, moving_grid2world,
                              starting_affine)

--- a/dipy/align/imwarp.py
+++ b/dipy/align/imwarp.py
@@ -199,7 +199,7 @@ class DiffeomorphicMap(object):
         self.backward = None
 
     def interpret_matrix(self, obj):
-        ''' Try to interpret `obj` as a matrix
+        """ Try to interpret `obj` as a matrix
 
         Some operations are performed faster if we know in advance if a matrix
         is the identity (so we can skip the actual matrix-vector
@@ -217,7 +217,7 @@ class DiffeomorphicMap(object):
         obj : object
             the same object given as argument if `obj` is None or a numpy
             array. None if `obj` is the 'identity' string.
-        '''
+        """
         if (obj is None) or isinstance(obj, np.ndarray):
             return obj
         if isinstance(obj, str) and (obj == 'identity'):

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -175,7 +175,7 @@ class ParzenJointHistogram(object):
         return _bin_index(xnorm, self.nbins, self.padding)
 
     def update_pdfs_dense(self, static, moving, smask=None, mmask=None):
-        r''' Computes the Probability Density Functions of two images
+        r""" Computes the Probability Density Functions of two images
 
         The joint PDF is stored in self.joint. The marginal distributions
         corresponding to the static and moving images are computed and
@@ -195,7 +195,7 @@ class ParzenJointHistogram(object):
             mask of moving object being registered (a binary array with 1's
             inside the object of interest and 0's along the background).
             If None, ones_like(moving) is used as mask.
-        '''
+        """
         if static.shape != moving.shape:
             raise ValueError("Images must have the same shape")
         dim = len(static.shape)
@@ -218,7 +218,7 @@ class ParzenJointHistogram(object):
                                    self.smarginal, self.mmarginal)
 
     def update_pdfs_sparse(self, sval, mval):
-        r''' Computes the Probability Density Functions from a set of samples
+        r""" Computes the Probability Density Functions from a set of samples
 
         The list of intensities `sval` and `mval` are assumed to be sampled
         from the static and moving images, respectively, at the same
@@ -237,7 +237,7 @@ class ParzenJointHistogram(object):
             sampled intensities from the static image at sampled_points
         mval : array, shape (n,)
             sampled intensities from the moving image at sampled_points
-        '''
+        """
         if not self.setup_called:
             self.setup(sval, mval)
 
@@ -248,7 +248,7 @@ class ParzenJointHistogram(object):
 
     def update_gradient_dense(self, theta, transform, static, moving,
                               grid2world, mgradient, smask=None, mmask=None):
-        r''' Computes the Gradient of the joint PDF w.r.t. transform parameters
+        r""" Computes the Gradient of the joint PDF w.r.t. transform parameters
 
         Computes the vector of partial derivatives of the joint histogram
         w.r.t. each transformation parameter.
@@ -289,7 +289,7 @@ class ParzenJointHistogram(object):
             mask of moving object being registered (a binary array with 1's
             inside the object of interest and 0's along the background).
             The default is None, indicating all voxels are considered.
-        '''
+        """
         if static.shape != moving.shape:
             raise ValueError("Images must have the same shape")
         dim = len(static.shape)
@@ -339,7 +339,7 @@ class ParzenJointHistogram(object):
 
     def update_gradient_sparse(self, theta, transform, sval, mval,
                                sample_points, mgradient):
-        r''' Computes the Gradient of the joint PDF w.r.t. transform parameters
+        r""" Computes the Gradient of the joint PDF w.r.t. transform parameters
 
         Computes the vector of partial derivatives of the joint histogram
         w.r.t. each transformation parameter.
@@ -369,7 +369,7 @@ class ParzenJointHistogram(object):
             sampled at
         mgradient : array, shape (m, 3)
             the gradient of the moving image at the sample points
-        '''
+        """
         dim = sample_points.shape[1]
         if mgradient.shape[1] != dim:
             raise ValueError('Dimensions of gradients and points are different')
@@ -422,7 +422,7 @@ class ParzenJointHistogram(object):
 
 
 cdef inline double _bin_normalize(double x, double mval, double delta) nogil:
-    r''' Normalizes intensity x to the range covered by the Parzen histogram
+    r""" Normalizes intensity x to the range covered by the Parzen histogram
     We assume that mval was computed as:
 
     (1) mval = xmin / delta - padding
@@ -448,13 +448,13 @@ cdef inline double _bin_normalize(double x, double mval, double delta) nogil:
     [padding, nbins-padding], which contains bins with indices
     padding, padding+1, ..., nbins - 1 - padding (i.e., nbins - 2*padding bins)
 
-    '''
+    """
     return x / delta - mval
 
 
 cdef inline cnp.npy_intp _bin_index(double normalized, int nbins,
                                     int padding) nogil:
-    r''' Index of the bin in which the normalized intensity `normalized` lies.
+    r""" Index of the bin in which the normalized intensity `normalized` lies.
 
     The intensity is assumed to have been normalized to the range of
     intensities covered by the histogram: the bin index is the integer part of
@@ -475,7 +475,7 @@ cdef inline cnp.npy_intp _bin_index(double normalized, int nbins,
     -------
     bin : int
         index of the bin in which the normalized intensity 'normalized' lies
-    '''
+    """
     cdef:
         cnp.npy_intp bin
 
@@ -488,13 +488,13 @@ cdef inline cnp.npy_intp _bin_index(double normalized, int nbins,
 
 
 def cubic_spline(double[:] x):
-    r''' Evaluates the cubic spline at a set of values
+    r""" Evaluates the cubic spline at a set of values
 
     Parameters
     ----------
     x : array, shape (n)
         input values
-    '''
+    """
     cdef:
         cnp.npy_intp i
         cnp.npy_intp n = x.shape[0]
@@ -506,7 +506,7 @@ def cubic_spline(double[:] x):
 
 
 cdef inline double _cubic_spline(double x) nogil:
-    r''' Cubic B-Spline evaluated at x
+    r""" Cubic B-Spline evaluated at x
     See eq. (3) of [Matttes03].
 
     References
@@ -515,7 +515,7 @@ cdef inline double _cubic_spline(double x) nogil:
                & Eubank, W. PET-CT image registration in the chest using
                free-form deformations. IEEE Transactions on Medical Imaging,
                22(1), 120-8, 2003.
-    '''
+    """
     cdef:
         double absx = -x if x < 0.0 else x
         double sqrx = x * x
@@ -528,13 +528,13 @@ cdef inline double _cubic_spline(double x) nogil:
 
 
 def cubic_spline_derivative(double[:] x):
-    r''' Evaluates the cubic spline derivative at a set of values
+    r""" Evaluates the cubic spline derivative at a set of values
 
     Parameters
     ----------
     x : array, shape (n)
         input values
-    '''
+    """
     cdef:
         cnp.npy_intp i
         cnp.npy_intp n = x.shape[0]
@@ -546,7 +546,7 @@ def cubic_spline_derivative(double[:] x):
 
 
 cdef inline double _cubic_spline_derivative(double x) nogil:
-    r''' Derivative of cubic B-Spline evaluated at x
+    r""" Derivative of cubic B-Spline evaluated at x
     See eq. (3) of [Mattes03].
 
     References
@@ -555,7 +555,7 @@ cdef inline double _cubic_spline_derivative(double x) nogil:
                & Eubank, W. PET-CT image registration in the chest using
                free-form deformations. IEEE Transactions on Medical Imaging,
                22(1), 120-8, 2003.
-    '''
+    """
     cdef:
         double absx = -x if x < 0.0 else x
     if absx < 1.0:
@@ -577,7 +577,7 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
                             double mmin, double mdelta,
                             int nbins, int padding, double[:, :] joint,
                             double[:] smarginal, double[:] mmarginal):
-    r''' Joint Probability Density Function of intensities of two 2D images
+    r""" Joint Probability Density Function of intensities of two 2D images
 
     Parameters
     ----------
@@ -612,7 +612,7 @@ cdef _compute_pdfs_dense_2d(double[:, :] static, double[:, :] moving,
         the array to write the marginal PDF associated with the static image
     mmarginal : array, shape (nbins,)
         the array to write the marginal PDF associated with the moving image
-    '''
+    """
     cdef:
         cnp.npy_intp nrows = static.shape[0]
         cnp.npy_intp ncols = static.shape[1]
@@ -665,7 +665,7 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
                             double mmin, double mdelta,
                             int nbins, int padding, double[:, :] joint,
                             double[:] smarginal, double[:] mmarginal):
-    r''' Joint Probability Density Function of intensities of two 3D images
+    r""" Joint Probability Density Function of intensities of two 3D images
 
     Parameters
     ----------
@@ -700,7 +700,7 @@ cdef _compute_pdfs_dense_3d(double[:, :, :] static, double[:, :, :] moving,
         the array to write the marginal PDF associated with the static image
     mmarginal : array, shape (nbins,)
         the array to write the marginal PDF associated with the moving image
-    '''
+    """
     cdef:
         cnp.npy_intp nslices = static.shape[0]
         cnp.npy_intp nrows = static.shape[1]
@@ -754,7 +754,7 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
                           double sdelta, double mmin, double mdelta,
                           int nbins, int padding, double[:, :] joint,
                           double[:] smarginal, double[:] mmarginal):
-    r''' Probability Density Functions of paired intensities
+    r""" Probability Density Functions of paired intensities
 
     Parameters
     ----------
@@ -783,7 +783,7 @@ cdef _compute_pdfs_sparse(double[:] sval, double[:] mval, double smin,
         the array to write the marginal PDF associated with the static image
     mmarginal : array, shape (nbins,)
         the array to write the marginal PDF associated with the moving image
-    '''
+    """
     cdef:
         cnp.npy_intp n = sval.shape[0]
         cnp.npy_intp offset, valid_points
@@ -833,7 +833,7 @@ cdef _joint_pdf_gradient_dense_2d(double[:] theta, Transform transform,
                                   int[:, :] mmask, double smin, double sdelta,
                                   double mmin, double mdelta, int nbins,
                                   int padding, double[:, :, :] grad_pdf):
-    r''' Gradient of the joint PDF w.r.t. transform parameters theta
+    r""" Gradient of the joint PDF w.r.t. transform parameters theta
 
     Computes the vector of partial derivatives of the joint histogram w.r.t.
     each transformation parameter. The transformation itself is not necessary
@@ -878,7 +878,7 @@ cdef _joint_pdf_gradient_dense_2d(double[:] theta, Transform transform,
         sides of the histogram is actually 2*padding)
     grad_pdf : array, shape (nbins, nbins, len(theta))
         the array to write the gradient to
-    '''
+    """
     cdef:
         cnp.npy_intp nrows = static.shape[0]
         cnp.npy_intp ncols = static.shape[1]
@@ -943,7 +943,7 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
                                   double sdelta, double mmin, double mdelta,
                                   int nbins, int padding,
                                   double[:, :, :] grad_pdf):
-    r''' Gradient of the joint PDF w.r.t. transform parameters theta
+    r""" Gradient of the joint PDF w.r.t. transform parameters theta
 
     Computes the vector of partial derivatives of the joint histogram w.r.t.
     each transformation parameter. The transformation itself is not necessary
@@ -988,7 +988,7 @@ cdef _joint_pdf_gradient_dense_3d(double[:] theta, Transform transform,
         sides of the histogram is actually 2*padding)
     grad_pdf : array, shape (nbins, nbins, len(theta))
         the array to write the gradient to
-    '''
+    """
     cdef:
         cnp.npy_intp nslices = static.shape[0]
         cnp.npy_intp nrows = static.shape[1]
@@ -1053,7 +1053,7 @@ cdef _joint_pdf_gradient_sparse_2d(double[:] theta, Transform transform,
                                    double sdelta, double mmin,
                                    double mdelta, int nbins, int padding,
                                    double[:, :, :] grad_pdf):
-    r''' Gradient of the joint PDF w.r.t. transform parameters theta
+    r""" Gradient of the joint PDF w.r.t. transform parameters theta
 
     Computes the vector of partial derivatives of the joint histogram w.r.t.
     each transformation parameter. The transformation itself is not necessary
@@ -1091,7 +1091,7 @@ cdef _joint_pdf_gradient_sparse_2d(double[:] theta, Transform transform,
         sides of the histogram is actually 2*padding)
     grad_pdf : array, shape (nbins, nbins, len(theta))
         the array to write the gradient to
-    '''
+    """
     cdef:
         cnp.npy_intp n = theta.shape[0]
         cnp.npy_intp m = sval.shape[0]
@@ -1143,7 +1143,7 @@ cdef _joint_pdf_gradient_sparse_3d(double[:] theta, Transform transform,
                                    double sdelta, double mmin,
                                    double mdelta, int nbins, int padding,
                                    double[:, :, :] grad_pdf):
-    r''' Gradient of the joint PDF w.r.t. transform parameters theta
+    r""" Gradient of the joint PDF w.r.t. transform parameters theta
 
     Computes the vector of partial derivatives of the joint histogram w.r.t.
     each transformation parameter. The transformation itself is not necessary
@@ -1181,7 +1181,7 @@ cdef _joint_pdf_gradient_sparse_3d(double[:] theta, Transform transform,
         sides of the histogram is actually 2*padding)
     grad_pdf : array, shape (nbins, nbins, len(theta))
         the array to write the gradient to
-    '''
+    """
     cdef:
         cnp.npy_intp n = theta.shape[0]
         cnp.npy_intp m = sval.shape[0]

--- a/dipy/align/tests/test_imwarp.py
+++ b/dipy/align/tests/test_imwarp.py
@@ -370,11 +370,11 @@ def simple_callback(sdr, status):
 
 
 def test_ssd_2d_demons():
-    r''' Test 2D SyN with SSD metric, demons-like optimizer
+    r""" Test 2D SyN with SSD metric, demons-like optimizer
 
     Classical Circle-To-C experiment for 2D monomodal registration. We
     verify that the final registration is of good quality.
-    '''
+    """
     fname_moving = get_fnames('reg_o')
     fname_static = get_fnames('reg_c')
 
@@ -439,11 +439,11 @@ def test_ssd_2d_demons():
 
 
 def test_ssd_2d_gauss_newton():
-    r''' Test 2D SyN with SSD metric, Gauss-Newton optimizer
+    r""" Test 2D SyN with SSD metric, Gauss-Newton optimizer
 
     Classical Circle-To-C experiment for 2D monomodal registration. We
     verify that the final registration is of good quality.
-    '''
+    """
     fname_moving = get_fnames('reg_o')
     fname_static = get_fnames('reg_c')
 
@@ -595,12 +595,12 @@ def get_synthetic_warped_circle(nslices):
 
 
 def test_ssd_3d_demons():
-    r''' Test 3D SyN with SSD metric, demons-like optimizer
+    r""" Test 3D SyN with SSD metric, demons-like optimizer
 
     Register a stack of circles ('cylinder') before and after warping them
     with a synthetic diffeomorphism. We verify that the final registration
     is of good quality.
-    '''
+    """
     moving, static = get_synthetic_warped_circle(30)
     moving[..., :8] = 0
     moving[..., -1:-9:-1] = 0
@@ -642,12 +642,12 @@ def test_ssd_3d_demons():
 
 
 def test_ssd_3d_gauss_newton():
-    r''' Test 3D SyN with SSD metric, Gauss-Newton optimizer
+    r""" Test 3D SyN with SSD metric, Gauss-Newton optimizer
 
     Register a stack of circles ('cylinder') before and after warping them
     with a synthetic diffeomorphism. We verify that the final registration
     is of good quality.
-    '''
+    """
     moving, static = get_synthetic_warped_circle(35)
     moving[..., :10] = 0
     moving[..., -1:-11:-1] = 0
@@ -689,12 +689,12 @@ def test_ssd_3d_gauss_newton():
 
 
 def test_cc_2d():
-    r''' Test 2D SyN with CC metric
+    r""" Test 2D SyN with CC metric
 
     Register a coronal slice from a T1w brain MRI before and after warping
     it under a synthetic invertible map. We verify that the final
     registration is of good quality.
-    '''
+    """
     fname = get_fnames('t1_coronal_slice')
     nslices = 1
     b = 0.1
@@ -725,13 +725,13 @@ def test_cc_2d():
 
 
 def test_cc_3d():
-    r''' Test 3D SyN with CC metric
+    r""" Test 3D SyN with CC metric
 
     Register a volume created by stacking copies of a coronal slice from
     a T1w brain MRI before and after warping it under a synthetic
     invertible map. We verify that the final registration is of good
     quality.
-    '''
+    """
     fname = get_fnames('t1_coronal_slice')
     nslices = 21
     b = 0.1
@@ -775,13 +775,13 @@ def test_cc_3d():
 
 
 def test_em_3d_gauss_newton():
-    r''' Test 3D SyN with EM metric, Gauss-Newton optimizer
+    r""" Test 3D SyN with EM metric, Gauss-Newton optimizer
 
     Register a volume created by stacking copies of a coronal slice from
     a T1w brain MRI before and after warping it under a synthetic
     invertible map. We verify that the final registration is of good
     quality.
-    '''
+    """
     fname = get_fnames('t1_coronal_slice')
     nslices = 21
     b = 0.1
@@ -828,12 +828,12 @@ def test_em_3d_gauss_newton():
 
 
 def test_em_2d_gauss_newton():
-    r''' Test 2D SyN with EM metric, Gauss-Newton optimizer
+    r""" Test 2D SyN with EM metric, Gauss-Newton optimizer
 
     Register a coronal slice from a T1w brain MRI before and after warping
     it under a synthetic invertible map. We verify that the final
     registration is of good quality.
-    '''
+    """
 
     fname = get_fnames('t1_coronal_slice')
     nslices = 1
@@ -869,13 +869,13 @@ def test_em_2d_gauss_newton():
 
 
 def test_em_3d_demons():
-    r''' Test 3D SyN with EM metric, demons-like optimizer
+    r""" Test 3D SyN with EM metric, demons-like optimizer
 
     Register a volume created by stacking copies of a coronal slice from
     a T1w brain MRI before and after warping it under a synthetic
     invertible map. We verify that the final registration is of good
     quality.
-    '''
+    """
     fname = get_fnames('t1_coronal_slice')
     nslices = 21
     b = 0.1
@@ -922,12 +922,12 @@ def test_em_3d_demons():
 
 
 def test_em_2d_demons():
-    r''' Test 2D SyN with EM metric, demons-like optimizer
+    r""" Test 2D SyN with EM metric, demons-like optimizer
 
     Register a coronal slice from a T1w brain MRI before and after warping
     it under a synthetic invertible map. We verify that the final
     registration is of good quality.
-    '''
+    """
     fname = get_fnames('t1_coronal_slice')
     nslices = 1
     b = 0.1

--- a/dipy/align/transforms.pyx
+++ b/dipy/align/transforms.pyx
@@ -266,7 +266,7 @@ cdef class RotationTransform2D(Transform):
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
                        double[:, :] J)nogil:
-        r''' Jacobian matrix of a 2D rotation with parameter theta, at x
+        r""" Jacobian matrix of a 2D rotation with parameter theta, at x
 
         The transformation is given by:
 
@@ -291,7 +291,7 @@ cdef class RotationTransform2D(Transform):
         is_constant : int
             always returns 0, indicating that the Jacobian is not
             constant (it depends on the value of x)
-        '''
+        """
         cdef:
             double st = sin(theta[0])
             double ct = cos(theta[0])
@@ -341,7 +341,7 @@ cdef class RotationTransform3D(Transform):
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
                        double[:, :] J)nogil:
-        r''' Jacobian matrix of a 3D rotation with parameters theta, at x
+        r""" Jacobian matrix of a 3D rotation with parameters theta, at x
 
         Parameters
         ----------
@@ -357,7 +357,7 @@ cdef class RotationTransform3D(Transform):
         is_constant : int
             always returns 0, indicating that the Jacobian is not
             constant (it depends on the value of x)
-        '''
+        """
         cdef:
             double sa = sin(theta[0])
             double ca = cos(theta[0])
@@ -443,7 +443,7 @@ cdef class RigidTransform2D(Transform):
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
                        double[:, :] J)nogil:
-        r''' Jacobian matrix of a 2D rigid transform (rotation + translation)
+        r""" Jacobian matrix of a 2D rigid transform (rotation + translation)
 
         The transformation is given by:
 
@@ -472,7 +472,7 @@ cdef class RigidTransform2D(Transform):
         is_constant : int
             always returns 0, indicating that the Jacobian is not
             constant (it depends on the value of x)
-        '''
+        """
         cdef:
             double st = sin(theta[0])
             double ct = cos(theta[0])
@@ -535,7 +535,7 @@ cdef class RigidTransform3D(Transform):
 
     cdef int _jacobian(self, double[:] theta, double[:] x,
                        double[:, :] J)nogil:
-        r''' Jacobian matrix of a 3D rigid transform (rotation + translation)
+        r""" Jacobian matrix of a 3D rigid transform (rotation + translation)
 
         Parameters
         ----------
@@ -557,7 +557,7 @@ cdef class RigidTransform3D(Transform):
         is_constant : int
             always returns 0, indicating that the Jacobian is not
             constant (it depends on the value of x)
-        '''
+        """
         cdef:
             double sa = sin(theta[0])
             double ca = cos(theta[0])

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -1,4 +1,4 @@
-''' Utility functions for algebra etc '''
+""" Utility functions for algebra etc """
 from __future__ import division, print_function, absolute_import
 
 import math
@@ -27,7 +27,7 @@ _TUPLE2AXES = dict((v, k) for k, v in _AXES2TUPLE.items())
 
 
 def sphere2cart(r, theta, phi):
-    ''' Spherical to Cartesian coordinates
+    """ Spherical to Cartesian coordinates
 
     This is the standard physics convention where `theta` is the
     inclination (polar) angle, and `phi` is the azimuth angle.
@@ -90,7 +90,7 @@ def sphere2cart(r, theta, phi):
     name, because the Matlab function uses an unusual convention for the
     angles that we did not want to replicate.  The Matlab function is
     trivial to implement with the formulae given in the Matlab help.
-    '''
+    """
     sin_theta = np.sin(theta)
     x = r * np.cos(phi) * sin_theta
     y = r * np.sin(phi) * sin_theta
@@ -100,7 +100,7 @@ def sphere2cart(r, theta, phi):
 
 
 def cart2sphere(x, y, z):
-    r''' Return angles for Cartesian 3D coordinates `x`, `y`, and `z`
+    r""" Return angles for Cartesian 3D coordinates `x`, `y`, and `z`
 
     See doc for ``sphere2cart`` for angle conventions and derivation
     of the formulae.
@@ -124,7 +124,7 @@ def cart2sphere(x, y, z):
        inclination (polar) angle
     phi : array
        azimuth angle
-    '''
+    """
     r = np.sqrt(x * x + y * y + z * z)
     theta = np.arccos(np.divide(z, r, where=r > 0))
     theta = np.where(r > 0, theta, 0.)
@@ -146,7 +146,7 @@ def sph2latlon(theta, phi):
 
 
 def normalized_vector(vec, axis=-1):
-    ''' Return vector divided by its Euclidean (L2) norm
+    """ Return vector divided by its Euclidean (L2) norm
 
     See :term:`unit vector` and :term:`Euclidean norm`
 
@@ -171,12 +171,12 @@ def normalized_vector(vec, axis=-1):
     True
     >>> normalized_vector(vec).shape == (1, 3)
     True
-    '''
+    """
     return vec / vector_norm(vec, axis, keepdims=True)
 
 
 def vector_norm(vec, axis=-1, keepdims=False):
-    ''' Return vector Euclidean (L2) norm
+    """ Return vector Euclidean (L2) norm
 
     See :term:`unit vector` and :term:`Euclidean norm`
 
@@ -207,7 +207,7 @@ def vector_norm(vec, axis=-1, keepdims=False):
            [ 85.]])
     >>> vector_norm(vec, axis=0)
     array([  8.,  39.,  77.])
-    '''
+    """
     vec = np.asarray(vec)
     vec_norm = np.sqrt((vec * vec).sum(axis))
     if keepdims:
@@ -283,7 +283,7 @@ def rodrigues_axis_rotation(r, theta):
 
 
 def nearest_pos_semi_def(B):
-    ''' Least squares positive semi-definite tensor estimation
+    """ Least squares positive semi-definite tensor estimation
 
     Parameters
     ------------
@@ -310,7 +310,7 @@ def nearest_pos_semi_def(B):
            2006;1:2622-5. PubMed PMID: 17946125; PubMed Central PMCID:
            PMC2791793.
 
-    '''
+    """
     B = np.asarray(B)
     vals, vecs = npl.eigh(B)
     # indices of eigenvalues in descending order
@@ -399,7 +399,7 @@ def sphere_distance(pts1, pts2, radius=None, check_radius=True):
 
 
 def cart_distance(pts1, pts2):
-    ''' Cartesian distance between `pts1` and `pts2`
+    """ Cartesian distance between `pts1` and `pts2`
 
     If either of `pts1` or `pts2` is 2D, then we take the first
     dimension to index points, and the second indexes coordinate.  More
@@ -430,7 +430,7 @@ def cart_distance(pts1, pts2):
     ----------
     >>> cart_distance([0,0,0], [0,0,3])
     3.0
-    '''
+    """
     sqs = np.subtract(pts1, pts2) ** 2
     return np.sqrt(np.sum(sqs, axis=-1))
 
@@ -507,7 +507,7 @@ def lambert_equal_area_projection_polar(theta, phi):
 
 
 def lambert_equal_area_projection_cart(x, y, z):
-    r''' Lambert Equal Area Projection from cartesian vector to plane
+    r""" Lambert Equal Area Projection from cartesian vector to plane
 
     Return positions in $(y_1,y_2)$ plane corresponding to the
     directions of the vectors with cartesian coordinates xyz under the
@@ -535,7 +535,7 @@ def lambert_equal_area_projection_cart(x, y, z):
     ----------
     y : (N,2) array
        planar coordinates of points following mapping by Lambert's EAP.
-    '''
+    """
 
     (r, theta, phi) = cart2sphere(x, y, z)
     return lambert_equal_area_projection_polar(theta, phi)
@@ -778,7 +778,7 @@ def decompose_matrix(matrix):
 
 
 def circumradius(a, b, c):
-    ''' a, b and c are 3-dimensional vectors which are the vertices of a
+    """ a, b and c are 3-dimensional vectors which are the vertices of a
     triangle. The function returns the circumradius of the triangle, i.e
     the radius of the smallest circle that can contain the triangle. In
     the degenerate case when the 3 points are collinear it returns
@@ -793,7 +793,7 @@ def circumradius(a, b, c):
     -------
     circumradius : float
         the desired circumradius
-    '''
+    """
     x = a - c
     xx = np.linalg.norm(x) ** 2
     y = b - c

--- a/dipy/core/graph.py
+++ b/dipy/core/graph.py
@@ -3,12 +3,12 @@ from __future__ import division, print_function, absolute_import
 
 
 class Graph(object):
-    ''' A simple graph class
+    """ A simple graph class
 
-    '''
+    """
 
     def __init__(self):
-        ''' A graph class with nodes and edges :-)
+        """ A graph class with nodes and edges :-)
 
         This class allows us to:
 
@@ -32,7 +32,7 @@ class Graph(object):
         >>> g.up_short('d')
         ['d', 'b', 'a']
 
-        '''
+        """
 
         self.node = {}
         self.pred = {}

--- a/dipy/core/profile.py
+++ b/dipy/core/profile.py
@@ -13,7 +13,7 @@ pstats, _, _ = optional_package('pstats',
 
 
 class Profiler():
-    ''' Profile python/cython files or functions
+    """ Profile python/cython files or functions
 
     If you are profiling cython code you need to add
     # cython: profile=True on the top of your .pyx file
@@ -48,7 +48,7 @@ class Profiler():
     http://docs.python.org/library/profile.html
     http://packages.python.org/line_profiler/
 
-    '''
+    """
 
     def __init__(self, call=None, *args):
         # Delay import until use of class instance.  We were getting some very
@@ -84,7 +84,7 @@ class Profiler():
         self.call(*self.args)
 
     def print_stats(self, N=10):
-        ''' Print stats for profiling
+        """ Print stats for profiling
 
         You can use it in all different ways developed in pstats
         for example
@@ -97,5 +97,5 @@ class Profiler():
         ------------
         N : stats.print_stats argument
 
-        '''
+        """
         self.stats.print_stats(N)

--- a/dipy/core/rng.py
+++ b/dipy/core/rng.py
@@ -6,7 +6,7 @@ from platform import architecture
 
 
 def WichmannHill2006():
-    '''
+    """
     B.A. Wichmann, I.D. Hill, Generating good pseudo-random numbers,
     Computational Statistics & Data Analysis, Volume 51, Issue 3, 1
     December 2006, Pages 1614-1622, ISSN 0167-9473, DOI:
@@ -21,7 +21,7 @@ def WichmannHill2006():
     >>> rng.ix, rng.iy, rng.iz, rng.it = 100001, 200002, 300003, 400004
     >>> N = 1000
     >>> a = [rng.WichmannHill2006() for i in range(N)]
-    '''
+    """
 
     global ix, iy, iz, it
 
@@ -58,7 +58,7 @@ def WichmannHill2006():
 
 
 def WichmannHill1982():
-    '''
+    """
     Algorithm AS 183 Appl. Statist. (1982) vol.31, no.2
 
     Returns a pseudo-random number rectangularly distributed
@@ -70,7 +70,7 @@ def WichmannHill1982():
     30000 before the first entry.
 
     Integer arithmetic up to 5212632 is required.
-    '''
+    """
 
     import numpy as np
 
@@ -80,7 +80,7 @@ def WichmannHill1982():
     iy = (172 * iy) % 30307
     iz = (170 * iz) % 30323
 
-    '''
+    """
     If integer arithmetic only up to 30323 (!) is available, the preceding
     3 statements may be replaced by:
 
@@ -94,20 +94,20 @@ def WichmannHill1982():
         iy = iy + 30307
     if iz < 0:
         iz = iz + 30323
-    '''
+    """
     return np.remainder(np.float(ix) / 30269. + np.float(iy) / 30307. +
                         np.float(iz) / 30323., 1.0)
 
 
 def LEcuyer():
-    '''
+    """
     Generate uniformly distributed random numbers using the 32-bit
     generator from figure 3 of:
         L'Ecuyer, P. Efficient and portable combined random number
         generators, C.A.C.M., vol. 31, 742-749 & 774-?, June 1988.
 
     The cycle length is claimed to be 2.30584E+18
-    '''
+    """
 
     global s1, s2
 

--- a/dipy/core/sphere_stats.py
+++ b/dipy/core/sphere_stats.py
@@ -8,7 +8,7 @@ from itertools import permutations
 
 
 def random_uniform_on_sphere(n=1, coords='xyz'):
-    r'''Random unit vectors from a uniform distribution on the sphere.
+    r"""Random unit vectors from a uniform distribution on the sphere.
 
     Parameters
     -----------
@@ -43,7 +43,7 @@ def random_uniform_on_sphere(n=1, coords='xyz'):
     >>> X = random_uniform_on_sphere(4, 'xyz')
     >>> X.shape == (4, 3)
     True
-    '''
+    """
     z = np.random.uniform(-1, 1, n)
     theta = np.arccos(z)
     phi = np.random.uniform(0, 2*np.pi, n)
@@ -58,7 +58,7 @@ def random_uniform_on_sphere(n=1, coords='xyz'):
 
 
 def eigenstats(points, alpha=0.05):
-    r'''Principal direction and confidence ellipse
+    r"""Principal direction and confidence ellipse
 
     Implements equations in section 6.3.1(ii) of Fisher, Lewis and
     Embleton, supplemented by equations in section 3.2.5.
@@ -77,7 +77,7 @@ def eigenstats(points, alpha=0.05):
         centre of ellipsoid
     b1 : vector (2,)
         lengths of semi-axes of ellipsoid
-    '''
+    """
     n = points.shape[0]
     # the number of points
 
@@ -85,13 +85,13 @@ def eigenstats(points, alpha=0.05):
     # scale angles from radians to degrees
 
     # there is a problem with averaging and axis data.
-    '''
+    """
     centroid = np.sum(points, axis=0)/n
     normed_centroid = geometry.normalized_vector(centroid)
     x,y,z = normed_centroid
     #coordinates of normed centroid
     polar_centroid = np.array(geometry.cart2sphere(x,y,z))*rad2deg
-    '''
+    """
 
     cross = np.dot(points.T, points)/n
     # cross-covariance of points
@@ -158,7 +158,7 @@ def eigenstats(points, alpha=0.05):
 
 
 def compare_orientation_sets(S, T):
-    r'''Computes the mean cosine distance of the best match between
+    r"""Computes the mean cosine distance of the best match between
     points of two sets of vectors S and T (angular similarity)
 
     Parameters
@@ -190,7 +190,7 @@ def compare_orientation_sets(S, T):
     >>> compare_orientation_sets(S,T)
     1.0
 
-    '''
+    """
 
     m = len(S)
     n = len(T)
@@ -208,7 +208,7 @@ def compare_orientation_sets(S, T):
 
 
 def angular_similarity(S, T):
-    r'''Computes the cosine distance of the best match between
+    r"""Computes the cosine distance of the best match between
     points of two sets of vectors S and T
 
     Parameters
@@ -268,7 +268,7 @@ def angular_similarity(S, T):
     >>> T=np.array([[0,np.sqrt(2)/2.,np.sqrt(2)/2.]])
     >>> print('%.12f' % angular_similarity(S,T))
     0.707106781187
-    '''
+    """
     m = len(S)
     n = len(T)
     if m < n:

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -156,7 +156,7 @@ def get_skeleton(name='C1'):
 
 
 def get_sphere(name='symmetric362'):
-    ''' provide triangulated spheres
+    """ provide triangulated spheres
 
     Parameters
     ------------
@@ -187,7 +187,7 @@ def get_sphere(name='symmetric362'):
     Traceback (most recent call last):
         ...
     DataError: No sphere called "not a sphere name"
-    '''
+    """
     fname = SPHERE_FILES.get(name)
     if fname is None:
         raise DataError('No sphere called "%s"' % name)

--- a/dipy/external/fsl.py
+++ b/dipy/external/fsl.py
@@ -1,4 +1,4 @@
-''' FSL IO '''
+""" FSL IO """
 
 from __future__ import with_statement
 
@@ -36,7 +36,7 @@ def have_flirt():
 
 
 def write_bvals_bvecs(bvals, bvecs, outpath=None, prefix=''):
-    ''' Write FSL FDT bvals and bvecs files
+    """ Write FSL FDT bvals and bvecs files
 
     Parameters
     -------------
@@ -50,7 +50,7 @@ def write_bvals_bvecs(bvals, bvecs, outpath=None, prefix=''):
        None results in current working directory.
     prefix : str
        prefix for bvals, bvecs files in directory.  Defaults to ''
-    '''
+    """
     if outpath is None:
         outpath = os.getcwd()
     bvals = tuple(bvals)
@@ -174,7 +174,7 @@ def flirt2aff_files(matfile, in_fname, ref_fname):
 
 
 def warp_displacements(ffa, flaff, fdis, fref, ffaw, order=1):
-    ''' Warp an image using fsl displacements
+    """ Warp an image using fsl displacements
 
     Parameters
     ------------
@@ -183,7 +183,7 @@ def warp_displacements(ffa, flaff, fdis, fref, ffaw, order=1):
     fdis :  filename of displacements (fnirtfileutils)
     fref : filename of reference volume e.g. (FMRIB58_FA_1mm.nii.gz)
     ffaw : filename for the output warped image
-    '''
+    """
     refaff = nib.load(fref).affine
     disdata = nib.load(fdis).get_data()
     imgfa = nib.load(ffa)
@@ -195,7 +195,7 @@ def warp_displacements(ffa, flaff, fdis, fref, ffaw, order=1):
     ires = np.linalg.inv(res)
     # create the 4d volume which has the indices for the reference image
     reftmp = np.zeros(disdata.shape)
-    '''
+    """
     #create the grid indices for the reference
     #refinds = np.ndindex(disdata.shape[:3])
     for ijk_t in refinds:
@@ -203,7 +203,7 @@ def warp_displacements(ffa, flaff, fdis, fref, ffaw, order=1):
         reftmp[i,j,k,0]=i
         reftmp[i,j,k,1]=j
         reftmp[i,j,k,2]=k
-    '''
+    """
     # same as commented above but much faster
     reftmp[..., 0] = np.arange(disdata.shape[0])[:, newaxis, newaxis]
     reftmp[..., 1] = np.arange(disdata.shape[1])[newaxis, :, newaxis]

--- a/dipy/io/pickles.py
+++ b/dipy/io/pickles.py
@@ -4,7 +4,7 @@ from dipy.utils.six.moves import cPickle
 
 
 def save_pickle(fname, dix):
-    ''' Save `dix` to `fname` as pickle
+    """ Save `dix` to `fname` as pickle
 
     Parameters
     ------------
@@ -31,14 +31,14 @@ def save_pickle(fname, dix):
     ----------
     dipy.io.pickles.load_pickle
 
-    '''
+    """
     out = open(fname, 'wb')
     cPickle.dump(dix, out, protocol=cPickle.HIGHEST_PROTOCOL)
     out.close()
 
 
 def load_pickle(fname):
-    ''' Load object from pickle file `fname`
+    """ Load object from pickle file `fname`
 
     Parameters
     ------------
@@ -53,7 +53,7 @@ def load_pickle(fname):
     Examples
     ----------
     dipy.io.pickles.save_pickle
-    '''
+    """
     inp = open(fname, 'rb')
     dix = cPickle.load(inp)
     inp.close()

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -1,4 +1,4 @@
-''' Utility functions for file formats '''
+""" Utility functions for file formats """
 from __future__ import division, print_function, absolute_import
 
 import numpy as np

--- a/dipy/pkg_info.py
+++ b/dipy/pkg_info.py
@@ -9,7 +9,7 @@ from dipy.utils.six.moves import configparser
 COMMIT_INFO_FNAME = 'COMMIT_INFO.txt'
 
 def pkg_commit_hash(pkg_path):
-    ''' Get short form of commit hash given directory `pkg_path`
+    """ Get short form of commit hash given directory `pkg_path`
 
     There should be a file called 'COMMIT_INFO.txt' in `pkg_path`.  This is a
     file in INI file format, with at least one section: ``commit hash``, and two
@@ -37,7 +37,7 @@ def pkg_commit_hash(pkg_path):
        Where we got the hash from - description
     hash_str : str
        short form of hash
-    '''
+    """
     # Try and get commit from written commit text file
     pth = os.path.join(pkg_path, COMMIT_INFO_FNAME)
     if not os.path.isfile(pth):
@@ -62,7 +62,7 @@ def pkg_commit_hash(pkg_path):
 
 
 def get_pkg_info(pkg_path):
-    ''' Return dict describing the context of this package
+    """ Return dict describing the context of this package
 
     Parameters
     ------------
@@ -73,7 +73,7 @@ def get_pkg_info(pkg_path):
     ----------
     context : dict
        with named parameters of interest
-    '''
+    """
     src, hsh = pkg_commit_hash(pkg_path)
     import numpy
     import dipy

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -1399,8 +1399,8 @@ def mapmri_isotropic_M_mu_independent(radial_order, q):
 
 
 def mapmri_isotropic_M_mu_dependent(radial_order, mu, qval):
-    '''Computed the mu dependent part of the signal design matrix.
-    '''
+    """Computed the mu dependent part of the signal design matrix.
+    """
     ind_mat = mapmri_isotropic_index_matrix(radial_order)
 
     n_elem = ind_mat.shape[0]
@@ -1491,8 +1491,8 @@ def mapmri_isotropic_radial_pdf_basis(j, l, mu, r):
 
 
 def mapmri_isotropic_K_mu_independent(radial_order, rgrad):
-    '''Computes mu independent part of K. Same trick as with M.
-    '''
+    """Computes mu independent part of K. Same trick as with M.
+    """
     r, theta, phi = cart2sphere(rgrad[:, 0], rgrad[:, 1],
                                 rgrad[:, 2])
     theta[np.isnan(theta)] = 0
@@ -1517,8 +1517,8 @@ def mapmri_isotropic_K_mu_independent(radial_order, rgrad):
 
 
 def mapmri_isotropic_K_mu_dependent(radial_order, mu, rgrad):
-    '''Computes mu dependent part of M. Same trick as with M.
-    '''
+    """Computes mu dependent part of M. Same trick as with M.
+    """
     r, theta, phi = cart2sphere(rgrad[:, 0], rgrad[:, 1],
                                 rgrad[:, 2])
     theta[np.isnan(theta)] = 0
@@ -1660,7 +1660,7 @@ def mapmri_isotropic_odf_sh_matrix(radial_order, mu, s):
 
 
 def mapmri_isotropic_laplacian_reg_matrix(radial_order, mu):
-    r''' Computes the Laplacian regularization matrix for MAP-MRI's isotropic
+    r""" Computes the Laplacian regularization matrix for MAP-MRI's isotropic
     implementation [1]_ eq. (C7).
 
     Parameters
@@ -1680,7 +1680,7 @@ def mapmri_isotropic_laplacian_reg_matrix(radial_order, mu):
     .. [1]_ Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
     using Laplacian-regularized MAP-MRI and its application to HCP data."
     NeuroImage (2016).
-    '''
+    """
     ind_mat = mapmri_isotropic_index_matrix(radial_order)
     return mapmri_isotropic_laplacian_reg_matrix_from_index_matrix(
         ind_mat, mu
@@ -1688,7 +1688,7 @@ def mapmri_isotropic_laplacian_reg_matrix(radial_order, mu):
 
 
 def mapmri_isotropic_laplacian_reg_matrix_from_index_matrix(ind_mat, mu):
-    r''' Computes the Laplacian regularization matrix for MAP-MRI's isotropic
+    r""" Computes the Laplacian regularization matrix for MAP-MRI's isotropic
     implementation [1]_ eq. (C7).
 
     Parameters
@@ -1708,7 +1708,7 @@ def mapmri_isotropic_laplacian_reg_matrix_from_index_matrix(ind_mat, mu):
     .. [1]_ Fick, Rutger HJ, et al. "MAPL: Tissue microstructure estimation
     using Laplacian-regularized MAP-MRI and its application to HCP data."
     NeuroImage (2016).
-    '''
+    """
     n_elem = ind_mat.shape[0]
     LR = np.zeros((n_elem, n_elem))
 

--- a/dipy/testing/__init__.py
+++ b/dipy/testing/__init__.py
@@ -1,4 +1,4 @@
-''' Utilities for testing '''
+""" Utilities for testing """
 from os.path import dirname, abspath, join as pjoin
 from dipy.testing.spherepoints import sphere_points
 from dipy.testing.decorators import doctest_skip_parser

--- a/dipy/testing/spherepoints.py
+++ b/dipy/testing/spherepoints.py
@@ -1,10 +1,10 @@
-''' Create example sphere points '''
+""" Create example sphere points """
 
 import numpy as np
 
 
 def _make_pts():
-    ''' Make points around sphere quadrants '''
+    """ Make points around sphere quadrants """
     thetas = np.arange(1, 4) * np.pi/4
     phis = np.arange(8) * np.pi/4
     north_pole = (0, 0, 1)

--- a/dipy/tests/test_scripts.py
+++ b/dipy/tests/test_scripts.py
@@ -4,7 +4,7 @@
 
 Run scripts and check outputs
 """
-'''
+"""
 from __future__ import division, print_function, absolute_import
 
 import glob
@@ -148,4 +148,4 @@ def test_qb_commandline_output_path_handling():
         os.chdir('../')
         output_files_list = glob.glob('output/tracks300_*.trk')
         assert_true(output_files_list)
-'''
+"""

--- a/dipy/tracking/distances.pyx
+++ b/dipy/tracking/distances.pyx
@@ -31,7 +31,7 @@ DEF biggest_double = 1.79769e+308 #np.finfo('f8').max
 DEF biggest_float = 3.4028235e+38 #np.finfo('f4').max
 
 cdef inline cnp.ndarray[cnp.float32_t, ndim=1] as_float_3vec(object vec):
-    ''' Utility function to convert object to 3D float vector '''
+    """ Utility function to convert object to 3D float vector """
     return np.squeeze(np.asarray(vec, dtype=np.float32))
 
 
@@ -40,7 +40,7 @@ cdef inline float* asfp(cnp.ndarray pt):
 
 
 def normalized_3vec(vec):
-    ''' Return normalized 3D vector
+    """ Return normalized 3D vector
 
     Vector divided by Euclidean (L2) norm
 
@@ -51,7 +51,7 @@ def normalized_3vec(vec):
     Returns
     -------
     vec_out : array shape (3,)
-    '''
+    """
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_in = as_float_3vec(vec)
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_out = np.zeros((3,), np.float32)
     cnormalized_3vec(<float *>vec_in.data, <float*>vec_out.data)
@@ -59,7 +59,7 @@ def normalized_3vec(vec):
 
 
 def norm_3vec(vec):
-    ''' Euclidean (L2) norm of length 3 vector
+    """ Euclidean (L2) norm of length 3 vector
 
     Parameters
     ----------
@@ -69,13 +69,13 @@ def norm_3vec(vec):
     -------
     norm : float
        Euclidean norm
-    '''
+    """
     cdef cnp.ndarray[cnp.float32_t, ndim=1] vec_in = as_float_3vec(vec)
     return cnorm_3vec(<float *>vec_in.data)
 
 
 cdef inline float cnorm_3vec(float *vec):
-    ''' Calculate Euclidean norm of input vector
+    """ Calculate Euclidean norm of input vector
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ cdef inline float cnorm_3vec(float *vec):
     -------
     norm : float
        Euclidean norm
-    '''
+    """
     cdef float v0, v1, v2
     v0 = vec[0]
     v1 = vec[1]
@@ -95,7 +95,7 @@ cdef inline float cnorm_3vec(float *vec):
 
 
 cdef inline void cnormalized_3vec(float *vec_in, float *vec_out):
-    ''' Calculate and fill normalized 3D vector
+    """ Calculate and fill normalized 3D vector
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ cdef inline void cnormalized_3vec(float *vec_in, float *vec_out):
     vec_out : float *
        Memory into which to write normalized length 3 vector
 
-    '''
+    """
     cdef float norm = cnorm_3vec(vec_in)
     cdef int i
     for i in range(3):
@@ -181,7 +181,7 @@ cdef cnp.dtype f32_dt = np.dtype(np.float32)
 
 
 def cut_plane(tracks, ref):
-    ''' Extract divergence vectors and points of intersection
+    """ Extract divergence vectors and points of intersection
     between planes normal to the reference fiber and other tracks
 
     Parameters
@@ -214,7 +214,7 @@ def cut_plane(tracks, ref):
     [[ 1.          1.5         0.          0.70710683  0.        ]]
     >>> print(res[1])
     [[ 2.          2.5         0.          0.70710677  0.        ]]
-    '''
+    """
     cdef:
         size_t n_hits, hit_no, max_hit_len
         float alpha,beta,lrq,rcd,lhp,ld
@@ -300,13 +300,13 @@ def cut_plane(tracks, ref):
                             delta = rMq # just renaming
                             # |r-q| == |delta|
                             ld = cnorm_3vec(delta)
-                            ''' # Summary of stuff in comments
+                            """ # Summary of stuff in comments
                             # divergence =((r-q)-inner(r-q,normal)*normal)/|r-q|
                             div[0] = (rMq[0]-beta*normal[0]) / ld
                             div[1] = (rMq[1]-beta*normal[1]) / ld
                             div[2] = (rMq[2]-beta*normal[2]) / ld
                             # radial coefficient of divergence d.(h-p)/|h-p|
-                            '''
+                            """
                             # radial divergence
                             # np.inner(delta, (hit-p)) / (ld * lhp)
                             if lhp > 0:
@@ -343,7 +343,7 @@ def cut_plane(tracks, ref):
 
 
 def most_similar_track_mam(tracks,metric='avg'):
-    ''' Find the most similar track in a bundle
+    """ Find the most similar track in a bundle
     using distances calculated from Zhang et. al 2008.
 
     Parameters
@@ -379,7 +379,7 @@ def most_similar_track_mam(tracks,metric='avg'):
             s holds the maximum similarities
 
     si holds the index of the track with min {avg,min,max} average metric
-    '''
+    """
     cdef:
         size_t i, j, lent
         int metric_type
@@ -453,7 +453,7 @@ def most_similar_track_mam(tracks,metric='avg'):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def bundles_distances_mam(tracksA, tracksB, metric='avg'):
-    ''' Calculate distances between list of tracks A and list of tracks B
+    """ Calculate distances between list of tracks A and list of tracks B
 
     Parameters
     ----------
@@ -469,7 +469,7 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
     DM : array, shape (len(tracksA), len(tracksB))
         distances between tracksA and tracksB according to metric
 
-    '''
+    """
     cdef:
         size_t i, j, lentA, lentB
         int metric_type
@@ -532,7 +532,7 @@ def bundles_distances_mam(tracksA, tracksB, metric='avg'):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def bundles_distances_mdf(tracksA, tracksB):
-    ''' Calculate distances between list of tracks A and list of tracks B
+    """ Calculate distances between list of tracks A and list of tracks B
 
     All tracks need to have the same number of points
 
@@ -552,7 +552,7 @@ def bundles_distances_mdf(tracksA, tracksB):
     ---------
     dipy.metrics.downsample
 
-    '''
+    """
     cdef:
         size_t i, j, lentA, lentB
     # preprocess tracks
@@ -610,7 +610,7 @@ cdef inline cnp.float32_t czhang(size_t t1_len,
                                  cnp.float32_t *track2_ptr,
                                  cnp.float32_t *min_buffer,
                                  int metric_type) nogil:
-    ''' Note ``nogil`` - no python calls allowed in this function '''
+    """ Note ``nogil`` - no python calls allowed in this function """
     cdef:
         cnp.float32_t *min_t2t1, *min_t1t2
     min_t2t1 = min_buffer
@@ -685,7 +685,7 @@ cdef inline void min_distances(size_t t1_len,
 
 
 def mam_distances(xyz1,xyz2,metric='all'):
-    ''' Min/Max/Mean Average Minimum Distance between tracks xyz1 and xyz2
+    """ Min/Max/Mean Average Minimum Distance between tracks xyz1 and xyz2
 
     Based on the metrics in Zhang, Correia, Laidlaw 2008
     http://ieeexplore.ieee.org/xpl/freeabs_all.jsp?arnumber=4479455
@@ -727,7 +727,7 @@ def mam_distances(xyz1,xyz2,metric='all'):
     if metric is 'avg' then return (avg_minAB + avg_minBA)/2.0
     if metric is 'min' then return min(avg_minAB,avg_minBA)
     if metric is 'max' then return max(avg_minAB,avg_minBA)
-    '''
+    """
     cdef:
         cnp.ndarray[cnp.float32_t, ndim=2] track1
         cnp.ndarray[cnp.float32_t, ndim=2] track2
@@ -771,7 +771,7 @@ def mam_distances(xyz1,xyz2,metric='all'):
 
 
 def minimum_closest_distance(xyz1,xyz2):
-    ''' Find the minimum distance between two curves xyz1, xyz2
+    """ Find the minimum distance between two curves xyz1, xyz2
 
     Parameters
     ----------
@@ -795,7 +795,7 @@ def minimum_closest_distance(xyz1,xyz2):
     find min of minBA stored in min_minBA
 
     Then return (min_minAB + min_minBA)/2.0
-    '''
+    """
     cdef:
         cnp.ndarray[cnp.float32_t, ndim=2] track1
         cnp.ndarray[cnp.float32_t, ndim=2] track2
@@ -829,7 +829,7 @@ def minimum_closest_distance(xyz1,xyz2):
 
 
 def lee_perpendicular_distance(start0, end0, start1, end1):
-    ''' Calculates perpendicular distance metric for the distance between two line segments
+    """ Calculates perpendicular distance metric for the distance between two line segments
 
     Based on Lee , Han & Whang SIGMOD07.
 
@@ -873,7 +873,7 @@ def lee_perpendicular_distance(start0, end0, start1, end1):
     >>> d = lee_perpendicular_distance([0,0,0],[1,0,0],[3,4,5],[5,4,3])
     >>> print('%.6f' % d)
     5.787888
-    '''
+    """
 
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1,fvec2,fvec3,fvec4
 
@@ -886,8 +886,8 @@ def lee_perpendicular_distance(start0, end0, start1, end1):
 
 
 cdef float clee_perpendicular_distance(float *start0, float *end0,float *start1, float *end1):
-    ''' This function assumes that norm(end0-start0)>norm(end1-start1)
-    '''
+    """ This function assumes that norm(end0-start0)>norm(end1-start1)
+    """
 
     cdef:
         float l0,l1,ltmp,u1,u2,lperp1,lperp2
@@ -932,7 +932,7 @@ cdef float clee_perpendicular_distance(float *start0, float *end0,float *start1,
 
 
 def lee_angle_distance(start0, end0, start1, end1):
-    ''' Calculates angle distance metric for the distance between two line segments
+    """ Calculates angle distance metric for the distance between two line segments
 
     Based on Lee , Han & Whang SIGMOD07.
 
@@ -962,7 +962,7 @@ def lee_angle_distance(start0, end0, start1, end1):
     --------
     >>> lee_angle_distance([0,0,0],[1,0,0],[3,4,5],[5,4,3])
     2.0
-    '''
+    """
 
     cdef cnp.ndarray[cnp.float32_t, ndim=1] fvec1,fvec2,fvec3,fvec4
 
@@ -975,8 +975,8 @@ def lee_angle_distance(start0, end0, start1, end1):
 
 
 cdef float clee_angle_distance(float *start0, float *end0,float *start1, float *end1):
-    ''' This function assumes that norm(end0-start0)>norm(end1-start1)
-    '''
+    """ This function assumes that norm(end0-start0)>norm(end1-start1)
+    """
 
     cdef:
         float l0,l1,ltmp,cos_theta_squared
@@ -998,7 +998,7 @@ cdef float clee_angle_distance(float *start0, float *end0,float *start1, float *
 
 
 def approx_polygon_track(xyz,alpha=0.392):
-    ''' Fast and simple trajectory approximation algorithm by Eleftherios and Ian
+    """ Fast and simple trajectory approximation algorithm by Eleftherios and Ian
 
     It will reduce the number of points of the track by keeping
     intact the start and endpoints of the track and trying to remove
@@ -1041,7 +1041,7 @@ def approx_polygon_track(xyz,alpha=0.392):
     segments of a trajectory and if the angle is higher than pi/4 we
     choose that point as a characteristic point otherwise we move at the
     next point.
-    '''
+    """
     cdef :
         int mid_index
         cnp.ndarray[cnp.float32_t, ndim=2] track
@@ -1082,7 +1082,7 @@ def approx_polygon_track(xyz,alpha=0.392):
 
 
 def approximate_mdl_trajectory(xyz, alpha=1.):
-    ''' Implementation of Lee et al Approximate Trajectory
+    """ Implementation of Lee et al Approximate Trajectory
     Partitioning Algorithm
 
     This is base on the minimum description length principle
@@ -1098,7 +1098,7 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
     -------
     characteristic_points : list of M array(3,) points
 
-    '''
+    """
     cdef :
         int start_index,length,current_index, i
         double cost_par,cost_nopar,alphac
@@ -1149,7 +1149,7 @@ def approximate_mdl_trajectory(xyz, alpha=1.):
 
 
 def intersect_segment_cylinder(sa,sb,p,q,r):
-    ''' Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p,q and r
+    """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p,q and r
 
     See p.197 from Real Time Collision Detection by C. Ericson
 
@@ -1170,7 +1170,7 @@ def intersect_segment_cylinder(sa,sb,p,q,r):
 
     >>> intersect_segment_cylinder(sa, sb, p, q, r)
     (1.0, 0.25, 0.75)
-    '''
+    """
     cdef:
         float *csa,*csb,*cp,*cq
         float cr
@@ -1189,7 +1189,7 @@ def intersect_segment_cylinder(sa,sb,p,q,r):
     return tmp, ct[0], ct[1]
 
 cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, float r, float *t):
-    ''' Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p,q and r
+    """ Intersect Segment S(t) = sa +t(sb-sa), 0 <=t<= 1 against cylinder specified by p,q and r
 
     Look p.197 from Real Time Collision Detection C. Ericson
 
@@ -1198,7 +1198,7 @@ cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, f
     inter : bool
         0 no intersection
         1 intersection
-    '''
+    """
     cdef:
         float d[3],m[3],n[3]
         float md,nd,dd, nn, mn, a, k, c,b, discr
@@ -1262,7 +1262,7 @@ cdef float cintersect_segment_cylinder(float *sa,float *sb,float *p, float *q, f
 
 
 def point_segment_sq_distance(a, b, c):
-    ''' Calculate the squared distance from a point c to a finite line segment ab.
+    """ Calculate the squared distance from a point c to a finite line segment ab.
 
     Examples
     --------
@@ -1277,7 +1277,7 @@ def point_segment_sq_distance(a, b, c):
     >>> c = np.array([-1,1,0], dtype=np.float32)
     >>> point_segment_sq_distance(a, b, c)
     2.0
-    '''
+    """
     cdef:
         float *ca,*cb,*cc
         float cr
@@ -1292,9 +1292,9 @@ def point_segment_sq_distance(a, b, c):
 
 @cython.cdivision(True)
 cdef inline float cpoint_segment_sq_dist(float * a, float * b, float * c) nogil:
-    ''' Calculate the squared distance from a point c to a line segment ab.
+    """ Calculate the squared distance from a point c to a line segment ab.
 
-    '''
+    """
     cdef:
         float ab[3],ac[3],bc[3]
         float e,f
@@ -1315,7 +1315,7 @@ cdef inline float cpoint_segment_sq_dist(float * a, float * b, float * c) nogil:
 
 
 def track_dist_3pts(tracka,trackb):
-    ''' Calculate the euclidean distance between two 3pt tracks
+    """ Calculate the euclidean distance between two 3pt tracks
 
     Both direct and flip distances are calculated but only the smallest is returned
 
@@ -1337,7 +1337,7 @@ def track_dist_3pts(tracka,trackb):
     >>> c = track_dist_3pts(a, b)
     >>> print('%.6f' % c)
     2.721573
-    '''
+    """
 
     cdef cnp.ndarray[cnp.float32_t, ndim=2] a,b
     cdef float d[2]
@@ -1358,7 +1358,7 @@ def track_dist_3pts(tracka,trackb):
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
-    r''' Direct and flip average distance between two tracks
+    r""" Direct and flip average distance between two tracks
 
     Parameters
     ----------
@@ -1393,7 +1393,7 @@ cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
     See also
     --------
     dipy.tracking.distances.local_skeleton_clustering
-    '''
+    """
     cdef:
         long i=0,j=0
         float sub=0,subf=0,distf=0,dist=0,tmprow=0, tmprowf=0
@@ -1415,7 +1415,7 @@ cdef void track_direct_flip_dist(float *a,float *b,long rows,float *out) nogil:
 
 @cython.cdivision(True)
 cdef inline void track_direct_flip_3dist(float *a1, float *b1,float  *c1,float *a2, float *b2, float *c2, float *out) nogil:
-    ''' Calculate the euclidean distance between two 3pt tracks
+    """ Calculate the euclidean distance between two 3pt tracks
     both direct and flip are given as output
 
     Parameters
@@ -1427,7 +1427,7 @@ cdef inline void track_direct_flip_3dist(float *a1, float *b1,float  *c1,float *
     -------
     out : a float[2] array having the euclidean distance and the fliped euclidean distance
 
-    '''
+    """
 
     cdef:
         int i
@@ -1647,7 +1647,7 @@ def local_skeleton_clustering(tracks, d_thr=10):
     return C
 
 def local_skeleton_clustering_3pts(tracks, d_thr=10):
-    ''' Does a first pass clustering
+    """ Does a first pass clustering
 
     Every track can only have 3 pts neither less or more.
     Use `dipy.tracking.metrics.downsample` to restrict the number of points
@@ -1687,7 +1687,7 @@ def local_skeleton_clustering_3pts(tracks, d_thr=10):
                 fvtk.add(r,fos.line(tracks[i],color))
         fvtk.show(r)
 
-    '''
+    """
     cdef :
         cnp.ndarray[cnp.float32_t, ndim=2] track
         cnp.ndarray[cnp.float32_t, ndim=2] h
@@ -1745,7 +1745,7 @@ def local_skeleton_clustering_3pts(tracks, d_thr=10):
 
 
 cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1,float  *c1,float *a2, float *b2, float *c2, float *out):
-    ''' Calculate the average squared euclidean distance between two 3pt tracks
+    """ Calculate the average squared euclidean distance between two 3pt tracks
     both direct and flip are given as output
 
     Parameters
@@ -1759,7 +1759,7 @@ cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1,float  *c1,floa
     -------
     out : float[2] array
         The euclidean distance and the flipped euclidean distance.
-    '''
+    """
 
     cdef:
         int i
@@ -1777,7 +1777,7 @@ cdef inline void track_direct_flip_3sq_dist(float *a1, float *b1,float  *c1,floa
 
 
 def larch_3split(tracks, indices=None, thr=10.):
-    '''Generate a first pass clustering using 3 points on the tracks only.
+    """Generate a first pass clustering using 3 points on the tracks only.
 
     Parameters
     ----------
@@ -1828,7 +1828,7 @@ def larch_3split(tracks, indices=None, thr=10.):
         for c in C:
             r.add(actor.line(C[c]['rep3']/C[c]['N'],fos.white))
         window.show(r)
-    '''
+    """
 
     cdef:
         cnp.ndarray[cnp.float32_t, ndim=2] track
@@ -1880,7 +1880,7 @@ def larch_3split(tracks, indices=None, thr=10.):
 
 
 def larch_3merge(C,thr=10.):
-    '''
+    """
     Reassign tracks to existing clusters by merging clusters that their
     representative tracks are not very distant i.e. less than sqd_thr. Using
     tracks consisting of 3 points (first, mid and last). This is necessary
@@ -1898,7 +1898,7 @@ def larch_3merge(C,thr=10.):
     -------
     C : dict
        a tree graph containing the clusters
-    '''
+    """
 
     cdef cnp.ndarray[cnp.float32_t, ndim=2] h=np.zeros((3,3),dtype=np.float32)
     cdef cnp.ndarray[cnp.float32_t, ndim=2] ch=np.zeros((3,3),dtype=np.float32)
@@ -1946,7 +1946,7 @@ def larch_3merge(C,thr=10.):
 def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,
                                   cnp.ndarray[float,ndim=1] point,
                                   double sq_dist_thr):
-    ''' Check if square distance of track from point is smaller than threshold
+    """ Check if square distance of track from point is smaller than threshold
 
     Parameters
     ----------
@@ -1970,7 +1970,7 @@ def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,
     False
     >>> point_track_sq_distance_check(t,p,2**2)
     True
-    '''
+    """
 
     cdef:
         float *t=<float *>track.data
@@ -2002,7 +2002,7 @@ def point_track_sq_distance_check(cnp.ndarray[float,ndim=2] track,
         return False
 
 def track_roi_intersection_check(cnp.ndarray[float,ndim=2] track, cnp.ndarray[float,ndim=2] roi, double sq_dist_thr):
-    ''' Check if a track is intersecting a region of interest
+    """ Check if a track is intersecting a region of interest
 
     Parameters
     ----------
@@ -2022,7 +2022,7 @@ def track_roi_intersection_check(cnp.ndarray[float,ndim=2] track, cnp.ndarray[fl
     True
     >>> track_roi_intersection_check(t,np.array([[10,0,0]],dtype='f4'),1)
     False
-    '''
+    """
 
     cdef:
         float *t=<float *>track.data

--- a/dipy/tracking/eudx.py
+++ b/dipy/tracking/eudx.py
@@ -7,7 +7,7 @@ from dipy.data import get_sphere
 
 class EuDX(object):
 
-    '''Euler Delta Crossings
+    """Euler Delta Crossings
 
     Generates tracks with termination criteria defined by a delta function [1]_
     and it has similarities with FACT algorithm [2]_ and Basser's method
@@ -43,7 +43,7 @@ class EuDX(object):
     center of the center of the first voxel of the volume and all i,j,k
     coordinates start from the center of the voxel they represent.
 
-    '''
+    """
 
     def __init__(self, a, ind,
                  seeds,
@@ -55,7 +55,7 @@ class EuDX(object):
                  total_weight=.5,
                  max_points=1000,
                  affine=None):
-        '''
+        """
         Euler integration with multiple stopping criteria and supporting
         multiple multiple fibres in crossings [1]_.
 
@@ -136,7 +136,7 @@ class EuDX(object):
         .. [1] E. Garyfallidis (2012), "Towards an accurate brain
                tractography", PhD thesis, University of Cambridge, UK.
 
-        '''
+        """
         self.a = np.array(a, dtype=np.float64, copy=True, order="C")
         self.ind = np.array(ind, dtype=np.float64, copy=True, order="C")
         self.a_low = a_low
@@ -172,7 +172,7 @@ class EuDX(object):
         return utils.move_streamlines(voxel_tracks, self.affine)
 
     def _voxel_tracks(self, seed_voxels):
-        ''' This is were all the fun starts '''
+        """ This is were all the fun starts """
         if seed_voxels is not None and seed_voxels.dtype != np.float64:
             # This is a private method so users should never see this error. If
             # you've reached this error, there is a bug somewhere.

--- a/dipy/tracking/learning.py
+++ b/dipy/tracking/learning.py
@@ -1,10 +1,10 @@
-''' Learning algorithms for tractography'''
+""" Learning algorithms for tractography"""
 import numpy as np
 import dipy.tracking.distances as pf
 
 
 def detect_corresponding_tracks(indices, tracks1, tracks2):
-    ''' Detect corresponding tracks from list tracks1 to list tracks2
+    """ Detect corresponding tracks from list tracks1 to list tracks2
     where tracks1 & tracks2 are lists of tracks
 
     Parameters
@@ -42,7 +42,7 @@ def detect_corresponding_tracks(indices, tracks1, tracks2):
     for every index. (See 3rd column of arr in the example given below.)
 
 
-    '''
+    """
     li = len(indices)
 
     track2track = np.zeros((li, 2))
@@ -57,7 +57,7 @@ def detect_corresponding_tracks(indices, tracks1, tracks2):
 
 
 def detect_corresponding_tracks_plus(indices, tracks1, indices2, tracks2):
-    ''' Detect corresponding tracks from 1 to 2 where tracks1 & tracks2 are
+    """ Detect corresponding tracks from 1 to 2 where tracks1 & tracks2 are
     sequences of tracks
 
     Parameters
@@ -102,7 +102,7 @@ def detect_corresponding_tracks_plus(indices, tracks1, indices2, tracks2):
     ----------
     distances.mam_distances
 
-    '''
+    """
     li = len(indices)
     track2track = np.zeros((li, 2))
     cnt = 0

--- a/dipy/tracking/metrics.py
+++ b/dipy/tracking/metrics.py
@@ -1,4 +1,4 @@
-''' Metrics for tracks, where tracks are arrays of points '''
+""" Metrics for tracks, where tracks are arrays of points """
 from __future__ import division, print_function, absolute_import
 
 from dipy.utils.six.moves import xrange
@@ -9,7 +9,7 @@ from scipy.interpolate import splprep, splev
 
 
 def winding(xyz):
-    '''Total turning angle projected.
+    """Total turning angle projected.
 
     Project space curve to best fitting plane. Calculate the cumulative signed
     angle between each line segment and the previous one.
@@ -24,7 +24,7 @@ def winding(xyz):
     a : scalar
         Total turning angle in degrees.
 
-    '''
+    """
 
     U, s, V = np.linalg.svd(xyz-np.mean(xyz, axis=0), 0)
     proj = np.dot(U[:, 0:2], np.diag(s[0:2]))
@@ -42,7 +42,7 @@ def winding(xyz):
 
 
 def length(xyz, along=False):
-    ''' Euclidean length of track line
+    """ Euclidean length of track line
 
     This will give length in mm if tracks are expressed in world coordinates.
 
@@ -76,7 +76,7 @@ def length(xyz, along=False):
     0
     >>> length([], along=True)
     array([0])
-    '''
+    """
     xyz = np.asarray(xyz)
     if xyz.shape[0] < 2:
         if along:
@@ -89,7 +89,7 @@ def length(xyz, along=False):
 
 
 def bytes(xyz):
-    '''Size of track in bytes.
+    """Size of track in bytes.
 
     Parameters
     ------------
@@ -101,12 +101,12 @@ def bytes(xyz):
     b : int
         Number of bytes.
 
-    '''
+    """
     return xyz.nbytes
 
 
 def midpoint(xyz):
-    ''' Midpoint of track
+    """ Midpoint of track
 
     Parameters
     ----------
@@ -143,7 +143,7 @@ def midpoint(xyz):
     >>> xyz = np.array([[0,9,7],[1,9,7],[3,9,7]])
     >>> midpoint(xyz)
     array([ 1.5,  9. ,  7. ])
-    '''
+    """
     xyz = np.asarray(xyz)
     n_pts = xyz.shape[0]
     if n_pts == 0:
@@ -162,7 +162,7 @@ def midpoint(xyz):
 
 
 def center_of_mass(xyz):
-    ''' Center of mass of streamline
+    """ Center of mass of streamline
 
     Parameters
     ------------
@@ -186,7 +186,7 @@ def center_of_mass(xyz):
     >>> xyz = np.array([[0,0,0],[1,1,1],[2,2,2]])
     >>> center_of_mass(xyz)
     array([ 1.,  1.,  1.])
-    '''
+    """
     xyz = np.asarray(xyz)
     if xyz.size == 0:
         raise ValueError('xyz array cannot be empty')
@@ -194,9 +194,9 @@ def center_of_mass(xyz):
 
 
 def magn(xyz, n=1):
-    ''' magnitude of vector
+    """ magnitude of vector
 
-    '''
+    """
     mag = np.sum(xyz**2, axis=1)**0.5
     imag = np.where(mag == 0)
     mag[imag] = np.finfo(float).eps
@@ -207,7 +207,7 @@ def magn(xyz, n=1):
 
 
 def frenet_serret(xyz):
-    r''' Frenet-Serret Space Curve Invariants
+    r""" Frenet-Serret Space Curve Invariants
 
     Calculates the 3 vector and 2 scalar invariants of a space curve
     defined by vectors r = (x,y,z).  If z is omitted (i.e. the array xyz has
@@ -261,7 +261,7 @@ def frenet_serret(xyz):
     >>> z=theta/(2*np.pi)
     >>> xyz=np.vstack((x,y,z)).T
     >>> T,N,B,k,t=tm.frenet_serret(xyz)
-    '''
+    """
 
     xyz = np.asarray(xyz)
     n_pts = xyz.shape[0]
@@ -288,7 +288,7 @@ def frenet_serret(xyz):
 
 
 def mean_curvature(xyz):
-    ''' Calculates the mean curvature of a curve
+    """ Calculates the mean curvature of a curve
 
     Parameters
     ------------
@@ -317,7 +317,7 @@ def mean_curvature(xyz):
     >>> z=0*x
     >>> xyz=np.vstack((x,y,z)).T
     >>> _= tm.mean_curvature(xyz) #mean curvature for semi-circle
-    '''
+    """
     xyz = np.asarray(xyz)
     n_pts = xyz.shape[0]
     if n_pts == 0:
@@ -333,7 +333,7 @@ def mean_curvature(xyz):
 
 
 def mean_orientation(xyz):
-    '''
+    """
     Calculates the mean orientation of a curve
 
     Parameters
@@ -345,7 +345,7 @@ def mean_orientation(xyz):
     -------
     m : float
         Mean orientation.
-    '''
+    """
     xyz = np.asarray(xyz)
     n_pts = xyz.shape[0]
     if n_pts == 0:
@@ -393,7 +393,7 @@ def generate_combinations(items, n):
 
 
 def longest_track_bundle(bundle, sort=False):
-    ''' Return longest track or length sorted track indices in `bundle`
+    """ Return longest track or length sorted track indices in `bundle`
 
     If `sort` == True, return the indices of the sorted tracks in the
     bundle, otherwise return the longest track.
@@ -423,7 +423,7 @@ def longest_track_bundle(bundle, sort=False):
     >>> longest_track_bundle(bundle, True) #doctest: +ELLIPSIS
     array([0, 1]...)
 
-    '''
+    """
     alllengths = [length(t) for t in bundle]
     alllengths = np.array(alllengths)
     if sort:
@@ -435,7 +435,7 @@ def longest_track_bundle(bundle, sort=False):
 
 
 def intersect_sphere(xyz, center, radius):
-    ''' If any segment of the track is intersecting with a sphere of
+    """ If any segment of the track is intersecting with a sphere of
     specific center and radius return True otherwise False
 
     Parameters
@@ -466,7 +466,7 @@ def intersect_sphere(xyz, center, radius):
     http://local.wasp.uwa.edu.au/~pbourke/geometry/sphereline/source.cpp
     we just applied it for every segment neglecting the intersections where
     the intersecting points are not inside the segment
-    '''
+    """
     center = np.array(center)
     # print center
 
@@ -509,7 +509,7 @@ def intersect_sphere(xyz, center, radius):
 
 
 def inside_sphere(xyz, center, radius):
-    ''' If any point of the track is inside a sphere of a specified
+    """ If any point of the track is inside a sphere of a specified
     center and radius return True otherwise False.  Mathematicaly this
     can be simply described by $|x-c|\le r$ where $x$ a point $c$ the
     center of the sphere and $r$ the radius of the sphere.
@@ -536,12 +536,12 @@ def inside_sphere(xyz, center, radius):
     >>> sph_radius = 1
     >>> inside_sphere(line,sph_cent,sph_radius)
     True
-    '''
+    """
     return (np.sqrt(np.sum((xyz-center)**2, axis=1)) <= radius).any()
 
 
 def inside_sphere_points(xyz, center, radius):
-    ''' If a track intersects with a sphere of a specified center and
+    """ If a track intersects with a sphere of a specified center and
     radius return the points that are inside the sphere otherwise False.
     Mathematicaly this can be simply described by $|x-c| \le r$ where $x$
     a point $c$ the center of the sphere and $r$ the radius of the
@@ -569,12 +569,12 @@ def inside_sphere_points(xyz, center, radius):
     >>> sph_radius = 1
     >>> inside_sphere_points(line,sph_cent,sph_radius)
     array([[1, 1, 1]])
-    '''
+    """
     return xyz[(np.sqrt(np.sum((xyz-center)**2, axis=1)) <= radius)]
 
 
 def spline(xyz, s=3, k=2, nest=-1):
-    ''' Generate B-splines as documented in
+    """ Generate B-splines as documented in
     http://www.scipy.org/Cookbook/Interpolation
 
     The scipy.interpolate packages wraps the netlib FITPACK routines
@@ -636,7 +636,7 @@ def spline(xyz, s=3, k=2, nest=-1):
     ----------
     scipy.interpolate.splprep
     scipy.interpolate.splev
-    '''
+    """
     # find the knot points
     tckp, u = splprep([xyz[:, 0], xyz[:, 1], xyz[:, 2]], s=s, k=k, nest=nest)
     # evaluate spline, including interpolated points
@@ -645,7 +645,7 @@ def spline(xyz, s=3, k=2, nest=-1):
 
 
 def startpoint(xyz):
-    ''' First point of the track
+    """ First point of the track
 
     Parameters
     -------------
@@ -670,12 +670,12 @@ def startpoint(xyz):
     >>> sp.any()==xyz[0].any()
     True
 
-    '''
+    """
     return xyz[0]
 
 
 def endpoint(xyz):
-    '''
+    """
     Parameters
     ----------
     xyz : array, shape(N,3)
@@ -698,13 +698,13 @@ def endpoint(xyz):
     >>> ep=endpoint(xyz)
     >>> ep.any()==xyz[-1].any()
     True
-    '''
+    """
 
     return xyz[-1]
 
 
 def arbitrarypoint(xyz, distance):
-    ''' Select an arbitrary point along distance on the track (curve)
+    """ Select an arbitrary point along distance on the track (curve)
 
     Parameters
     ----------
@@ -731,7 +731,7 @@ def arbitrarypoint(xyz, distance):
     >>> z=0*x
     >>> xyz=np.vstack((x,y,z)).T
     >>> ap=arbitrarypoint(xyz,length(xyz)/3)
-    '''
+    """
     xyz = np.asarray(xyz)
     n_pts = xyz.shape[0]
     if n_pts == 0:
@@ -752,8 +752,8 @@ def arbitrarypoint(xyz, distance):
 
 
 def _extrap(xyz, cumlen, distance):
-    ''' Helper function for extrapolate
-    '''
+    """ Helper function for extrapolate
+    """
     ind = np.where((cumlen-distance) > 0)[0][0]
     len0 = cumlen[ind-1]
     len1 = cumlen[ind]
@@ -763,7 +763,7 @@ def _extrap(xyz, cumlen, distance):
 
 
 def downsample(xyz, n_pols=3):
-    ''' downsample for a specific number of points along the curve/track
+    """ downsample for a specific number of points along the curve/track
 
     Uses the length of the curve. It works in a similar fashion to
     midpoint and arbitrarypoint but it also reduces the number of segments
@@ -803,7 +803,7 @@ def downsample(xyz, n_pols=3):
     >>> xyz3=downsample(xyz,10)
     >>> len(xyz3)
     10
-    '''
+    """
     xyz = np.asarray(xyz)
     n_pts = xyz.shape[0]
     if n_pts == 0:
@@ -828,7 +828,7 @@ def downsample(xyz, n_pols=3):
 
 
 def principal_components(xyz):
-    ''' We use PCA to calculate the 3 principal directions for a track
+    """ We use PCA to calculate the 3 principal directions for a track
 
     Parameters
     ----------
@@ -854,14 +854,14 @@ def principal_components(xyz):
     >>> va, ve = principal_components(xyz)
     >>> np.allclose(va, [0.51010101, 0.09883545, 0])
     True
-    '''
+    """
     C = np.cov(xyz.T)
     va, ve = np.linalg.eig(C)
     return va, ve
 
 
 def midpoint2point(xyz, p):
-    ''' Calculate distance from midpoint of a curve to arbitrary point p
+    """ Calculate distance from midpoint of a curve to arbitrary point p
 
     Parameters
     -------------
@@ -887,7 +887,7 @@ def midpoint2point(xyz, p):
     >>> xyz=np.vstack((x,y,z)).T
     >>> dist=midpoint2point(xyz,np.array([0,0,0]))
 
-    '''
+    """
     mid = midpoint(xyz)
     return np.sqrt(np.sum((xyz-mid)**2))
 

--- a/dipy/tracking/propspeed.pyx
+++ b/dipy/tracking/propspeed.pyx
@@ -30,7 +30,7 @@ cdef cnp.npy_intp offset(cnp.npy_intp *indices,
                          cnp.npy_intp *strides,
                          int lenind,
                          int typesize) nogil:
-    ''' Access any element of any ndimensional numpy array using cython.
+    """ Access any element of any ndimensional numpy array using cython.
 
     Parameters
     ------------
@@ -45,7 +45,7 @@ cdef cnp.npy_intp offset(cnp.npy_intp *indices,
     ----------
     offset : integer
         Element position in array
-    '''
+    """
     cdef int i
     cdef cnp.npy_intp summ = 0
     for i from 0 <= i < lenind:
@@ -58,7 +58,7 @@ def ndarray_offset(cnp.ndarray[cnp.npy_intp, ndim=1] indices,
                    cnp.ndarray[cnp.npy_intp, ndim=1] strides,
                    int lenind,
                    int typesize):
-    ''' Find offset in an N-dimensional ndarray using strides
+    """ Find offset in an N-dimensional ndarray using strides
 
     Parameters
     ----------
@@ -87,7 +87,7 @@ def ndarray_offset(cnp.ndarray[cnp.npy_intp, ndim=1] indices,
     4
     >>> A.ravel()[4]==A[1,1]
     True
-    '''
+    """
     if not cnp.PyArray_CHKFLAGS(indices, cnp.NPY_C_CONTIGUOUS):
         raise ValueError(u"indices is not C contiguous")
     if not cnp.PyArray_CHKFLAGS(strides, cnp.NPY_C_CONTIGUOUS):
@@ -105,7 +105,7 @@ def map_coordinates_trilinear_iso(cnp.ndarray[double, ndim=3] data,
                                   cnp.ndarray[cnp.npy_intp, ndim=1] data_strides,
                                   cnp.npy_intp len_points,
                                   cnp.ndarray[double, ndim=1] result):
-    ''' Trilinear interpolation (isotropic voxel size)
+    """ Trilinear interpolation (isotropic voxel size)
 
     Has similar behavior to ``map_coordinates`` from ``scipy.ndimage``
 
@@ -129,7 +129,7 @@ def map_coordinates_trilinear_iso(cnp.ndarray[double, ndim=3] data,
     Notes
     -----
     The output array `result` is filled in-place.
-    '''
+    """
     cdef:
         double w[8], values[24]
         cnp.npy_intp index[24], off, i, j
@@ -163,13 +163,13 @@ def map_coordinates_trilinear_iso(cnp.ndarray[double, ndim=3] data,
 cdef void _trilinear_interpolation_iso(double *X,
                                        double *W,
                                        cnp.npy_intp *IN) nogil:
-    ''' Interpolate in 3d volumes given point X
+    """ Interpolate in 3d volumes given point X
 
     Returns
     -------
     W : weights
     IN : indices of the volume
-    '''
+    """
     cdef double Xf[3], d[3], nd[3]
     cdef cnp.npy_intp i
     # define the rectangular box where every corner is a neighboring voxel
@@ -212,7 +212,7 @@ cdef cnp.npy_intp _nearest_direction(double* dx,
                                      double *odf_vertices,
                                      double qa_thr, double ang_thr,
                                      double *direction) nogil:
-    ''' Give the nearest direction to a point, checking threshold and angle
+    """ Give the nearest direction to a point, checking threshold and angle
 
     Parameters
     ------------
@@ -238,7 +238,7 @@ cdef cnp.npy_intp _nearest_direction(double* dx,
     delta : bool
         Delta funtion: if 1 we give it weighting, if it is 0 we don't give any
         weighting.
-    '''
+    """
     cdef:
         double max_dot = 0
         double angl,curr_dot
@@ -364,8 +364,8 @@ cdef cnp.npy_intp _initial_direction(double* seed,double *qa,
                                      cnp.npy_intp* strides,
                                      cnp.npy_intp ref,
                                      double* direction) nogil:
-    ''' First direction that we get from a seeding point
-    '''
+    """ First direction that we get from a seeding point
+    """
     cdef:
         cnp.npy_intp point[4],off
         cnp.npy_intp i
@@ -400,7 +400,7 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
                          double step_sz,
                          double total_weight,
                          cnp.npy_intp max_points):
-    '''
+    """
     Parameters
     ------------
     seed : array, float64 shape (3,)
@@ -424,7 +424,7 @@ def eudx_both_directions(cnp.ndarray[double, ndim=1] seed,
     Returns
     -------
     track : array, shape (N,3)
-    '''
+    """
     cdef:
         double *ps = <double *> cnp.PyArray_DATA(seed)
         double *pqa = <double*> cnp.PyArray_DATA(qa)

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -55,7 +55,7 @@ cdef void c_arclengths_from_arraysequence(Streamline points,
 
 
 def length(streamlines):
-    ''' Euclidean length of streamlines
+    """ Euclidean length of streamlines
 
     Length is in mm only if streamlines are expressed in world coordinates.
 
@@ -94,7 +94,7 @@ def length(streamlines):
     >>> length(np.array([[1, 2, 3]]))
     0.0
 
-    '''
+    """
     if isinstance(streamlines, Streamlines):
         if len(streamlines) == 0:
             return 0.0
@@ -266,7 +266,7 @@ cdef void c_set_number_of_points_from_arraysequence(Streamline points,
 
 
 def set_number_of_points(streamlines, nb_points=3):
-    ''' Change the number of points of streamlines
+    """ Change the number of points of streamlines
         (either by downsampling or upsampling)
 
     Change the number of points of streamlines in order to obtain
@@ -315,7 +315,7 @@ def set_number_of_points(streamlines, nb_points=3):
     >>> [len(s) for s in new_streamlines]
     [10, 10]
 
-    '''
+    """
     if isinstance(streamlines, Streamlines):
         if len(streamlines) == 0:
             return Streamlines()

--- a/dipy/tracking/tests/test_learning.py
+++ b/dipy/tracking/tests/test_learning.py
@@ -1,4 +1,4 @@
-''' Testing track_metrics module '''
+""" Testing track_metrics module """
 
 import numpy as np
 from nose.tools import (assert_true, assert_false, assert_equal,

--- a/dipy/tracking/tests/test_metrics.py
+++ b/dipy/tracking/tests/test_metrics.py
@@ -1,4 +1,4 @@
-''' Testing track_metrics module '''
+""" Testing track_metrics module """
 from __future__ import division, print_function, absolute_import
 
 from dipy.utils.six.moves import xrange

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -324,7 +324,7 @@ cdef cnp.npy_intp _streamline_in_mask(
 @cython.wraparound(False)
 @cython.profile(False)
 def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
-    ''' Counts of points in `tracks` that pass through voxels in volume
+    """ Counts of points in `tracks` that pass through voxels in volume
 
     We find whether a point passed through a track by rounding the mm
     point values to voxels.  For a track that passes through a voxel more
@@ -390,7 +390,7 @@ def track_counts(tracks, vol_dims, vox_sizes=(1,1,1), return_elements=True):
     (5, 10, 15)
     >>> tcs[1,1,2], tcs[1,2,3]
     (1, 1)
-    '''
+    """
     vol_dims = np.asarray(vol_dims).astype(np.int)
     vox_sizes = np.asarray(vox_sizes).astype(np.double)
     n_voxels = np.prod(vol_dims)

--- a/dipy/utils/tripwire.py
+++ b/dipy/utils/tripwire.py
@@ -46,9 +46,9 @@ class TripWire(object):
         self._msg = msg
 
     def __getattr__(self, attr_name):
-        ''' Raise informative error accessing attributes '''
+        """ Raise informative error accessing attributes """
         raise TripWireError(self._msg)
 
     def __call__(self, *args, **kwargs):
-        ''' Raise informative error while calling '''
+        """ Raise informative error while calling """
         raise TripWireError(self._msg)

--- a/dipy/workflows/tests/test_docstring_parser.py
+++ b/dipy/workflows/tests/test_docstring_parser.py
@@ -43,7 +43,7 @@ else:
     def sixu(s): return unicode(s, 'unicode_escape')
 
 
-doc_txt = '''\
+doc_txt = """\
   numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
   Draw values from a multivariate normal distribution with specified
@@ -149,7 +149,7 @@ doc_txt = '''\
   .. index:: random
      :refguide: random;distributions, random;gauss
 
-  '''
+  """
 doc = NumpyDocString(doc_txt)
 
 doc_yields_txt = """

--- a/doc/examples/path_length_map.py
+++ b/doc/examples/path_length_map.py
@@ -140,10 +140,10 @@ ax = AxesGrid(fig, 111,
               cbar_size="10%",
               cbar_pad="5%")
 
-'''
+"""
 We will mask our WMPL to ignore values less than zero because negative numbers
 indicate no path back to the ROI was found in the provided streamlines
-'''
+"""
 
 wmpl_show = np.ma.masked_where(wmpl < 0, wmpl)
 

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -186,10 +186,10 @@ mapping = sdr.optimize(static, moving)
 
 warped = mapping.transform(moving)
 
-'''
+"""
 We can see the effect of the warping by switching between the images before and
 after registration
-'''
+"""
 
 regtools.overlay_images(static, moving, 'Static', 'Overlay', 'Moving',
                't1_slices_input.png')
@@ -211,9 +211,9 @@ regtools.overlay_images(static, warped, 'Static', 'Overlay', 'Warped moving',
    Moving image transformed under the (direct) transformation in green on top of the static image (in red).
 """
 
-'''
+"""
 And we can apply the inverse warping too
-'''
+"""
 
 inv_warped = mapping.transform_inverse(static)
 regtools.overlay_images(inv_warped, moving, 'Warped static', 'Overlay', 'moving',
@@ -226,9 +226,9 @@ regtools.overlay_images(inv_warped, moving, 'Warped static', 'Overlay', 'moving'
    Static image transformed under the (inverse) transformation in red on top of the moving image (in green).
 """
 
-'''
+"""
 Finally, let's see the deformation
-'''
+"""
 
 regtools.plot_2d_diffeomorphic_map(mapping, 5, 'diffeomorphic_map_b0s.png')
 

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -31,8 +31,8 @@ DEBUG = True
 
 
 class ApiDocWriter(object):
-    ''' Class for automatic detection and parsing of API docs
-    to Sphinx-parsable reST format'''
+    """ Class for automatic detection and parsing of API docs
+    to Sphinx-parsable reST format"""
 
     # only separating first two levels
     rst_section_levels = ['*', '=', '-', '~', '^']
@@ -44,7 +44,7 @@ class ApiDocWriter(object):
                  module_skip_patterns=None,
                  other_defines=True
                  ):
-        ''' Initialize package for parsing
+        """ Initialize package for parsing
 
         Parameters
         ----------
@@ -72,7 +72,7 @@ class ApiDocWriter(object):
         other_defines : {True, False}, optional
             Whether to include classes and functions that are imported in a
             particular module but not defined there.
-        '''
+        """
         if package_skip_patterns is None:
             package_skip_patterns = ['\\.tests$']
         if module_skip_patterns is None:
@@ -87,7 +87,7 @@ class ApiDocWriter(object):
         return self._package_name
 
     def set_package_name(self, package_name):
-        ''' Set package_name
+        """ Set package_name
 
         >>> docwriter = ApiDocWriter('sphinx')
         >>> import sphinx
@@ -97,7 +97,7 @@ class ApiDocWriter(object):
         >>> import docutils
         >>> docwriter.root_path == docutils.__path__[0]
         True
-        '''
+        """
         # It's also possible to imagine caching the module parsing here
         self._package_name = package_name
         root_module = self._import(package_name)
@@ -108,7 +108,7 @@ class ApiDocWriter(object):
                             'get/set package_name')
 
     def _import(self, name):
-        ''' Import namespace package '''
+        """ Import namespace package """
         mod = __import__(name)
         components = name.split('.')
         for comp in components[1:]:
@@ -116,7 +116,7 @@ class ApiDocWriter(object):
         return mod
 
     def _get_object_name(self, line):
-        ''' Get second token in line
+        """ Get second token in line
         >>> docwriter = ApiDocWriter('sphinx')
         >>> docwriter._get_object_name("  def func():  ")
         'func'
@@ -124,14 +124,14 @@ class ApiDocWriter(object):
         'Klass'
         >>> docwriter._get_object_name("  class Klass:  ")
         'Klass'
-        '''
+        """
         name = line.split()[1].split('(')[0].strip()
         # in case we have classes which are not derived from object
         # ie. old style classes
         return name.rstrip(':')
 
     def _uri2path(self, uri):
-        ''' Convert uri to absolute filepath
+        """ Convert uri to absolute filepath
 
         Parameters
         ----------
@@ -157,7 +157,7 @@ class ApiDocWriter(object):
         True
         >>> docwriter._uri2path('sphinx.does_not_exist')
 
-        '''
+        """
         if uri == self.package_name:
             return os.path.join(self.root_path, '__init__.py')
         path = uri.replace(self.package_name + '.', '')
@@ -173,7 +173,7 @@ class ApiDocWriter(object):
         return path
 
     def _path2uri(self, dirpath):
-        ''' Convert directory path to uri '''
+        """ Convert directory path to uri """
         package_dir = self.package_name.replace('.', os.path.sep)
         relpath = dirpath.replace(self.root_path, package_dir)
         if relpath.startswith(os.path.sep):
@@ -181,7 +181,7 @@ class ApiDocWriter(object):
         return relpath.replace(os.path.sep, '.')
 
     def _parse_module(self, uri):
-        ''' Parse module defined in *uri* '''
+        """ Parse module defined in *uri* """
         filename = self._uri2path(uri)
         if filename is None:
             print(filename, 'erk')
@@ -237,7 +237,7 @@ class ApiDocWriter(object):
         return functions, classes
 
     def _parse_lines(self, linesource):
-        ''' Parse lines of text for functions and classes '''
+        """ Parse lines of text for functions and classes """
         functions = []
         classes = []
         for line in linesource:
@@ -258,7 +258,7 @@ class ApiDocWriter(object):
         return functions, classes
 
     def generate_api_doc(self, uri):
-        '''Make autodoc documentation template string for a module
+        """Make autodoc documentation template string for a module
 
         Parameters
         ----------
@@ -271,7 +271,7 @@ class ApiDocWriter(object):
             Module name, table of contents.
         body : string
             Function and class docstrings.
-        '''
+        """
         # get the names of all classes and functions
         functions, classes = self._parse_module_with_import(uri)
         if not len(functions) and not len(classes) and DEBUG:
@@ -321,7 +321,7 @@ class ApiDocWriter(object):
         return head, body
 
     def _survives_exclude(self, matchstr, match_type):
-        ''' Returns True if *matchstr* does not match patterns
+        """ Returns True if *matchstr* does not match patterns
 
         ``self.package_name`` removed from front of string if present
 
@@ -340,7 +340,7 @@ class ApiDocWriter(object):
         >>> dw.module_skip_patterns.append('^\\.badmod$')
         >>> dw._survives_exclude('sphinx.badmod', 'module')
         False
-        '''
+        """
         if match_type == 'module':
             patterns = self.module_skip_patterns
         elif match_type == 'package':
@@ -363,7 +363,7 @@ class ApiDocWriter(object):
         return True
 
     def discover_modules(self):
-        ''' Return module sequence discovered from ``self.package_name``
+        """ Return module sequence discovered from ``self.package_name``
 
 
         Parameters
@@ -385,7 +385,7 @@ class ApiDocWriter(object):
         >>> 'sphinx.util' in dw.discover_modules()
         False
         >>>
-        '''
+        """
         modules = [self.package_name]
         # raw directory parsing
         for dirpath, dirnames, filenames in os.walk(self.root_path):

--- a/scratch/learning_old.py
+++ b/scratch/learning_old.py
@@ -1,4 +1,4 @@
-''' Learning algorithms for tractography'''
+""" Learning algorithms for tractography"""
 
 import numpy as np
 from dipy.core import track_metrics as tm
@@ -14,7 +14,7 @@ def larch(tracks,
           split_thrs=[50.**2,20.**2,10.**2],
           ret_atracks=False,
           info=False):
-    ''' LocAl Rapid Clusters for tractograpHy
+    """ LocAl Rapid Clusters for tractograpHy
 
     Parameters
     ----------
@@ -33,10 +33,10 @@ def larch(tracks,
        a tree graph containing the clusters
     atracks : sequence
        of approximated tracks the approximation preserves initial shape.
-    '''
+    """
 
 
-    '''
+    """
     t1=time.clock()    
     print 'Reducing to 3-point approximate tracks...'
     tracks3=[tm.downsample(t,3) for t in tracks]
@@ -74,13 +74,13 @@ def larch(tracks,
     else:
         return C
     
-    '''
+    """
 
     return
 
 
 def detect_corresponding_tracks(indices,tracks1,tracks2):
-    ''' Detect corresponding tracks from 1 to 2
+    """ Detect corresponding tracks from 1 to 2
     
     Parameters
     ----------
@@ -95,7 +95,7 @@ def detect_corresponding_tracks(indices,tracks1,tracks2):
     -------
     track2track : array
        of int showing the correspondance
-    '''
+    """
     li=len(indices)
     
     track2track=np.zeros((li,3))
@@ -111,7 +111,7 @@ def detect_corresponding_tracks(indices,tracks1,tracks2):
     return track2track.astype(int)
 
 def detect_corresponding_tracks_extended(indices,tracks1,indices2,tracks2):
-    ''' Detect corresponding tracks from 1 to 2
+    """ Detect corresponding tracks from 1 to 2
     
     Parameters:
     ----------------
@@ -132,7 +132,7 @@ def detect_corresponding_tracks_extended(indices,tracks1,indices2,tracks2):
     track2track: array of int
             showing the correspondance
     
-    '''
+    """
     li=len(indices)
     
     track2track=np.zeros((li,3))
@@ -149,7 +149,7 @@ def detect_corresponding_tracks_extended(indices,tracks1,indices2,tracks2):
 
 
 def rm_far_ends(ref,tracks,dist=25):
-    ''' rm tracks with far endpoints
+    """ rm tracks with far endpoints
     
     Parameters
     ----------
@@ -166,7 +166,7 @@ def rm_far_ends(ref,tracks,dist=25):
        reduced tracks
     indices : sequence
        indices of tracks
-    '''
+    """
     indices=[i for (i,t) in enumerate(tracks) if tm.max_end_distances(t,ref) <= dist]
     
     tracksr=[tracks[i] for i in indices]
@@ -175,7 +175,7 @@ def rm_far_ends(ref,tracks,dist=25):
  
 
 def rm_far_tracks(ref,tracks,dist=25,down=False):
-    ''' Remove tracks which are far away using as a distance metric the average euclidean distance of the 
+    """ Remove tracks which are far away using as a distance metric the average euclidean distance of the
     following three points start point, midpoint and end point.
 
     Parameters
@@ -196,7 +196,7 @@ def rm_far_tracks(ref,tracks,dist=25,down=False):
             reduced tracks
     indices : sequence
             indices of tracks
-    '''
+    """
 
     if down==False:
         
@@ -216,7 +216,7 @@ def rm_far_tracks(ref,tracks,dist=25,down=False):
  
 
 def missing_tracks(indices1,indices2):
-    ''' Missing tracks in bundle1 but not bundle2
+    """ Missing tracks in bundle1 but not bundle2
     
     Parameters:
     ------------------
@@ -241,12 +241,12 @@ def missing_tracks(indices1,indices2):
     >>> fornix_ind=G[5]['indices']
     >>> len(missing_tracks(fornix_ind, indar)) = 0
     
-    '''
+    """
     
     return list(set(indices1).difference(set(indices2)))    
 
 def skeletal_tracks(tracks,rand_selected=1000,ball_radius=5,neighb_no=50):
-    ''' Filter out unnescessary tracks and keep only a few good ones.  
+    """ Filter out unnescessary tracks and keep only a few good ones.
     Aka the balls along a track method.  
     
     Parameters:
@@ -266,7 +266,7 @@ def skeletal_tracks(tracks,rand_selected=1000,ball_radius=5,neighb_no=50):
             of indices of representative aka skeletal tracks. They should be <= rand_selected
     
     
-    '''
+    """
     trackno=len(tracks)
     #select 1000 random tracks
     random_indices=(trackno*np.random.rand(rand_selected)).astype(int)
@@ -324,7 +324,7 @@ def skeletal_tracks(tracks,rand_selected=1000,ball_radius=5,neighb_no=50):
     return representative
 
 def detect_corpus_callosum(tracks,plane=91,ysize=217,zsize=181,width=1.0,use_atlas=0,use_preselected_tracks=0,ball_radius=5):
-    ''' Detect corpus callosum in a mni registered dataset of shape (181,217,181)   
+    """ Detect corpus callosum in a mni registered dataset of shape (181,217,181)
     
     Parameters:
     ----------------
@@ -339,7 +339,7 @@ def detect_corpus_callosum(tracks,plane=91,ysize=217,zsize=181,width=1.0,use_atl
     left_indices: sequence
             with the indices of the rest of the brain
        
-    '''
+    """
 
     cc=[]
 
@@ -419,7 +419,7 @@ def detect_corpus_callosum(tracks,plane=91,ysize=217,zsize=181,width=1.0,use_atl
     imgl=imgl[0]
     
     #find the biggest objects the second biggest should be the cc the biggest should be the background
-    '''
+    """
     find_big=np.zeros(no_labels)
     
     for i in range(no_labels):
@@ -430,7 +430,7 @@ def detect_corpus_callosum(tracks,plane=91,ysize=217,zsize=181,width=1.0,use_atl
     print find_big
     
     find_bigi=np.argsort(find_big)
-    '''
+    """
     cc_label=imgl[p1max,p2max]
     
     imgl2=np.zeros((ysize,zsize))
@@ -548,7 +548,7 @@ def relabel_by_atlas_value_and_mam(atlas_tracks,atlas,tes,tracks,tracksd,zhang_t
 
 
 def threshold_hitdata(hitdata, divergence_threshold=0.25, fibre_weight=0.8):
-    ''' [1] Removes hits in hitdata which have divergence above threshold.
+    """ [1] Removes hits in hitdata which have divergence above threshold.
        [2] Removes fibres in hitdata whose fraction of remaining hits is below
         the required weight.
 
@@ -568,7 +568,7 @@ def threshold_hitdata(hitdata, divergence_threshold=0.25, fibre_weight=0.8):
     -----------    
     reduced_hitdata: array, shape (M, 5)
     light_weight_fibres: list of integer track indices
-    '''
+    """
     # first pass: remove hits with r>divergence_threshold
     firstpass = [[[x,y,z,r,f] for (x,y,z,r,f) in plane  if r<=divergence_threshold] for plane in hitdata]
 
@@ -591,9 +591,9 @@ def threshold_hitdata(hitdata, divergence_threshold=0.25, fibre_weight=0.8):
     return reduced_hitdata, heavy_weight_fibres
 
 def neck_finder(hitdata, ref):
-    '''
+    """
     To identify regions of concentration of fibres related by hitdata to a reference fibre
-    '''
+    """
     
     #typically len(hitdata) = len(ref)-2 at present, though it should ideally be
     # len(ref)-1 which is the number of segments in ref
@@ -630,9 +630,9 @@ def neck_finder(hitdata, ref):
         np.array(unweighted_mean_dist), np.array(weighted_mean_dist)
 
 def max_concentration(plane_hits,ref):
-    '''
+    """
     calculates the log determinant of the concentration matrix for the hits in planehits    
-    '''
+    """
     dispersions = [np.prod(np.sort(npla.eigvals(np.cov(p[:,0:3].T)))[1:2]) for p in plane_hits]
     index = np.argmin(dispersions)
     log_max_concentration = -np.log2(dispersions[index])
@@ -640,11 +640,11 @@ def max_concentration(plane_hits,ref):
     return index, centre, log_max_concentration
 
 def refconc(brain, ref, divergence_threshold=0.3, fibre_weight=0.7):
-    '''
+    """
     given a reference fibre locates the parallel fibres in brain (tracks)
     with threshold_hitdata applied to cut_planes output then follows
     with concentration to locate the locus of a neck
-    '''
+    """
     
     hitdata = pf.cut_plane(brain, ref)
     reduced_hitdata, heavy_weight_fibres = threshold_hitdata(hitdata, divergence_threshold, fibre_weight)
@@ -656,8 +656,8 @@ def refconc(brain, ref, divergence_threshold=0.3, fibre_weight=0.7):
     return heavy_weight_fibres, index, centre
 
 def bundle_from_refs(brain,braind, refs, divergence_threshold=0.3, fibre_weight=0.7,far_thresh=25,zhang_thresh=15, end_thresh=10):
-    '''
-    '''
+    """
+    """
     bundle = set([])
     # centres = []
     # indices = []
@@ -693,7 +693,7 @@ def bundle_from_refs(brain,braind, refs, divergence_threshold=0.3, fibre_weight=
 
 
 class FACT_Delta():
-    ''' Generates tracks with termination criteria defined by a
+    """ Generates tracks with termination criteria defined by a
     delta function [1]_ and it has similarities with FACT algorithm [2]_.
 
     Can be used with any reconstruction method as DTI,DSI,QBI,GQI which can
@@ -720,10 +720,10 @@ class FACT_Delta():
     in the brain by magnetic resonance imaging. Ann. Neurol. 1999.
     
 
-    '''
+    """
 
     def __init__(self,qa,ind,seeds_no=1000,odf_vertices=None,qa_thr=0.0239,step_sz=0.5,ang_thr=60.):
-        '''
+        """
         Parameters
         ----------
 
@@ -749,7 +749,7 @@ class FACT_Delta():
 
         tracks: sequence of arrays
 
-        '''
+        """
 
         if len(qa.shape)==3:
             qa.shape=qa.shape+(1,)
@@ -788,7 +788,7 @@ class FACT_Delta():
 
 
     def trilinear_interpolation(self,X):
-        '''
+        """
         Parameters
         ----------
         X: array, shape(3,), a point
@@ -800,7 +800,7 @@ class FACT_Delta():
 
         IN: array, shape(8,2), the corners of the unit cube
 
-        '''
+        """
 
         Xf=np.floor(X)        
         #d holds the distance from the (floor) corner of the voxel
@@ -829,7 +829,7 @@ class FACT_Delta():
         return W,IN.astype(np.int)
 
     def nearest_direction(self,dx,qa,ind,odf_vertices,qa_thr=0.0245,ang_thr=60.):
-        ''' Give the nearest direction to a point
+        """ Give the nearest direction to a point
 
         Parameters
         ----------        
@@ -857,7 +857,7 @@ class FACT_Delta():
         direction: array, shape(3,), the fiber orientation to be
         consider in the interpolation
 
-        '''
+        """
 
         max_dot=0
         max_doti=0
@@ -884,8 +884,8 @@ class FACT_Delta():
 
         
     def propagation_direction(self,point,dx,qa,ind,odf_vertices,qa_thr,ang_thr):
-        ''' Find where you are moving next
-        '''
+        """ Find where you are moving next
+        """
         total_w = 0 # total weighting
         new_direction = np.array([0,0,0])
         w,index=self.trilinear_interpolation(point)
@@ -912,9 +912,9 @@ class FACT_Delta():
         return True, new_direction/np.sqrt(np.sum(new_direction**2))
     
     def initial_direction(self,seed,qa,ind,odf_vertices,qa_thr):
-        ''' First direction that we get from a seeding point
+        """ First direction that we get from a seeding point
 
-        '''
+        """
         #very tricky/cool addition/flooring that helps create a valid
         #neighborhood (grid) for the trilinear interpolation to run smoothly
         #seed+=0.5
@@ -930,7 +930,7 @@ class FACT_Delta():
 
 
     def propagation(self,seed,qa,ind,odf_vertices,qa_thr,ang_thr,step_sz):
-        '''
+        """
         Parameters
         ----------
         seed: array, shape(3,), point where the tracking starts        
@@ -943,7 +943,7 @@ class FACT_Delta():
         d: bool, delta function result        
         idirection: array, shape(3,), index of the direction of the propagation
 
-        '''
+        """
         point_bak=seed.copy()
         point=seed.copy()
         #d is the delta function 

--- a/scratch/learning_old.py
+++ b/scratch/learning_old.py
@@ -35,7 +35,6 @@ def larch(tracks,
        of approximated tracks the approximation preserves initial shape.
     """
 
-
     """
     t1=time.clock()    
     print 'Reducing to 3-point approximate tracks...'
@@ -175,8 +174,9 @@ def rm_far_ends(ref,tracks,dist=25):
  
 
 def rm_far_tracks(ref,tracks,dist=25,down=False):
-    """ Remove tracks which are far away using as a distance metric the average euclidean distance of the
-    following three points start point, midpoint and end point.
+    """ Remove tracks which are far away using as a distance metric the average
+    euclidean distance of the following three points start point, midpoint and
+    end point.
 
     Parameters
     ----------
@@ -324,7 +324,8 @@ def skeletal_tracks(tracks,rand_selected=1000,ball_radius=5,neighb_no=50):
     return representative
 
 def detect_corpus_callosum(tracks,plane=91,ysize=217,zsize=181,width=1.0,use_atlas=0,use_preselected_tracks=0,ball_radius=5):
-    """ Detect corpus callosum in a mni registered dataset of shape (181,217,181)
+    """ Detect corpus callosum in a mni registered dataset of shape
+    (181,217,181)
     
     Parameters:
     ----------------

--- a/scratch/very_scratch/bingham.py
+++ b/scratch/very_scratch/bingham.py
@@ -4,7 +4,7 @@ from scipy.optimize import fmin_powell
 import numpy as np
 import scipy as sc
 
-'''
+"""
 def integrand(t,n,x):
     return np.exp(-x*t) / t**n
 
@@ -15,30 +15,30 @@ vec_expint = np.vectorize(expint)
 
 print vec_expint(3,np.arange(1.0,4.0,0.5))
 
-'''
+"""
 #array([ 0.1097,  0.0567,  0.0301,  0.0163,  0.0089,  0.0049])
-'''
+"""
 
 print sc.special.expn(3,np.arange(1.0,4.0,0.5))
 
-'''
+"""
 #array([ 0.1097,  0.0567,  0.0301,  0.0163,  0.0089,  0.0049])
-'''
+"""
 
 result = quad(lambda x: expint(3, x), 0, np.inf)
 
 print result
 
-'''
+"""
 #(0.33333333324560266, 2.8548934485373678e-09)
-'''
+"""
 
 I3 = 1.0/3.0
 
 print I3
 
 #0.333333333333
-'''
+"""
 
 def bingham_kernel(k1,k2,theta,phi):
     return np.exp(((k1*np.cos(phi)**2+k2*np.sin(phi)**2)*np.sin(theta)**2)/4*np.pi)
@@ -68,7 +68,7 @@ print min
 
 
 
-'''
+"""
 def I(n):
     return dblquad(lambda t, x: np.exp(-x*t)/t**n, 0, np.Inf, lambda x: 1, lambda x: np.Inf)
 
@@ -91,9 +91,9 @@ d = sympy.integrate(sympy.exp((k1*sympy.cos(phi)**2+k2*sympy.sin(phi)**2)*sympy.
 from scipy.integrate import quad
 from math import pi
 d = sympy.integrate(sympy.exp((k1*sympy.cos(phi)**2+k2*sympy.sin(phi)**2)*sympy.sin(theta)**2)/(4*sympy.pi),(phi,0,2*sympy.pi),(theta,0,sympy.pi))
-'''
+"""
 
-'''
+"""
 Table C.3: 	Maximum likelihood estimators of k1,k2 in the Bingham
 distribution for given eigenvalues w1,w2. Data from Mardia and Zemroch
 (1977). Upper (lower) number is k1(k2)
@@ -150,4 +150,4 @@ w2
 
 Taken from http://magician.ucsd.edu/Essentials/WebBookse115.html#x136-237000C.2a
         
-'''
+"""

--- a/scratch/very_scratch/bingham.py
+++ b/scratch/very_scratch/bingham.py
@@ -66,8 +66,6 @@ print min
 
 #d = sympy.integrate(sympy.exp((k1*sympy.cos(phi)**2+k2*sympy.sin(phi)**2)*sympy.sin(theta)**2)/(4*sympy.pi),(phi,0,2*sympy.pi),(theta,0,sympy.pi))
 
-
-
 """
 def I(n):
     return dblquad(lambda t, x: np.exp(-x*t)/t**n, 0, np.Inf, lambda x: 1, lambda x: np.Inf)

--- a/scratch/very_scratch/check_flipping.py
+++ b/scratch/very_scratch/check_flipping.py
@@ -35,7 +35,7 @@ for c in C:
     
 fos.show(r)
 
-'''
+"""
 
 print len(C)
 
@@ -52,7 +52,7 @@ for c in C:
 for c in C:    
     fos.add(r,fos.line(C[c]['rep3']/C[c]['N']+np.array([14.,0.,0.]),fos.white))
 fos.show(r)
-'''
+"""
 
 
 

--- a/scratch/very_scratch/dcm2S0asnii.py
+++ b/scratch/very_scratch/dcm2S0asnii.py
@@ -34,8 +34,6 @@ print data.shape
 
 #S0 = data[:,:,:,0]
 
-
-
 """
 
 #save the structural volume

--- a/scratch/very_scratch/dcm2S0asnii.py
+++ b/scratch/very_scratch/dcm2S0asnii.py
@@ -36,7 +36,7 @@ print data.shape
 
 
 
-'''
+"""
 
 #save the structural volume
 
@@ -63,4 +63,4 @@ np.save(smallname_grad,gradients)
 
 np.save(smallname_bvals,bvals)
 
-'''
+"""

--- a/scratch/very_scratch/diffusion_sphere_stats.py
+++ b/scratch/very_scratch/diffusion_sphere_stats.py
@@ -122,7 +122,6 @@ def gq_tn_calc_save():
         tnfile = simdir+'tn/'+dataname+'.pkl'
         pkl.save_pickle(tnfile,tn)
 
-
         """
         tn.ADC               tn.__init__          tn._getevals
         tn.B                 tn.__module__        tn._getevecs

--- a/scratch/very_scratch/diffusion_sphere_stats.py
+++ b/scratch/very_scratch/diffusion_sphere_stats.py
@@ -16,7 +16,7 @@ import dipy.core.geometry as geometry
 import get_vertices as gv
 
 #old SimData files
-'''
+"""
 results_SNR030_1fibre
 results_SNR030_1fibre+iso
 results_SNR030_2fibres_15deg
@@ -28,16 +28,16 @@ results_SNR030_2fibres+iso_30deg
 results_SNR030_2fibres+iso_60deg
 results_SNR030_2fibres+iso_90deg
 results_SNR030_isotropic
-'''
+"""
 #fname='/home/ian/Data/SimData/results_SNR030_1fibre'
-''' file  has one row for every voxel, every voxel is repeating 1000
+""" file  has one row for every voxel, every voxel is repeating 1000
 times with the same noise level , then we have 100 different
 directions. 1000 * 100 is the number of all rows.
 
 The 100 conditions are given by 10 polar angles (in degrees) 0, 20, 40, 60, 80,
 80, 60, 40, 20 and 0, and each of these with longitude angle 0, 40, 80,
 120, 160, 200, 240, 280, 320, 360. 
-'''
+"""
 
 #new complete SimVoxels files
 simdata = ['fibres_2_SNR_80_angle_90_l1_1.4_l2_0.35_l3_0.35_iso_0_diso_00',
@@ -112,18 +112,18 @@ def gq_tn_calc_save():
         gqfile = simdir+'gq/'+dataname+'.pkl'
         pkl.save_pickle(gqfile,gq)
 
-        '''
+        """
         gq.IN               gq.__doc__          gq.glob_norm_param
         gq.QA               gq.__init__         gq.odf              
         gq.__class__        gq.__module__       gq.q2odf_params
-        '''
+        """
 
         tn = ddti.Tensor(sim_data,bvals,gradients)
         tnfile = simdir+'tn/'+dataname+'.pkl'
         pkl.save_pickle(tnfile,tn)
 
 
-        '''
+        """
         tn.ADC               tn.__init__          tn._getevals
         tn.B                 tn.__module__        tn._getevecs
         tn.D                 tn.__new__           tn._getndim
@@ -138,9 +138,9 @@ def gq_tn_calc_save():
         tn.__getattribute__  tn._evals            tn.ndim
         tn.__getitem__       tn._evecs            tn.shape
         tn.__hash__          tn._getD             
-        '''
+        """
 
-        ''' file  has one row for every voxel, every voxel is repeating 1000
+        """ file  has one row for every voxel, every voxel is repeating 1000
         times with the same noise level , then we have 100 different
         directions. 100 * 1000 is the number of all rows.
 
@@ -149,12 +149,12 @@ def gq_tn_calc_save():
         are the antipodal partners of directions 0 to 180. So when counting the
         number of different vertices that occur as maximal directions we wll map
         the indices modulo 181.
-        '''
+        """
 
 def analyze_maxima(indices, max_dirs, subsets):
-    '''This calculates the eigenstats for each of the replicated batches
+    """This calculates the eigenstats for each of the replicated batches
     of the simulation data
-    '''
+    """
 
     results = []
 
@@ -259,13 +259,13 @@ def run_gq_sims(sample_data=[35,23,46,39,40,10,37,27,21,20]):
             
             print >> out, dataname, j, npa, tn.fa()[0]
             
-            '''
+            """
             for (i,o) in enumerate(gqs.odf(s)):
                 print i,o
             
             for (i,o) in enumerate(gqs.odf_vertices):
                 print i,o
-            '''
+            """
         
     out.close()
 
@@ -289,11 +289,11 @@ def run_small_data():
     evals=tnsmall.evals
     evals = evals.reshape(xyz,3)
         
-    '''
+    """
     eds=np.load(opj(os.path.dirname(__file__),\
                         '..','matrices',\
                         'evenly_distributed_sphere_362.npz'))
-    '''
+    """
     from dipy.data import get_sphere
 
     odf_vertices,odf_faces=get_sphere('symmetric362')
@@ -355,11 +355,11 @@ def run_small_data():
         summary[istr]['n_peaks'] = n_peaks
         summary[istr]['peak_heights'] = peak_heights
         summary[istr]['fa'] = FA[i]
-    '''
+    """
     QA/=fwd
     QA=QA.reshape(x,y,z,5)    
     IN=IN.reshape(x,y,z,5)
-    '''
+    """
     
     peaks_1 = [i for i in range(1000) if summary[str(i)]['n_peaks']==1]
     peaks_2 = [i for i in range(1000) if summary[str(i)]['n_peaks']==2]
@@ -370,7 +370,7 @@ def run_small_data():
     return FA, summary
 
 def Q2odf(s,q2odf_params):
-    ''' construct odf for a voxel '''
+    """ construct odf for a voxel """
     odf=np.dot(s,q2odf_params)
     return odf
 

--- a/scratch/very_scratch/eddy_currents.py
+++ b/scratch/very_scratch/eddy_currents.py
@@ -8,7 +8,7 @@ dname = '/home/eg01/Data_Backup/Data/Eleftherios/CBU090133_METHODS/20090227_1454
 
 data,affine,bvals,gradients=dp.load_dcm_dir(dname)
 
-'''
+"""
 rot=np.array([[1,0,0,0],
               [0,np.cos(np.pi/2),-np.sin(np.pi/2),0],
               [0,np.sin(np.pi/2), np.cos(np.pi/2),0],
@@ -17,7 +17,7 @@ rot=np.array([[1,0,0,0],
 from scipy.ndimage import affine_transform as aff
 
 naffine=np.dot(affine,rot)
-'''
+"""
 
 data[:,:,:,1]
 

--- a/scratch/very_scratch/gqsampling_stats.py
+++ b/scratch/very_scratch/gqsampling_stats.py
@@ -94,7 +94,7 @@ def test_gqiodf():
     summary['faces'] = odf_faces
     f = odf_faces.shape[0]
 
-    '''
+    """
     If e = number_of_edges
     the Euler formula says f-e+v = 2 for a mesh on a sphere
     Here, assuming we have a healthy triangulation
@@ -102,7 +102,7 @@ def test_gqiodf():
     exactly two faces = so 2*e = 3*f
     to avoid division we test whether 2*f - 3*f + 2*v == 4
     or equivalently 2*v - f == 4
-    '''
+    """
 
     assert_equal(2*v-f, 4,'Direct Euler test fails')
     assert_true(meshes.euler_characteristic_check(odf_vertices, odf_faces,chi=2),'euler_characteristic_check fails')
@@ -181,11 +181,11 @@ def test_gqiodf():
 
     width = 0.02#0.3 #0.05
     
-    '''
+    """
     print 'pole_1 equator contains:', len([i for i,v in enumerate(vertices) if np.abs(np.dot(v,pole_1)) < width])
     print 'pole_2 equator contains:', len([i for i,v in enumerate(vertices) if np.abs(np.dot(v,pole_2)) < width])
     print 'pole_3 equator contains:', len([i for i,v in enumerate(vertices) if np.abs(np.dot(v,pole_3)) < width])
-    '''
+    """
     
     #print 'pole_1 equator contains:', len(meshes.equatorial_vertices(vertices,pole_1,width))
     #print 'pole_2 equator contains:', len(meshes.equatorial_vertices(vertices,pole_2,width))
@@ -195,7 +195,7 @@ def test_gqiodf():
     #print triple_odf_maxima(vertices,summary['10']['odf'],width)
     #print triple_odf_maxima(vertices,summary['44']['odf'],width)
     #print summary['0']['evals']
-    '''
+    """
 
     pole=np.array([0,0,1])
 
@@ -207,7 +207,7 @@ def test_gqiodf():
             fos.add(r,fos.point(ev,fos.red))
     fos.show(r)
 
-    '''
+    """
 
     triple = triple_odf_maxima(vertices, summary['10']['odf'], width)
     
@@ -215,7 +215,7 @@ def test_gqiodf():
     indmax2, odfmax2 = triple[1]
     indmax3, odfmax3 = triple[2] 
 
-    '''
+    """
     from dipy.viz import fos
     r=fos.ren()
     for v in vertices:
@@ -229,7 +229,7 @@ def test_gqiodf():
     fos.add(r,fos.sphere(upper_hemi_map(summary['0']['evecs'][:,2]),radius=0.025,color=fos.blue,opacity=0.7))
     fos.add(r,fos.sphere([0,0,0],radius=0.01,color=fos.white))
     fos.show(r)
-    '''
+    """
     
     mat = np.vstack([vertices[indmax1],vertices[indmax2],vertices[indmax3]])
 
@@ -240,18 +240,18 @@ def test_gqiodf():
     #return summary
 
 def upper_hemi_map(v):
-    '''
+    """
     maps a 3-vector into the z-upper hemisphere
-    '''
+    """
     return np.sign(v[2])*v
 
 def equatorial_maximum(vertices, odf, pole, width):
 
     eqvert = meshes.equatorial_zone_vertices(vertices, pole, width)
 
-    '''
+    """
     need to test for whether eqvert is empty or not
-    '''
+    """
     if len(eqvert) == 0:
 
         print 'empty equatorial band at pole', pole, 'with width', width
@@ -269,9 +269,9 @@ def equatorial_maximum(vertices, odf, pole, width):
     return eqvertmax, eqvalmax
 
 def patch_vertices(vertices,pole, width):
-    '''
+    """
     find 'vertices' within the cone of 'width' around 'pole'
-    '''
+    """
     
     return [i for i,v in enumerate(vertices) if np.dot(v,pole) > 1- width]
 
@@ -280,9 +280,9 @@ def patch_maximum(vertices, odf, pole, width):
 
     eqvert = patch_vertices(vertices, pole, width)
 
-    '''
+    """
     need to test for whether eqvert is empty or not
-    '''
+    """
     if len(eqvert) == 0:
 
         print 'empty cone around pole', pole, 'with width', width

--- a/scratch/very_scratch/joint_hist.py
+++ b/scratch/very_scratch/joint_hist.py
@@ -10,7 +10,8 @@ from dipy.core import geometry as gm
 import pylab
 
 def affine_transform2d(I,M):
-    """ Inspired by the work of Alexis Roche and the independent work of D. Kroon
+    """ Inspired by the work of Alexis Roche and the independent work of
+    D. Kroon
 
     Parameters
     ----------

--- a/scratch/very_scratch/joint_hist.py
+++ b/scratch/very_scratch/joint_hist.py
@@ -10,7 +10,7 @@ from dipy.core import geometry as gm
 import pylab
 
 def affine_transform2d(I,M):
-    ''' Inspired by the work of Alexis Roche and the independent work of D. Kroon
+    """ Inspired by the work of Alexis Roche and the independent work of D. Kroon
 
     Parameters
     ----------
@@ -23,7 +23,7 @@ def affine_transform2d(I,M):
     -------
     Iout: array, shape(N,M), transformed image
       
-    '''
+    """
     #the transpose is for contiguous C arrays (default)
     #I=I.T
     
@@ -91,7 +91,7 @@ def affine_transform2d(I,M):
 
 
 def joint_histogram(A,B,binA,binB):
-    ''' Calculate joint histogram and individual histograms for A and B
+    """ Calculate joint histogram and individual histograms for A and B
     ndarrays
 
     Parameters
@@ -113,7 +113,7 @@ def joint_histogram(A,B,binA,binB):
     >>> bin_B=np.array([-np.Inf,.1,.35,.75,np.Inf])
     >>> JH,HA,HB=joint_histogram(A,B,bin_A,bin_B)
     
-    '''    
+    """
 
     A=A.ravel()
     B=B.ravel()
@@ -143,8 +143,8 @@ def joint_histogram(A,B,binA,binB):
 
 
 def mutual_information(A,B,binA,binB):
-    ''' Calculate mutual information for A and B
-    '''
+    """ Calculate mutual information for A and B
+    """
     JH,HA,HB=joint_histogram(A,B,binA,binB)
     N=float(len(A.ravel()))    
     MI=np.zeros(JH.shape)
@@ -161,8 +161,8 @@ def mutual_information(A,B,binA,binB):
 
     
 def apply_mapping(A,T,order=0,map_type='affine2d'):
-    ''' Apply mapping
-    '''
+    """ Apply mapping
+    """
     
     if map_type=='affine2d':
 
@@ -225,8 +225,8 @@ def apply_mapping(A,T,order=0,map_type='affine2d'):
 
 
 def objective_mi(T,A,B,binA,binB,order=0,map_type='affine2d'):
-    ''' Objective function for mutual information
-    '''
+    """ Objective function for mutual information
+    """
     AT=apply_mapping(A,T,order=0,map_type=map_type)
     #AT=np.round(AT)
 
@@ -269,10 +269,10 @@ def objective_sd(T,A,B,order=0,map_type='affine2d'):
 
 
 def register(A,B,guess,metric='sd',binA=None,binB=None,xtol=0.1,ftol=0.01,order=0,map_type='affine2d'):
-    ''' Register source A to target B using modified powell's method
+    """ Register source A to target B using modified powell's method
 
     Powell's method tries to minimize the objective function
-    '''
+    """
     if metric=='mi':
         finalT=fmin_powell(objective_mi,x0=guess,args=(A,B,binA,binB,order,map_type),xtol=xtol,ftol=ftol)
         #finalT=leastsq(func=objective_mi,x0=np.array(guess),args=(A,B,binA,binB,order,map_type))
@@ -297,7 +297,7 @@ def evaluate(A,B,guess,metric='sd',binA=None,binB=None,xtol=0.1,ftol=0.01,order=
 
     T_final=[]
 
-    '''
+    """
     for c1 in tc1:
         for c2 in tc2:
             for s1 in sc1:
@@ -308,7 +308,7 @@ def evaluate(A,B,guess,metric='sd',binA=None,binB=None,xtol=0.1,ftol=0.01,order=
                         if f<f_min:
                             f_min=f
                             T_final=T
-    '''
+    """
 
     for c1 in tc1:
         for c2 in tc2:

--- a/scratch/very_scratch/pbc_training_set_clustering.py
+++ b/scratch/very_scratch/pbc_training_set_clustering.py
@@ -99,9 +99,6 @@ for c in C: print c, C[c]['rep3']/C[c]['N']
 
 show_rep3(C,r,fos.red)
 
-
-
-
 """
 
 #print 'Showing initial dataset.'

--- a/scratch/very_scratch/pbc_training_set_clustering.py
+++ b/scratch/very_scratch/pbc_training_set_clustering.py
@@ -102,7 +102,7 @@ show_rep3(C,r,fos.red)
 
 
 
-'''
+"""
 
 #print 'Showing initial dataset.'
 r=fos.ren()
@@ -152,4 +152,4 @@ print 'singletons ',lens.count(1)
 print 'doubletons ',lens.count(2)
 print 'tripletons ',lens.count(3)
 
-'''
+"""

--- a/scratch/very_scratch/registration_example.py
+++ b/scratch/very_scratch/registration_example.py
@@ -215,10 +215,7 @@ def test_registration():
     # LPS to RAS
 
 
-    
-
 if __name__ == '__main__':
-
 
     """
     print('Goal is to compare FA of grid versus shell acquisitions using STEAM')
@@ -239,10 +236,3 @@ if __name__ == '__main__':
                                [FA_grid_img.get_data(),FA_shell_imgT.get_data()])
 
     """
-
-    
-
-
-
-
-    

--- a/scratch/very_scratch/registration_example.py
+++ b/scratch/very_scratch/registration_example.py
@@ -220,7 +220,7 @@ def test_registration():
 if __name__ == '__main__':
 
 
-    '''
+    """
     print('Goal is to compare FA of grid versus shell acquisitions using STEAM')
 
     print('find filenames for grid and shell data')    
@@ -238,7 +238,7 @@ if __name__ == '__main__':
     save_volumes_as_mosaic('/tmp/mosaic_fa.png',\
                                [FA_grid_img.get_data(),FA_shell_imgT.get_data()])
 
-    '''
+    """
 
     
 

--- a/scratch/very_scratch/simulation_comparison_dsi_gqi.py
+++ b/scratch/very_scratch/simulation_comparison_dsi_gqi.py
@@ -24,7 +24,6 @@ gradients=b_vals_dirs[:,1:]
 
 gq = dp.GeneralizedQSampling(sim_data,bvals,gradients)
 tn = dp.Tensor(sim_data,bvals,gradients)
-#"""
 
 gqfile = '/home/ian/Data/SimData/gq_SNR030_1fibre.pkl'
 pkl.save_pickle(gqfile,gq)

--- a/scratch/very_scratch/simulation_comparison_dsi_gqi.py
+++ b/scratch/very_scratch/simulation_comparison_dsi_gqi.py
@@ -8,11 +8,11 @@ fname='/home/ian/Data/SimData/results_SNR030_1fibre'
 #fname='/home/eg01/Data_Backup/Data/Marta/DSI/SimData/results_SNR030_isotropic'
 
 
-''' file  has one row for every voxel, every voxel is repeating 1000
+""" file  has one row for every voxel, every voxel is repeating 1000
 times with the same noise level , then we have 100 different
 directions. 1000 * 100 is the number of all rows.
 
-'''
+"""
 marta_table_fname='/home/ian/Data/SimData/Dir_and_bvals_DSI_marta.txt'
 sim_data=np.loadtxt(fname)
 #bvalsf='/home/eg01/Data_Backup/Data/Marta/DSI/SimData/bvals101D_float.txt'
@@ -24,7 +24,7 @@ gradients=b_vals_dirs[:,1:]
 
 gq = dp.GeneralizedQSampling(sim_data,bvals,gradients)
 tn = dp.Tensor(sim_data,bvals,gradients)
-#'''
+#"""
 
 gqfile = '/home/ian/Data/SimData/gq_SNR030_1fibre.pkl'
 pkl.save_pickle(gqfile,gq)
@@ -32,7 +32,7 @@ tnfile = '/home/ian/Data/SimData/tn_SNR030_1fibre.pkl'
 pkl.save_pickle(tnfile,tn)
 
 
-'''
+"""
 print tn.evals.shape
 print tn.evecs.shape
 
@@ -45,4 +45,4 @@ first_directions = tn.evecs[:,:,0]
 first1000 = first_directions[:1000,:]
 cross = np.dot(first1000.T,first1000)
 np.linalg.eig(cross)
-'''
+"""

--- a/scratch/very_scratch/simulation_comparisons.py
+++ b/scratch/very_scratch/simulation_comparisons.py
@@ -13,7 +13,7 @@ import dipy.core.geometry as geometry
 import get_vertices as gv
 
 #old SimData files
-'''
+"""
 results_SNR030_1fibre
 results_SNR030_1fibre+iso
 results_SNR030_2fibres_15deg
@@ -25,16 +25,16 @@ results_SNR030_2fibres+iso_30deg
 results_SNR030_2fibres+iso_60deg
 results_SNR030_2fibres+iso_90deg
 results_SNR030_isotropic
-'''
+"""
 #fname='/home/ian/Data/SimData/results_SNR030_1fibre'
-''' file  has one row for every voxel, every voxel is repeating 1000
+""" file  has one row for every voxel, every voxel is repeating 1000
 times with the same noise level , then we have 100 different
 directions. 1000 * 100 is the number of all rows.
 
 The 100 conditions are given by 10 polar angles (in degrees) 0, 20, 40, 60, 80,
 80, 60, 40, 20 and 0, and each of these with longitude angle 0, 40, 80,
 120, 160, 200, 240, 280, 320, 360. 
-'''
+"""
 
 #new complete SimVoxels files
 simdata = ['fibres_2_SNR_80_angle_90_l1_1.4_l2_0.35_l3_0.35_iso_0_diso_00',
@@ -108,18 +108,18 @@ def gq_tn_calc_save():
         gqfile = simdir+'gq/'+dataname+'.pkl'
         pkl.save_pickle(gqfile,gq)
 
-        '''
+        """
         gq.IN               gq.__doc__          gq.glob_norm_param
         gq.QA               gq.__init__         gq.odf              
         gq.__class__        gq.__module__       gq.q2odf_params
-        '''
+        """
 
         tn = dp.Tensor(sim_data,bvals,gradients)
         tnfile = simdir+'tn/'+dataname+'.pkl'
         pkl.save_pickle(tnfile,tn)
 
 
-        '''
+        """
         tn.ADC               tn.__init__          tn._getevals
         tn.B                 tn.__module__        tn._getevecs
         tn.D                 tn.__new__           tn._getndim
@@ -134,9 +134,9 @@ def gq_tn_calc_save():
         tn.__getattribute__  tn._evals            tn.ndim
         tn.__getitem__       tn._evecs            tn.shape
         tn.__hash__          tn._getD             
-        '''
+        """
 
-        ''' file  has one row for every voxel, every voxel is repeating 1000
+        """ file  has one row for every voxel, every voxel is repeating 1000
         times with the same noise level , then we have 100 different
         directions. 100 * 1000 is the number of all rows.
 
@@ -145,12 +145,12 @@ def gq_tn_calc_save():
         are the antipodal partners of directions 0 to 180. So when counting the
         number of different vertices that occur as maximal directions we wll map
         the indices modulo 181.
-        '''
+        """
 
 def analyze_maxima(indices, max_dirs, subsets):
-    '''This calculates the eigenstats for each of the replicated batches
+    """This calculates the eigenstats for each of the replicated batches
     of the simulation data
-    '''
+    """
 
     results = []
 
@@ -269,13 +269,13 @@ def run_gq_sims(sample_data=[35]):
             t0, t1, t2, npa = gqs.npa(s, width = 5)
             
             print t0, t1, t2, npa
-            '''
+            """
             for (i,o) in enumerate(gqs.odf(s)):
                 print i,o
             
             for (i,o) in enumerate(gqs.odf_vertices):
                 print i,o
-            '''
+            """
             #o = gqs.odf(s)
             #v = gqs.odf_vertices
             #pole = v[t0[0]]

--- a/scratch/very_scratch/simulation_comparisons.py
+++ b/scratch/very_scratch/simulation_comparisons.py
@@ -118,7 +118,6 @@ def gq_tn_calc_save():
         tnfile = simdir+'tn/'+dataname+'.pkl'
         pkl.save_pickle(tnfile,tn)
 
-
         """
         tn.ADC               tn.__init__          tn._getevals
         tn.B                 tn.__module__        tn._getevecs

--- a/scratch/very_scratch/simulation_comparisons_modified.py
+++ b/scratch/very_scratch/simulation_comparisons_modified.py
@@ -118,7 +118,6 @@ def gq_tn_calc_save():
         tnfile = simdir+'tn/'+dataname+'.pkl'
         pkl.save_pickle(tnfile,tn)
 
-
         """
         tn.ADC               tn.__init__          tn._getevals
         tn.B                 tn.__module__        tn._getevecs

--- a/scratch/very_scratch/simulation_comparisons_modified.py
+++ b/scratch/very_scratch/simulation_comparisons_modified.py
@@ -12,7 +12,7 @@ import dipy.core.geometry as geometry
 import get_vertices as gv
 
 #old SimData files
-'''
+"""
 results_SNR030_1fibre
 results_SNR030_1fibre+iso
 results_SNR030_2fibres_15deg
@@ -24,16 +24,16 @@ results_SNR030_2fibres+iso_30deg
 results_SNR030_2fibres+iso_60deg
 results_SNR030_2fibres+iso_90deg
 results_SNR030_isotropic
-'''
+"""
 #fname='/home/ian/Data/SimData/results_SNR030_1fibre'
-''' file  has one row for every voxel, every voxel is repeating 1000
+""" file  has one row for every voxel, every voxel is repeating 1000
 times with the same noise level , then we have 100 different
 directions. 1000 * 100 is the number of all rows.
 
 The 100 conditions are given by 10 polar angles (in degrees) 0, 20, 40, 60, 80,
 80, 60, 40, 20 and 0, and each of these with longitude angle 0, 40, 80,
 120, 160, 200, 240, 280, 320, 360. 
-'''
+"""
 
 #new complete SimVoxels files
 simdata = ['fibres_2_SNR_80_angle_90_l1_1.4_l2_0.35_l3_0.35_iso_0_diso_00',
@@ -108,18 +108,18 @@ def gq_tn_calc_save():
         gqfile = simdir+'gq/'+dataname+'.pkl'
         pkl.save_pickle(gqfile,gq)
 
-        '''
+        """
         gq.IN               gq.__doc__          gq.glob_norm_param
         gq.QA               gq.__init__         gq.odf              
         gq.__class__        gq.__module__       gq.q2odf_params
-        '''
+        """
 
         tn = dp.Tensor(sim_data,bvals,gradients)
         tnfile = simdir+'tn/'+dataname+'.pkl'
         pkl.save_pickle(tnfile,tn)
 
 
-        '''
+        """
         tn.ADC               tn.__init__          tn._getevals
         tn.B                 tn.__module__        tn._getevecs
         tn.D                 tn.__new__           tn._getndim
@@ -134,9 +134,9 @@ def gq_tn_calc_save():
         tn.__getattribute__  tn._evals            tn.ndim
         tn.__getitem__       tn._evecs            tn.shape
         tn.__hash__          tn._getD             
-        '''
+        """
 
-        ''' file  has one row for every voxel, every voxel is repeating 1000
+        """ file  has one row for every voxel, every voxel is repeating 1000
         times with the same noise level , then we have 100 different
         directions. 100 * 1000 is the number of all rows.
 
@@ -145,12 +145,12 @@ def gq_tn_calc_save():
         are the antipodal partners of directions 0 to 180. So when counting the
         number of different vertices that occur as maximal directions we wll map
         the indices modulo 181.
-        '''
+        """
 
 def analyze_maxima(indices, max_dirs, subsets):
-    '''This calculates the eigenstats for each of the replicated batches
+    """This calculates the eigenstats for each of the replicated batches
     of the simulation data
-    '''
+    """
 
     results = []
 
@@ -283,13 +283,13 @@ def run_gq_sims(sample_data=[35,23,46,39,40,10,37,27,21,20]):
             
             print >> out, dataname, j, npa, tn.fa()[0]
             
-            '''
+            """
             for (i,o) in enumerate(gqs.odf(s)):
                 print i,o
             
             for (i,o) in enumerate(gqs.odf_vertices):
                 print i,o
-            '''
+            """
             #o = gqs.odf(s)
             #v = gqs.odf_vertices
             #pole = v[t0[0]]

--- a/scratch/very_scratch/spherical_statistics.py
+++ b/scratch/very_scratch/spherical_statistics.py
@@ -101,11 +101,11 @@ for key in ['fy642']:
     print '%6.3f %6.3f %6.3f %6.3f' % (polar.min(), polar.mean(), polar.max(), np.sqrt(polar.var()))
 
 def spherical_statistics(vertices, north=np.array([0,0,1]), width=0.02):
-    '''
+    """
     function to evaluate a spherical triangulation by looking at the
     variability of numbers of vertices in 'vertices' in equatorial bands
     of width 'width' orthogonal to each point in 'vertices'
-    ''' 
+    """
 
     equatorial_counts = np.array([len(equatorial_zone_vertices(vertices, pole, width=width)) for pole in vertices if np.dot(pole,north) >= 0])
 

--- a/scratch/very_scratch/tractography_clustering_new_fos.py
+++ b/scratch/very_scratch/tractography_clustering_new_fos.py
@@ -115,9 +115,9 @@ print 'singletons ',lens.count(1)
 print 'doubletons ',lens.count(2)
 print 'tripletons ',lens.count(3)
 
-''' Next Level
+""" Next Level
 
 12: cluster0=[T[t] for t in C[0]['indices']]
 13: pf.most_similar_track_mam(cluster0)
 
-'''
+"""

--- a/scratch/very_scratch/warptalk.py
+++ b/scratch/very_scratch/warptalk.py
@@ -152,7 +152,7 @@ print t2-t1,len(T)
 
 Tfinal=[]
 
-'''
+"""
 for (i,track) in enumerate(T):
     print i
     ntrack=np.dot(track,im2im[:3,:3].T)+im2im[:3,3]
@@ -161,7 +161,7 @@ for (i,track) in enumerate(T):
     mck=mc(dk,ntrack.T)
     wtrack=ntrack+np.vstack((mci,mcj,mck)).T
     Tfinal.append(np.dot(wtrack,daff[:3,:3].T)+daff[:3,3])
-'''
+"""
 
 lengths=[len(t) for t in T]
 lengths.insert(0,0)
@@ -188,12 +188,12 @@ imgref=nib.load(ref_fname)
 refdata=imgref.get_data()
 refaff=imgref.affine
 
-'''
+"""
 refI=np.array(np.where(refdata>5000)).T    
 wrefI=np.dot(refaff[:3,:3],refI.T).T+refaff[:3,3]
 print wrefI.shape
 wrefI=wrefI.astype('f4')
-'''
+"""
 
     
 from dipy.viz import fos
@@ -302,21 +302,21 @@ print daff
 #n1=cube_mni_grid_nearest[1,:]
 #n2=cube_mni_grid_nearest[2,:]
 
-'''
+"""
 n0 = np.min(np.max(cube_mni_grid_nearest[0,:],0),d0)
 n1 = np.min(np.max(cube_mni_grid_nearest[1,:],0),d1)
 n2 = np.min(np.max(cube_mni_grid_nearest[2,:],0),d2)
-'''
+"""
 
 
 #cube_mni_data=np.zeros(disdata.shape[:-1],dtype=np.float32)
 
 #cube_mni_data[n0,n1,n2]=1
 
-'''
+"""
 D=disdata[n0,n1,n2]
 
-'''
+"""
 
 #from dipy.viz import fos
 #r=fos.ren()
@@ -396,12 +396,12 @@ def test_flirt2aff():
     import scipy.ndimage as ndi
     import nibabel as nib
     
-    '''
+    """
     matfile = pjoin('fa_data',
                     '1312211075232351192010092912092080924175865ep2dadvdiffDSI10125x25x25STs005a001_affine_transf.mat')
     in_fname = pjoin('fa_data',
                      '1312211075232351192010092912092080924175865ep2dadvdiffDSI10125x25x25STs005a001_bet_FA.nii.gz')
-    '''
+    """
     
     matfile=flirtaff
     in_fname = ffa

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-''' Checkout gitwash repo into directory and do search replace on name '''
+""" Checkout gitwash repo into directory and do search replace on name """
 
 import os
 from os.path import join as pjoin
@@ -51,9 +51,9 @@ def cp_files(in_path, globs, out_path):
 
 
 def filename_search_replace(sr_pairs, filename, backup=False):
-    ''' Search and replace for expressions in files
+    """ Search and replace for expressions in files
 
-    '''
+    """
     in_txt = open(filename, 'rt').read(-1)
     out_txt = in_txt[:]
     for in_exp, out_exp in sr_pairs:
@@ -152,13 +152,13 @@ def make_link_targets(proj_name,
     out_links.close()
 
 
-USAGE = ''' <output_directory> <project_name>
+USAGE = """ <output_directory> <project_name>
 
 If not set with options, the repository name is the same as the <project
 name>
 
 If not set with options, the main github user is the same as the
-repository name.'''
+repository name."""
 
 
 GITWASH_CENTRAL = 'git://github.com/matthew-brett/gitwash.git'

--- a/version_helpers.py
+++ b/version_helpers.py
@@ -1,11 +1,11 @@
-''' Distutils / setuptools helpers for versioning
+""" Distutils / setuptools helpers for versioning
 
 This code started life in the nibabel package as nisexts/sexts.py
 
 Code transferred by Matthew Brett, who holds copyright.
 
 This version under the standard dipy BSD license.
-'''
+"""
 
 from os.path import join as pjoin
 try:
@@ -52,7 +52,7 @@ def get_comrec_build(pkg_dir, build_cmd=build_py):
     package for an example.
     """
     class MyBuildPy(build_cmd):
-        ''' Subclass to write commit data into installation tree '''
+        """ Subclass to write commit data into installation tree """
         def run(self):
             build_cmd.run(self)
             import subprocess


### PR DESCRIPTION
Fix
```
Triple double-quoted strings should be used for docstrings.
```

PEP8 warning.

Indeed, according to
https://www.python.org/dev/peps/pep-0008/

*For triple-quoted strings, always use double quote characters to be
consistent with the docstring convention in PEP 257.*