### PR TITLE
BF: changes min_signal defaults from 1 to 1e-5

### DIFF
--- a/dipy/reconst/shm.py
+++ b/dipy/reconst/shm.py
@@ -507,7 +507,7 @@ class SphHarmModel(OdfModel, Cache):
 
 class QballBaseModel(SphHarmModel):
     """To be subclassed by Qball type models."""
-    def __init__(self, gtab, sh_order, smooth=0.006, min_signal=1.,
+    def __init__(self, gtab, sh_order, smooth=0.006, min_signal=1e-5,
                  assume_normed=False):
         """Creates a model that can be used to fit or sample diffusion data
 
@@ -733,7 +733,7 @@ class QballModel(QballBaseModel):
         return dot(data[..., self._where_dwi], self._fit_matrix.T)
 
 
-def normalize_data(data, where_b0, min_signal=1., out=None):
+def normalize_data(data, where_b0, min_signal=1e-5, out=None):
     """Normalizes the data with respect to the mean b0
     """
     if out is None:
@@ -825,7 +825,7 @@ class ResidualBootstrapWrapper(object):
     There wrapper than samples the residual boostrap distribution of signal and
     returns that sample.
     """
-    def __init__(self, signal_object, B, where_dwi, min_signal=1.):
+    def __init__(self, signal_object, B, where_dwi, min_signal=1e-5):
         """Builds a ResidualBootstrapWapper
 
         Given some linear model described by B, the design matrix, and a

--- a/dipy/reconst/tests/test_shm.py
+++ b/dipy/reconst/tests/test_shm.py
@@ -265,6 +265,14 @@ class TestQballModel(object):
         fit = model.fit(signal, mask)
         assert_array_equal(fit.gfa, 0)
 
+    def test_min_signal_default(self):
+        signal, gtab, expected = make_fake_signal()
+        model_default = self.model(gtab, 4)
+        shm_default = model_default.fit(signal).shm_coeff
+        model_correct = self.model(gtab, 4, min_signal=1e-5)
+        shm_correct = model_correct.fit(signal).shm_coeff
+        assert_equal(shm_default, shm_correct)
+
 
 def test_SphHarmFit():
     coef = np.zeros((3, 4, 5, 45))


### PR DESCRIPTION
Addresses https://github.com/nipy/dipy/issues/1763

The default value for `min_signal` in all Q-ball models in reconst/shm.py is set to 1. This causes all ODFs to be reconstructed the same if the data happens to be between [0,1] prior to reconstruction. 

I checked the history, and at some point in the past, the default was set to 1e-5. I'm assuming there was a reason it was changed up to 1.0, but as far as I know, changing it back to 1e-5 shouldn't affect the stability.