### PR TITLE
BF: added check to avoid infinite loop on consecutive coordinates.

### DIFF
--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -267,6 +267,10 @@ cdef cnp.npy_intp _streamline_in_mask(
         direction_norm = norm(direction[0], direction[1], direction[2])
         remaining_distance = direction_norm
 
+        # If consecutive coordinates are the same, skip one.
+        if direction_norm == 0:
+            continue
+
         # Check if it's already a real edge. If not, find the closest edge.
         if floor(current_edge[0]) != current_edge[0] and \
            floor(current_edge[1]) != current_edge[1] and \


### PR DESCRIPTION
In the `_streamline_in_mask` function, if two or more consecutive points shared exactly the same coordinates, the loop would never finish. Added a quick check on the distance to avoid such case.

This is a test that is already present in our in house code and has been tested extensively.