### PR TITLE
REL: 0.16.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -87,3 +87,9 @@ Chandan Gangwar <chandan.gangwar0411@gmail.com>
 Naveen Kumarmarri <naveenkumarmarri6014@gmail.com>
 Jakob Wasserthal <j.wasserthal@dkfz.de>
 Shreyas Fadnavis <shreyasfadnavis@gmail.com>
+Daniel Enrico Cahall <danielenricocahall@gmail.com>
+Bramsh Qamar <bramshq@gmail.com>
+Bramsh Qamar <bramshq@gmail.com> Bramsh Qamar <bramshqamar@Bramshs-MacBook-Pro.local>
+Yash Sherry <yash14123@iiitd.ac.in>
+endolith <endolith@gmail.com>
+ArjitJ <32598699+ArjitJ@users.noreply.github.com>

--- a/Changelog
+++ b/Changelog
@@ -26,7 +26,7 @@ The code found in Dipy was created by the people found in the AUTHOR file.
 
 * 0.16.0 (Sunday, 10 March 2019)
 
-- Horizon, fast, modular, unified and adaptive visualization
+- Horizon, medical visualization interface powered by QuickBundlesX
 - New Tractometry tools : Bundle Analysis / Bundle Profiles
 - New reconstruction model: IVIM Mix
 - New command line interface: Affine and Diffeomorphic Registration

--- a/Changelog
+++ b/Changelog
@@ -24,6 +24,18 @@ Dipy
 
 The code found in Dipy was created by the people found in the AUTHOR file.
 
+* 0.16.0 (Sunday, 10 March 2019)
+
+- Horizon, fast, modular, unified and adaptive visualization
+- New Tractometry tools : Bundle Analysis / Bundle Profiles
+- New reconstruction model: IVIM Mix
+- New command line interface: Affine and Diffeomorphic Registration
+- New command line interface: Probalistic, Deterministic and PFT Tracking
+- Integration of Cython Guidelines for developers
+- Replacement of Nose by Pytest
+- Documentation update.
+- Closed 103 issues and merged 41 pull requests.
+
 * 0.15 (Wednesday, 12 December 2018)
 
 - Updated RecoBundles for automatic anatomical bundle segmentation.

--- a/Changelog
+++ b/Changelog
@@ -30,7 +30,7 @@ The code found in Dipy was created by the people found in the AUTHOR file.
 - New Tractometry tools : Bundle Analysis / Bundle Profiles
 - New reconstruction model: IVIM Mix
 - New command line interface: Affine and Diffeomorphic Registration
-- New command line interface: Probalistic, Deterministic and PFT Tracking
+- New command line interface: Probabilistic, Deterministic and PFT Tracking
 - Integration of Cython Guidelines for developers
 - Replacement of Nose by Pytest
 - Documentation update.

--- a/Changelog
+++ b/Changelog
@@ -28,7 +28,7 @@ The code found in Dipy was created by the people found in the AUTHOR file.
 
 - Horizon, medical visualization interface powered by QuickBundlesX.
 - New Tractometry tools: Bundle Analysis / Bundle Profiles.
-- New reconstruction model: IVIM MIX.
+- New reconstruction model: IVIM MIX (Variable Projection).
 - New command line interface: Affine and Diffeomorphic Registration.
 - New command line interface: Probabilistic, Deterministic and PFT Tracking.
 - Integration of Cython Guidelines for developers.

--- a/Changelog
+++ b/Changelog
@@ -26,13 +26,13 @@ The code found in Dipy was created by the people found in the AUTHOR file.
 
 * 0.16.0 (Sunday, 10 March 2019)
 
