### PR TITLE
DOC: Fix typo in `linear_fascicle_evaluation.py` script.

### DIFF
--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -48,7 +48,7 @@ candidate_sl, hdr = load_trk('lr-superiorfrontal.trk')
 """
 
 The streamlines that are entered into the model are termed 'candidate
-streamliness' (or a 'candidate connectome'):
+streamlines' (or a 'candidate connectome'):
 
 """
 


### PR DESCRIPTION
Fix typo in `linear_fascicle_evaluation.py` script: change `streamliness`
to `streamlines`.