### PR TITLE
BUG: Fix Numpy `.random.random_integer` deprecation warning.

### DIFF
--- a/dipy/segment/tests/test_mrf.py
+++ b/dipy/segment/tests/test_mrf.py
@@ -45,13 +45,13 @@ square_gauss[99:157, 99:157, :] = square_gauss[99:157, 99:157, :] + noise_3
 
 square_1 = np.zeros((256, 256, 3)) + 0.001
 square_1 = add_noise(square_1, 10000, 1, noise_type='gaussian')
-temp_1 = np.random.random_integers(20, size=(171, 171, 3))
+temp_1 = np.random.randint(1, 21, size=(171, 171, 3))
 temp_1 = np.where(temp_1 < 20, 1, 3)
 square_1[42:213, 42:213, :] = temp_1
-temp_2 = np.random.random_integers(20, size=(114, 114, 3))
+temp_2 = np.random.randint(1, 21, size=(114, 114, 3))
 temp_2 = np.where(temp_2 < 19, 2, 1)
 square_1[71:185, 71:185, :] = temp_2
-temp_3 = np.random.random_integers(20, size=(58, 58, 3))
+temp_3 = np.random.randint(1, 21, size=(58, 58, 3))
 temp_3 = np.where(temp_3 < 20, 3, 1)
 square_1[99:157, 99:157, :] = temp_3
 

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -482,7 +482,7 @@ def test_length():
 
 
 def test_seeds_from_mask():
-    mask = np.random.random_integers(0, 1, size=(10, 10, 10))
+    mask = np.random.randint(0, 1, size=(10, 10, 10))
     seeds = seeds_from_mask(mask, density=1)
     assert_equal(mask.sum(), len(seeds))
     assert_array_equal(np.argwhere(mask), seeds)
@@ -504,7 +504,7 @@ def test_seeds_from_mask():
 
 
 def test_random_seeds_from_mask():
-    mask = np.random.random_integers(0, 1, size=(4, 6, 3))
+    mask = np.random.randint(0, 1, size=(4, 6, 3))
     seeds = random_seeds_from_mask(mask,
                                    seeds_count=24,
                                    seed_count_per_voxel=True)


### PR DESCRIPTION
Fix Numpy `.random.random_integer` deprecation warning. Fixes:
```
DeprecationWarning: This function is deprecated. Please call randint(1, 20
+ 1) instead
```

and similar warnings.