### PR TITLE
Remove deprecated module dipy.reconst.peaks

### DIFF
--- a/dipy/reconst/peaks.py
+++ b/dipy/reconst/peaks.py
@@ -1,7 +1,0 @@
-import warnings
-
-w_s = "The module 'dipy.reconst.peaks' is deprecated."
-w_s += " Please use the module 'dipy.direction.peaks' instead"
-warnings.warn(w_s, DeprecationWarning)
-
-from dipy.direction.peaks import *

--- a/doc/examples/streamline_tools.py
+++ b/doc/examples/streamline_tools.py
@@ -19,7 +19,8 @@ modules and download the data we'll be using.
 """
 
 from dipy.tracking.eudx import EuDX
-from dipy.reconst import peaks, shm
+from dipy.reconst import shm
+from dipy.direction import peaks
 from dipy.tracking import utils
 from dipy.tracking.streamline import Streamlines
 


### PR DESCRIPTION
This PR removes the deprecated module `dipy.reconst.peaks`. This module has been replaced by `dipy.direction.peaks`.