### PR TITLE
Remove Deprecated function  dipy.data.get_data

### DIFF
--- a/dipy/align/tests/test_imaffine.py
+++ b/dipy/align/tests/test_imaffine.py
@@ -8,7 +8,6 @@ from numpy.testing import (assert_array_equal,
                            assert_equal,
                            assert_raises)
 from dipy.core import geometry as geometry
-from dipy.data import get_data
 from dipy.viz import regtools as rt
 from dipy.align import floating
 from dipy.align import vector_fields as vf

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -294,16 +294,6 @@ def get_fnames(name='small_64D'):
         return pjoin(DATA_DIR, 't1_coronal_slice.npy')
 
 
-def get_data(name='small_64D'):
-    """Deprecate function."""
-    warnings.warn("The `dipy.data.get_data` function is deprecated as of" +
-                  " version 0.15 of Dipy and will be removed in a future" +
-                  " version. Please use `dipy.data.get_fnames` function" +
-                  " instead",
-                  DeprecationWarning)
-    return get_fnames(name)
-
-
 def _gradient_from_file(filename):
     """Reads a gradient file saved as a text file compatible with np.loadtxt
     and saved in the dipy data directory"""

--- a/dipy/reconst/tests/test_peak_finding.py
+++ b/dipy/reconst/tests/test_peak_finding.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 from dipy.reconst.recspeed import (local_maxima, remove_similar_vertices,
                                    search_descending)
-from dipy.data import get_sphere, get_data
+from dipy.data import get_sphere
 from dipy.core.sphere import unique_edges, HemiSphere
 from dipy.sims.voxel import all_tensor_evecs
 

--- a/doc/examples/reconst_shore_metrics.py
+++ b/doc/examples/reconst_shore_metrics.py
@@ -15,7 +15,7 @@ import nibabel as nib
 import numpy as np
 import matplotlib.pyplot as plt
 from dipy.data import fetch_taiwan_ntu_dsi, read_taiwan_ntu_dsi, get_sphere
-from dipy.data import get_data, dsi_voxels
+from dipy.data import dsi_voxels
 from dipy.reconst.shore import ShoreModel
 
 """


### PR DESCRIPTION
This PR is the first of a long series to remove all deprecated function/module in DIPY.

`get_data` has been replaced by `get_fnames`