### PR TITLE
BUG: Fix `dipy.io.trackvis` deprecation warnings.

### DIFF
--- a/doc/examples/deterministic_fiber_tracking.py
+++ b/doc/examples/deterministic_fiber_tracking.py
@@ -65,7 +65,7 @@ is used.
 
 from dipy.data import default_sphere
 from dipy.direction import DeterministicMaximumDirectionGetter
-from dipy.io.trackvis import save_trk
+from dipy.io.streamline import save_trk
 
 detmax_dg = DeterministicMaximumDirectionGetter.from_shcoeff(csd_fit.shm_coeff,
                                                              max_angle=30.,

--- a/doc/examples/particle_filtering_fiber_tracking.py
+++ b/doc/examples/particle_filtering_fiber_tracking.py
@@ -27,7 +27,7 @@ import numpy as np
 from dipy.data import (read_stanford_labels, default_sphere,
                        read_stanford_pve_maps)
 from dipy.direction import ProbabilisticDirectionGetter
-from dipy.io.trackvis import save_trk
+from dipy.io.streamline import save_trk
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response)
 from dipy.tracking.local import LocalTracking, ParticleFilteringTracking

--- a/doc/examples/probabilistic_fiber_tracking.py
+++ b/doc/examples/probabilistic_fiber_tracking.py
@@ -60,7 +60,7 @@ and/or model failures sometimes it can have negative values.
 
 from dipy.direction import ProbabilisticDirectionGetter
 from dipy.data import small_sphere
-from dipy.io.trackvis import save_trk
+from dipy.io.streamline import save_trk
 
 fod = csd_fit.odf(small_sphere)
 pmf = fod.clip(min=0)

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -15,7 +15,7 @@ Let's load the necessary modules for executing this tutorial.
 from dipy.data import read_stanford_labels
 from dipy.tracking import utils
 from dipy.tracking.local import (ThresholdTissueClassifier, LocalTracking)
-from dipy.io.trackvis import save_trk
+from dipy.io.streamline import save_trk
 from dipy.viz import window, actor, colormap as cmap
 
 renderer = window.Renderer()

--- a/doc/examples/tracking_tissue_classifier.py
+++ b/doc/examples/tracking_tissue_classifier.py
@@ -29,7 +29,7 @@ from dipy.data import (read_stanford_labels,
                        default_sphere,
                        read_stanford_pve_maps)
 from dipy.direction import DeterministicMaximumDirectionGetter
-from dipy.io.trackvis import save_trk
+from dipy.io.streamline import save_trk
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
                                    auto_response)
 from dipy.tracking.local import LocalTracking


### PR DESCRIPTION
Fix `dipy.io.trackvis` deprecation warnings: substitute by
`dipy.io.streamline` as per the DIPY 0.14. API changes:
https://github.com/nipy/dipy/blob/master/doc/api_changes.rst

Partially addresses #1664.