### PR TITLE
[Fix]  Workflow mask documentation

### DIFF
--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -242,7 +242,7 @@ class ReconstDtiFlow(Workflow):
             multiple bvectors files at once.
         mask_files : string
             Path to the input masks. This path may contain wildcards to use
-            multiple masks at once. 
+            multiple masks at once.
         b0_threshold : float, optional
             Threshold used to find b=0 directions (default 0.0)
         bvecs_tol : float, optional

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -242,7 +242,7 @@ class ReconstDtiFlow(Workflow):
             multiple bvectors files at once.
         mask_files : string
             Path to the input masks. This path may contain wildcards to use
-            multiple masks at once. (default: No mask used)
+            multiple masks at once. 
         b0_threshold : float, optional
             Threshold used to find b=0 directions (default 0.0)
         bvecs_tol : float, optional


### PR DESCRIPTION
As discussed with @jchoude, the goal of this PR is to fix #1764. The docstring was not coherent with the current behavior. Indeed, `mask` is mandatory for all reconstruction workflow.