-- Horizon, medical visualization interface powered by QuickBundlesX
-- New Tractometry tools : Bundle Analysis / Bundle Profiles
-- New reconstruction model: IVIM Mix
-- New command line interface: Affine and Diffeomorphic Registration
-- New command line interface: Probabilistic, Deterministic and PFT Tracking
-- Integration of Cython Guidelines for developers
-- Replacement of Nose by Pytest
+- Horizon, medical visualization interface powered by QuickBundlesX.
+- New Tractometry tools: Bundle Analysis / Bundle Profiles.
+- New reconstruction model: IVIM MIX.
+- New command line interface: Affine and Diffeomorphic Registration.
+- New command line interface: Probabilistic, Deterministic and PFT Tracking.
+- Integration of Cython Guidelines for developers.
+- Replacement of Nose by Pytest.
 - Documentation update.
 - Closed 103 issues and merged 41 pull requests.
 

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -9,8 +9,8 @@ docs.  In setup.py in particular, we exec this file, so it cannot import dipy
 _version_major = 0
 _version_minor = 16
 _version_micro = 0
-# _version_extra = 'dev'
-_version_extra = ''
+_version_extra = 'dev'
+# _version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -9,8 +9,8 @@ docs.  In setup.py in particular, we exec this file, so it cannot import dipy
 _version_major = 0
 _version_minor = 16
 _version_micro = 0
