### PR TITLE
[Fix] stripping in workflow documentation

### DIFF
--- a/dipy/workflows/base.py
+++ b/dipy/workflows/base.py
@@ -140,7 +140,7 @@ class IntrospectiveArgumentParser(argparse.ArgumentParser):
 
             typestr = self.doc[i][1]
             dtype, isnarg = self._select_dtype(typestr)
-            help_msg = ''.join(self.doc[i][2])
+            help_msg = ' '.join(self.doc[i][2])
 
             _args = ['{0}{1}'.format(prefix, arg)]
             _kwargs = {'help': help_msg,


### PR DESCRIPTION
this PR should fix @jchoude [comment](https://github.com/nipy/dipy/issues/1793#issuecomment-476027822) concerning the line break strips the space.
Reference: #1793

Before (look at positional args documentation):

![image](https://user-images.githubusercontent.com/23106443/55093170-45e73500-508a-11e9-807a-3dae3fe146fa.png)

After (look at positional args documentation):

![image](https://user-images.githubusercontent.com/23106443/55093198-5dbeb900-508a-11e9-9710-7040ebb0222c.png)
