### PR TITLE
BUG: Address `numpy.matrix` `PendingDeprecation` warnings.

### DIFF
--- a/dipy/reconst/qtdmri.py
+++ b/dipy/reconst/qtdmri.py
@@ -1818,7 +1818,7 @@ def GCV_cost_function(weight, arguments):
     """
     data, M, MMt, K, LR = arguments
     S = np.dot(np.dot(M, np.linalg.pinv(MMt + weight * LR)), M.T)
-    trS = np.matrix.trace(S)
+    trS = np.trace(S)
     normyytilde = np.linalg.norm(data - np.dot(S, data), 2)
     gcv_value = normyytilde / (K - trS)
     return gcv_value

--- a/dipy/viz/projections.py
+++ b/dipy/viz/projections.py
@@ -76,7 +76,7 @@ def sph_project(vertices, val, ax=None, vmin=None, vmax=None, cmap=None,
 
     # Rotate the coordinate system so that you are looking from the north pole:
     verts_rot = np.array(
-        np.dot(np.matrix([[0, 0, -1], [0, 1, 0], [1, 0, 0]]), vertices))
+        np.dot(np.array([[0, 0, -1], [0, 1, 0], [1, 0, 0]]), vertices))
 
     # To get the orthographic projection, when the first coordinate is
     # positive:

--- a/scratch/very_scratch/joint_hist.py
+++ b/scratch/very_scratch/joint_hist.py
@@ -185,22 +185,22 @@ def apply_mapping(A,T,order=0,map_type='affine2d'):
             sc1,sc2,sch1,sch2=(1,1,0,0)            
         
         #translation
-        TC=np.matrix([[1,0,tc1],
+        TC=np.array([[1,0,tc1],
                       [0,1,tc2],
                       [0,0,  1]])
 
         #scaling
-        SC=np.matrix([[sc1,  0,   0],
+        SC=np.array([[sc1,  0,   0],
                       [0,  sc2,   0],
                       [0,    0,   1]])
 
         #rotation
-        RC=np.matrix([[cos(rc), sin(rc), 0],
+        RC=np.array([[cos(rc), sin(rc), 0],
                       [-sin(rc), cos(rc), 0],
                       [0      ,       0, 1]])
         
         #shear        
-        SHC=np.matrix([[1,   sch1,0],
+        SHC=np.array([[1,   sch1,0],
                        [sch2,   1,0],
                        [0,      0,1]])            
         

--- a/scratch/very_scratch/joint_hist.py
+++ b/scratch/very_scratch/joint_hist.py
@@ -185,24 +185,24 @@ def apply_mapping(A,T,order=0,map_type='affine2d'):
             sc1,sc2,sch1,sch2=(1,1,0,0)            
         
         #translation
-        TC=np.array([[1,0,tc1],
-                      [0,1,tc2],
-                      [0,0,  1]])
+        TC = np.array([[1, 0, tc1],
+                      [0, 1, tc2],
+                      [0, 0,  1]])
 
         #scaling
-        SC=np.array([[sc1,  0,   0],
+        SC = np.array([[sc1,  0,   0],
                       [0,  sc2,   0],
                       [0,    0,   1]])
 
         #rotation
-        RC=np.array([[cos(rc), sin(rc), 0],
+        RC = np.array([[cos(rc), sin(rc), 0],
                       [-sin(rc), cos(rc), 0],
                       [0      ,       0, 1]])
         
         #shear        
-        SHC=np.array([[1,   sch1,0],
-                       [sch2,   1,0],
-                       [0,      0,1]])            
+        SHC = np.array([[1,   sch1, 0],
+                       [sch2,   1, 0],
+                       [0,      0, 1]])
         
         
         #apply


### PR DESCRIPTION
Address `numpy.matrix` `PendingDeprecation` warnings:
- Change the uses of `numpy.matrix` to `numpy.array`.
- Change the use of `numpy.matrix.trace` to `numpy.trace`.

Fixes warnings:
```
/home/travis/build/nipy/dipy/venv/lib/python3.4/site-packages/numpy/matrixlib/defmatrix.py:68:
PendingDeprecationWarning: the matrix subclass is not the recommended
way to represent matrices or deal with linear algebra (see
https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html).
Please adjust your code to use regular ndarray.
  return matrix(data, dtype=dtype, copy=False)
```

This should complete the work in PR #1678.