-_version_extra = 'dev'
-# _version_extra = ''
+# _version_extra = 'dev'
+_version_extra = ''
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 __version__ = "%s.%s.%s%s" % (_version_major,

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -10,7 +10,7 @@ DIPY 0.16 Changes
 
 **Stats**
 
-Welcome to the new module ``dipy.viz.stats``. This module will be use to integrate various analysis.
+Welcome to the new module ``dipy.viz.stats``. This module will be used to integrate various analysis.
 
 **Tracking**
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,6 +5,10 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
+DIPY 0.16 Changes
+-----------------
+
+
 DIPY 0.15 Changes
 -----------------
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -8,6 +8,19 @@ renamed or are deprecated (not recommended) during different release circles.
 DIPY 0.16 Changes
 -----------------
 
+**Stats**
+
+Welcome to the new module ``dipy.viz.stats``. This module will be use to integrate various analysis.
+
+**Tracking**
+
+- New option to adjust number of threads for SLR in Recobundles
+- The tracking algoritm excludes the stop point inside the mask during tracking process.
+
+**Notes**
+
+- Replacement of Nose by Pytest
+
 
 DIPY 0.15 Changes
 -----------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,7 @@ Highlights
 - New Tractometry tools : Bundle Analysis / Bundle Profiles
 - New reconstruction model: IVIM Mix
 - New command line interface: Affine and Diffeomorphic Registration
-- New command line interface: Probalistic, Deterministic and PFT Tracking
+- New command line interface: Probabilistic, Deterministic and PFT Tracking
 - Integration of Cython Guidelines for developers
 - Replacement of Nose by Pytest
 - Documentation update.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,13 +15,13 @@ Highlights
 
 **DIPY 0.16.0** is now available. New features include:
 
-- Horizon, medical visualization interface powered by QuickBundlesX
-- New Tractometry tools : Bundle Analysis / Bundle Profiles
-- New reconstruction model: IVIM Mix
-- New command line interface: Affine and Diffeomorphic Registration
-- New command line interface: Probabilistic, Deterministic and PFT Tracking
-- Integration of Cython Guidelines for developers
-- Replacement of Nose by Pytest
+- Horizon, medical visualization interface powered by QuickBundlesX.
+- New Tractometry tools: Bundle Analysis / Bundle Profiles.
+- New reconstruction model: IVIM MIX.
+- New command line interface: Affine and Diffeomorphic Registration.
+- New command line interface: Probabilistic, Deterministic and PFT Tracking.
+- Integration of Cython Guidelines for developers.
+- Replacement of Nose by Pytest.
 - Documentation update.
 - Closed 103 issues and merged 41 pull requests.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,7 @@ Highlights
 
 **DIPY 0.16.0** is now available. New features include:
 
-- Horizon, fast, modular, unified and adaptive visualization
+- Horizon, medical visualization interface powered by QuickBundlesX
 - New Tractometry tools : Bundle Analysis / Bundle Profiles
 - New reconstruction model: IVIM Mix
 - New command line interface: Affine and Diffeomorphic Registration

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,18 +13,11 @@ visualization, and statistical analysis of MRI data.
 Highlights
 **********
 
-**DIPY 0.15.0** is now available. New features include:
+**DIPY 0.16.0** is now available. New features include:
 
-- Updated RecoBundles for automatic anatomical bundle segmentation.
-- New Reconstruction Model: qtau-dMRI.
-- New command line interfaces (e.g. dipy_slr).
-- New continuous integration with AppVeyor CI.
-- Nibabel Streamlines API now used almost everywhere for better memory management.
-- Compatibility with Python 3.7.
-- Many tutorials added or updated (5 New).
-- Large documentation update.
-- Moved visualization module to a new library: FURY.
-- Closed 287 issues and merged 93 pull requests. 
+-
+-
+-
 
 See :ref:`Older Highlights <old_highlights>`.
 
@@ -38,10 +31,10 @@ Announcements
   <div style="width: 80% max-width=800px">
     <a href="https://workshop.dipy.org/" target="_blank"><img alt=" " class="align-center" src="_static/dipy-ws-header.png" style="width: 90%;max-height: 90%"></a>
   </div>
+- :ref:`DIPY 0.16 <release_notes/release0.16>` released March 8, 2019.
 - :ref:`DIPY 0.15 <release_notes/release0.15>` released December 12, 2018.
 - :ref:`DIPY 0.14 <release_notes/release0.14>` released May 1, 2018.
 - :ref:`DIPY 0.13 <release_notes/release0.13>` released October 24, 2017.
-- :ref:`DIPY 0.12 <release_notes/release0.12>` released June 26, 2017.
 
 See some of our :ref:`Past Announcements <old_news>`
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,7 @@ Highlights
 
 - Horizon, medical visualization interface powered by QuickBundlesX.
 - New Tractometry tools: Bundle Analysis / Bundle Profiles.
-- New reconstruction model: IVIM MIX.
+- New reconstruction model: IVIM MIX (Variable Projection).
 - New command line interface: Affine and Diffeomorphic Registration.
 - New command line interface: Probabilistic, Deterministic and PFT Tracking.
 - Integration of Cython Guidelines for developers.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,9 +15,15 @@ Highlights
 
 **DIPY 0.16.0** is now available. New features include:
 
--
--
--
+- Horizon, fast, modular, unified and adaptive visualization
+- New Tractometry tools : Bundle Analysis / Bundle Profiles
+- New reconstruction model: IVIM Mix
+- New command line interface: Affine and Diffeomorphic Registration
+- New command line interface: Probalistic, Deterministic and PFT Tracking
+- Integration of Cython Guidelines for developers
+- Replacement of Nose by Pytest
+- Documentation update.
+- Closed 103 issues and merged 41 pull requests.
 
 See :ref:`Older Highlights <old_highlights>`.
 
@@ -31,7 +37,7 @@ Announcements
   <div style="width: 80% max-width=800px">
     <a href="https://workshop.dipy.org/" target="_blank"><img alt=" " class="align-center" src="_static/dipy-ws-header.png" style="width: 90%;max-height: 90%"></a>
   </div>
-- :ref:`DIPY 0.16 <release_notes/release0.16>` released March 8, 2019.
+- :ref:`DIPY 0.16 <release_notes/release0.16>` released March 10, 2019.
 - :ref:`DIPY 0.15 <release_notes/release0.15>` released December 12, 2018.
 - :ref:`DIPY 0.14 <release_notes/release0.14>` released May 1, 2018.
 - :ref:`DIPY 0.13 <release_notes/release0.13>` released October 24, 2017.

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -17,6 +17,19 @@ Older Highlights
 - Moved visualization module to a new library: FURY.
 - Closed 287 issues and merged 93 pull requests. 
 
+**DIPY 0.14** is now available. New features include:
+
+- RecoBundles: anatomically relevant segmentation of bundles
+- New super fast clustering algorithm: QuickBundlesX
+- New tracking algorithm: Particle Filtering Tracking.
+- New tracking algorithm: Probabilistic Residual Bootstrap Tracking.
+- Integration of the Streamlines API for reading, saving and processing tractograms.
+- Fiber ORientation Estimated using Continuous Axially Symmetric Tensors (Forecast).
+- New command line interfaces.
+- Deprecated fvtk (old visualization framework).
+- A range of new visualization improvements.
+- Large documentation update.
+
 **DIPY 0.13.0** is now available. New features include:
 
 - Faster local PCA implementation.

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -4,6 +4,19 @@
 Older Highlights
 ****************
 
+**DIPY 0.15.0** is now available. New features include:
+
+- Updated RecoBundles for automatic anatomical bundle segmentation.
+- New Reconstruction Model: qtau-dMRI.
+- New command line interfaces (e.g. dipy_slr).
+- New continuous integration with AppVeyor CI.
+- Nibabel Streamlines API now used almost everywhere for better memory management.
+- Compatibility with Python 3.7.
+- Many tutorials added or updated (5 New).
+- Large documentation update.
+- Moved visualization module to a new library: FURY.
+- Closed 287 issues and merged 93 pull requests. 
+
 **DIPY 0.13.0** is now available. New features include:
 
 - Faster local PCA implementation.

--- a/doc/release_notes/release0.16.rst
+++ b/doc/release_notes/release0.16.rst
@@ -1,0 +1,140 @@
+.. _release0.16:
+
+====================================
+ Release notes for DIPY version 0.16
+====================================
+
+GitHub stats for 2018/12/12 - 2019/03/10 (tag: 0.15.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 14 authors contributed 361 commits.
+
+* Ariel Rokem
+* Bramsh Qamar
+* Clément Zotti
+* Eleftherios Garyfallidis
+* Francois Rheault
+* Gabriel Girard
+* Jean-Christophe Houde
+* Jon Haitz Legarreta Gorroño
+* Katrin Leinweber
+* Kesshi Jordan
+* Parichit Sharma
+* Serge Koudoro
+* Shreyas Fadnavis
+* Yijun Liu
+
+
+We closed a total of 103 issues, 41 pull requests and 62 regular issues;
+this is the full list (generated with the script 
+:file:`tools/github_stats.py`):
+
+Pull Requests (41):
+
+* :ghpull:`1755`: Bundle Analysis and Linear mixed Models Workflows
+* :ghpull:`1748`: [REBASED ] Symmetric Diffeomorphic registration workflow
+* :ghpull:`1714`: DOC: Add Cython style guideline for DIPY.
+* :ghpull:`1726`: IVIM MIX Model (MicroLearn)
+* :ghpull:`1753`: BF: Fixes #1751, by adding a `scale` key-word arg to `decfa`
+* :ghpull:`1743`: Horizon
+* :ghpull:`1749`: [Fix] Tutorial syntax
+* :ghpull:`1739`: IVIM Workflow
+* :ghpull:`1695`: A few tractometry functions 
+* :ghpull:`1741`: [Fix]  Pre-build : From relative to absolute import
+* :ghpull:`1742`: [REBASED] Apply Transform Workflow
+* :ghpull:`1745`: Adjust number of threads for SLR in Recobundles
+* :ghpull:`1746`: [DOC] Add NIH to sponsor list
+* :ghpull:`1735`: [Rebase] Affine Registration Workflow with Supporting Quality Metrics 
+* :ghpull:`1738`: [FIX] Python 3 compatibility for some tools script
+* :ghpull:`1740`: [FIX] mapmri  with cvxpy 1.0.15
+* :ghpull:`1730`: [Fix] Cython syntax error
+* :ghpull:`1666`: Remove the points added oustide of a mask. Fix the related tests.
+* :ghpull:`1737`: Doc Fix
+* :ghpull:`1733`: Minor Doc Fix
+* :ghpull:`1732`: MAIIncrement Python version for testing to 3.6
+* :ghpull:`1716`: DOC: Add `Imports` section on package shorthands recommendations.
+* :ghpull:`1640`: Workflows - Adding PFT, probabilistic, closestpeaks tracking
+* :ghpull:`1652`: Switching tests to pytest
+* :ghpull:`1720`: [WIP] DIPY Workshop link on current website
+* :ghpull:`1719`: BF: Syntax fix example images not rendering
+* :ghpull:`1715`: DOC: Avoid the bullet points being interpreted as quoted blocks.
+* :ghpull:`1706`: BUG: Fix Cython one-liner non-trivial type declaration warnings.
+* :ghpull:`1705`: BUG: Fix Numpy `.random.random_integer` deprecation warning.
+* :ghpull:`1704`: DOC: Fix typo in `linear_fascicle_evaluation.py` script.
+* :ghpull:`1701`: BUG: Fix Sphinx math notation documentation warnings.
+* :ghpull:`1707`: BUG: Address `numpy.matrix` `PendingDeprecation` warnings.
+* :ghpull:`1703`: BUG: Fix blank image being recorded at `linear_fascicle_evaluation.py`.
+* :ghpull:`1700`: DOC: Use triple double-quoted strings for docstrings.
+* :ghpull:`1708`: BF: Clip the values before passing to arccos, instead of fixing nans.
+* :ghpull:`1710`: DOC: fix typo in instruction below sample snippet 
+* :ghpull:`1702`: BUG: Fix `dipy.io.trackvis` deprecation warnings.
+* :ghpull:`1697`: Hyperlink DOIs to preferred resolver
+* :ghpull:`1696`: Transfer release notes to a specific folder
+* :ghpull:`1690`: Typo in release notes
+* :ghpull:`1693`: Changed the GSoC conduction years
+
+Issues (62):
+
+* :ghissue:`1757`: NI Learn info from sensors designed to acseptible eeg format?
+* :ghissue:`1755`: Bundle Analysis and Linear mixed Models Workflows
+* :ghissue:`1748`: [REBASED ] Symmetric Diffeomorphic registration workflow
+* :ghissue:`1714`: DOC: Add Cython style guideline for DIPY.
+* :ghissue:`1726`: IVIM MIX Model (MicroLearn)
+* :ghissue:`1751`: Scale values in `decfa`
+* :ghissue:`1753`: BF: Fixes #1751, by adding a `scale` key-word arg to `decfa`
+* :ghissue:`1754`: DeprecationWarning: This function is deprecated. Please call randint(0, 10000 + 1) instead    C:\Users\ranji\Anaconda3\lib\site-packages\ipykernel_launcher.py:14: DeprecationWarning: `imsave` is deprecated! `imsave` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use ``imageio.imwrite`` instead.
+* :ghissue:`1743`: Horizon
+* :ghissue:`1749`: [Fix] Tutorial syntax
+* :ghissue:`1616`: Implementing the Diffeomorphic registration 
+* :ghissue:`1739`: IVIM Workflow
+* :ghissue:`1695`: A few tractometry functions 
+* :ghissue:`1741`: [Fix]  Pre-build : From relative to absolute import
+* :ghissue:`1742`: [REBASED] Apply Transform Workflow
+* :ghissue:`1745`: Adjust number of threads for SLR in Recobundles
+* :ghissue:`1746`: [DOC] Add NIH to sponsor list
+* :ghissue:`1605`: Cleaned PR for Apply Transform Workflow to quickly register a set of moving NIFTI images using a given affine matrix.
+* :ghissue:`1735`: [Rebase] Affine Registration Workflow with Supporting Quality Metrics 
+* :ghissue:`1738`: [FIX] Python 3 compatibility for some tools script
+* :ghissue:`1740`: [FIX] mapmri  with cvxpy 1.0.15
+* :ghissue:`1730`: [Fix] Cython syntax error
+* :ghissue:`1661`: Local Tracking - BinaryTissueClassifier - dropping the last point
+* :ghissue:`1666`: Remove the points added oustide of a mask. Fix the related tests.
+* :ghissue:`1737`: Doc Fix
+* :ghissue:`1604`: Cleaned PR for Affine Registration Workflow with Supporting Quality Metrics
+* :ghissue:`1734`: Documentation Error
+* :ghissue:`1733`: Minor Doc Fix
+* :ghissue:`1565`: New warnings with `PRE=1`
+* :ghissue:`1732`: MAIIncrement Python version for testing to 3.6
+* :ghissue:`1716`: DOC: Add `Imports` section on package shorthands recommendations.
+* :ghissue:`1640`: Workflows - Adding PFT, probabilistic, closestpeaks tracking
+* :ghissue:`1729`: N3/N4 Bias correction?
+* :ghissue:`1652`: Switching tests to pytest
+* :ghissue:`1280`: Switch testing to pytest?
+* :ghissue:`1727`: Upgrade Scipy for MIX framework?
+* :ghissue:`1723`: Failure on 
+* :ghissue:`1720`: [WIP] DIPY Workshop link on current website
+* :ghissue:`1718`: cannot import name window
+* :ghissue:`1719`: BF: Syntax fix example images not rendering
+* :ghissue:`1717`: cannot import packages of dipy.viz
+* :ghissue:`1715`: DOC: Avoid the bullet points being interpreted as quoted blocks.
+* :ghissue:`1706`: BUG: Fix Cython one-liner non-trivial type declaration warnings.
+* :ghissue:`1705`: BUG: Fix Numpy `.random.random_integer` deprecation warning.
+* :ghissue:`1664`: Deprecation warnings on testing
+* :ghissue:`1704`: DOC: Fix typo in `linear_fascicle_evaluation.py` script.
+* :ghissue:`1701`: BUG: Fix Sphinx math notation documentation warnings.
+* :ghissue:`1707`: BUG: Address `numpy.matrix` `PendingDeprecation` warnings.
+* :ghissue:`1633`: Blank png saved/displayed on documentation
+* :ghissue:`1703`: BUG: Fix blank image being recorded at `linear_fascicle_evaluation.py`.
+* :ghissue:`1700`: DOC: Use triple double-quoted strings for docstrings.
+* :ghissue:`1708`: BF: Clip the values before passing to arccos, instead of fixing nans.
+* :ghissue:`1698`: test failure in travis
+* :ghissue:`1710`: DOC: fix typo in instruction below sample snippet 
+* :ghissue:`1702`: BUG: Fix `dipy.io.trackvis` deprecation warnings.
+* :ghissue:`1697`: Hyperlink DOIs to preferred resolver
+* :ghissue:`1696`: Transfer release notes to a specific folder
+* :ghissue:`1691`: Doc folder for release notes
+* :ghissue:`1690`: Typo in release notes
+* :ghissue:`1693`: Changed the GSoC conduction years
+* :ghissue:`1692`: Minor doc fix
+* :ghissue:`1632`: Link broken on website

--- a/doc/stateoftheart.rst
+++ b/doc/stateoftheart.rst
@@ -28,6 +28,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/release0.16
    release_notes/release0.15
    release_notes/release0.14
    release_notes/release0.13


### PR DESCRIPTION
# Summary

Preparation for 0.16.0 release, targeting Friday, March 8.  The last 0.X.X series. DIPY 1.0.0 in June!!!

It will be good to merge the following PR before the release on Friday.

- [x] #1748 (@skoudoro)
- [x] #1743 (@Garyfallidis )
- [x] #1714 (@jhlegarreta ) 
- [ ] #1230 (@RafaelNH )
- [x] #1726 (@ShreyasFadnavis)
- your suggestion ?

Just a note that any of this PR can block the release. If they are not in, it will be for the next release in
june.

# Release checklist
- [x] add release_notes 0.16.0
- [x] Update changelog an api_changes
- [x] Update .mailmap
- [x] Set release number in info.py and doc/conf.py
- [x] Check the copyright years in doc/conf.py and LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Update Highligth.rst, old_news.rst, stateofheart.rst
- [x] Update developers.rst list