### PR TITLE
BF: Clip the values before passing to arccos, instead of fixing nans.

### DIFF
--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -540,7 +540,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
     from scipy.interpolate import Rbf
 
     def angle(x1, x2):
-        xx = np.arccos(np.clip((x1 * x2).sum(axis=0), 0, 1))
+        xx = np.arccos(np.clip((x1 * x2).sum(axis=0), -1, 1))
         return np.nan_to_num(xx)
 
     def euclidean_norm(x1, x2):

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -540,8 +540,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
     from scipy.interpolate import Rbf
 
     def angle(x1, x2):
-        xx = np.arccos((x1 * x2).sum(axis=0))
-        xx[np.isnan(xx)] = 0
+        xx = np.arccos(np.clip((x1 * x2).sum(axis=0), 0, 1))
         return xx
 
     def euclidean_norm(x1, x2):

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -541,7 +541,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
 
     def angle(x1, x2):
         xx = np.arccos(np.clip((x1 * x2).sum(axis=0), 0, 1))
-        return xx
+        return np.nan_to_num(xx)
 
     def euclidean_norm(x1, x2):
         return np.sqrt(((x1 - x2)**2).sum(axis=0))


### PR DESCRIPTION
Fixes #1698.