### PR TITLE
[Bug FIx]  dipy_fit_csa and dipy_fit_csd workflow

### DIFF
--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -443,7 +443,7 @@ class ReconstCSDFlow(Workflow):
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the
             calibration procedure. Default: False
-        nbr_processes: int, optional
+        nbr_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
             (default multiprocessing.cpu_count()).
         out_dir : string, optional
@@ -610,7 +610,7 @@ class ReconstCSAFlow(Workflow):
         parallel : bool, optional
             Whether to use parallelization in peak-finding during the
             calibration procedure. Default: False
-        nbr_processes: int, optional
+        nbr_processes : int, optional
             If `parallel` is True, the number of subprocesses to use
             (default multiprocessing.cpu_count()).
         out_dir : string, optional


### PR DESCRIPTION
This should fix #1808. It was an error during doc parsing. NumpyDoc seems sensitive to space after the semicolon. Good to know for a future review.

@arokem, Can you test it? Thank you