### PR TITLE
[Fix]  Pre-build : From relative to absolute import

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -1,7 +1,7 @@
 """ Utility functions used by the Cross Correlation (CC) metric """
 
 import numpy as np
-from fused_types cimport floating
+from dipy.align.fused_types cimport floating
 cimport cython
 cimport numpy as cnp
 

--- a/dipy/align/expectmax.pyx
+++ b/dipy/align/expectmax.pyx
@@ -7,7 +7,7 @@
 import numpy as np
 cimport cython
 cimport numpy as cnp
-from .fused_types cimport floating, number
+from dipy.align.fused_types cimport floating, number
 cdef extern from "dpy_math.h" nogil:
     int dpy_isinf(double)
     double floor(double)

--- a/dipy/align/parzenhist.pyx
+++ b/dipy/align/parzenhist.pyx
@@ -7,8 +7,8 @@ import numpy as np
 cimport numpy as cnp
 cimport cython
 import numpy.random as random
-from .fused_types cimport floating
-from . import vector_fields as vf
+from dipy.align.fused_types cimport floating
+from dipy.align import vector_fields as vf
 
 from dipy.align.vector_fields cimport(_apply_affine_3d_x0,
                                       _apply_affine_3d_x1,

--- a/dipy/align/sumsqdiff.pyx
+++ b/dipy/align/sumsqdiff.pyx
@@ -3,7 +3,7 @@
 import numpy as np
 cimport cython
 cimport numpy as cnp
-from .fused_types cimport floating, number
+from dipy.align.fused_types cimport floating, number
 cdef extern from "dpy_math.h" nogil:
     int dpy_isinf(double)
     double sqrt(double)

--- a/dipy/align/vector_fields.pyx
+++ b/dipy/align/vector_fields.pyx
@@ -6,7 +6,7 @@
 import numpy as np
 cimport numpy as cnp
 cimport cython
-from .fused_types cimport floating, number
+from dipy.align.fused_types cimport floating, number
 
 
 cdef extern from "dpy_math.h" nogil:

--- a/dipy/segment/clustering_algorithms.pyx
+++ b/dipy/segment/clustering_algorithms.pyx
@@ -5,9 +5,9 @@ from dipy.utils.six.moves import xrange
 import itertools
 import numpy as np
 
-from cythonutils cimport Data2D, shape2tuple
-from metricspeed cimport Metric
-from clusteringspeed cimport ClustersCentroid, Centroid, QuickBundles, QuickBundlesX
+from dipy.segment.cythonutils cimport Data2D, shape2tuple
+from dipy.segment.metricspeed cimport Metric
+from dipy.segment.clusteringspeed cimport ClustersCentroid, Centroid, QuickBundles, QuickBundlesX
 from dipy.segment.clustering import ClusterMapCentroid, ClusterCentroid
 
 cdef extern from "stdlib.h" nogil:

--- a/dipy/segment/clusteringspeed.pxd
+++ b/dipy/segment/clusteringspeed.pxd
@@ -1,5 +1,5 @@
-from cythonutils cimport Data2D, Shape, shape2tuple, tuple2shape
-from metricspeed cimport Metric
+from dipy.segment.cythonutils cimport Data2D, Shape, shape2tuple, tuple2shape
+from dipy.segment.metricspeed cimport Metric
 
 
 cdef struct QuickBundlesStats:

--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -10,7 +10,7 @@ from dipy.segment.clustering import TreeCluster, TreeClusterMap
 
 
 from libc.math cimport fabs
-from cythonutils cimport Data2D, Shape, shape2tuple,\
+from dipy.segment.cythonutils cimport Data2D, Shape, shape2tuple,\
     tuple2shape, same_shape, create_memview_2d, free_memview_2d
 
 cdef extern from "math.h" nogil:

--- a/dipy/segment/featurespeed.pxd
+++ b/dipy/segment/featurespeed.pxd
@@ -1,4 +1,4 @@
-from cythonutils cimport Data2D, Shape
+from dipy.segment.cythonutils cimport Data2D, Shape
 cimport numpy as cnp
 
 cdef class Feature(object):

--- a/dipy/segment/featurespeed.pyx
+++ b/dipy/segment/featurespeed.pyx
@@ -4,7 +4,7 @@
 import numpy as np
 cimport numpy as cnp
 
-from cythonutils cimport tuple2shape, shape2tuple, shape_from_memview
+from dipy.segment.cythonutils cimport tuple2shape, shape2tuple, shape_from_memview
 from dipy.tracking.streamlinespeed cimport c_set_number_of_points, c_length
 
 

--- a/dipy/segment/metricspeed.pxd
+++ b/dipy/segment/metricspeed.pxd
@@ -1,5 +1,5 @@
-from cythonutils cimport Data2D, Shape
-from featurespeed cimport Feature
+from dipy.segment.cythonutils cimport Data2D, Shape
+from dipy.segment.featurespeed cimport Feature
 
 
 cdef class Metric(object):

--- a/dipy/segment/metricspeed.pyx
+++ b/dipy/segment/metricspeed.pyx
@@ -5,8 +5,8 @@ import numpy as np
 
 from libc.math cimport sqrt, acos
 
-from cythonutils cimport tuple2shape, shape2tuple, same_shape
-from featurespeed cimport IdentityFeature, ResampleFeature
+from dipy.segment.cythonutils cimport tuple2shape, shape2tuple, same_shape
+from dipy.segment.featurespeed cimport IdentityFeature, ResampleFeature
 
 DEF biggest_double = 1.7976931348623157e+308  #  np.finfo('f8').max
 


### PR DESCRIPTION
The goal of this PR is to fix Travis PRE build error. As you can see [here](https://travis-ci.org/nipy/dipy/jobs/493526375#L1399), DIPY was failing during compilation due to the change of the default Cython `language_level` (from `py2` to `py3str`, warning [here](https://travis-ci.org/nipy/dipy/jobs/493526375#L1343)). This implies to switch our relative import to absolute import to respect python 3 semantics. 

So, this is just an update of some `*.pyx`  and `*.pxd` files. Let's see if it works now...