### PR TITLE
[FIX] median_otsu deprecated parameter

### DIFF
--- a/dipy/core/histeq.py
+++ b/dipy/core/histeq.py
@@ -19,7 +19,7 @@ def histeq(arr, num_bins=256):
         Histogram equalized image.
     """
     # get image histogram
-    histo, bins = np.histogram(arr.flatten(), num_bins, normed=True)
+    histo, bins = np.histogram(arr.flatten(), num_bins, density=True)
     cdf = histo.cumsum()
     cdf = 255 * cdf / cdf[-1]
 


### PR DESCRIPTION
This PR should fix #1761. As you can see on [numpy documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram.html), `normed` parameter has been deprecated and superseded by `density` since a long time. 
