### PR TITLE
BF: Syntax fix example images not rendering

### DIFF
--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -60,7 +60,7 @@ Constrained Spherical Deconvolution
 
 - :ref:`example_reconst_csd`
 
-Fiber ORientation Estimated using Continuous Axially Symmetric Tensors
+Fiber Orientation Estimated using Continuous Axially Symmetric Tensors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_reconst_forecast`

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -79,7 +79,7 @@ Mean Apparent Propagator (MAP)-MRI
 Studying diffusion time-dependence using qt-dMRI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`example_reconst_qtdmri` 
+- :ref:`example_reconst_qtdmri`
 
 Diffusion Tensor Imaging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -166,7 +166,7 @@ Streamline analysis and connectivity
 - :ref:`example_streamline_tools`
 - :ref:`example_streamline_length`
 - :ref:`example_cluster_confidence`
-- :ref: `example_path_length_map`
+- :ref:`example_path_length_map`
 
 
 ------------------


### PR DESCRIPTION
Images aren't rendering in the website gallery (http://nipy.org/dipy/examples_built/path_length_map.html#example-path-length-map). I think this is because of a syntax error (there's an extra space in the examples_index.rst). I also fixed a random typo I found.