### PR TITLE
Corrected median_otsu function declaration that was breaking tutorials

### DIFF
--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -119,8 +119,8 @@ def crop(vol, mins, maxs):
     return vol[tuple(slice(i, j) for i, j in zip(mins, maxs))]
 
 
-def median_otsu(input_volume, median_radius=4, numpass=4,
-                autocrop=False, vol_idx=None, dilate=None):
+def median_otsu(input_volume, vol_idx=None, median_radius=4, numpass=4,
+                autocrop=False, dilate=None):
     """Simple brain extraction tool method for images from DWI data.
 
     It uses a median filter smoothing of the input_volumes `vol_idx` and an

--- a/dipy/segment/mask.py
+++ b/dipy/segment/mask.py
@@ -119,8 +119,8 @@ def crop(vol, mins, maxs):
     return vol[tuple(slice(i, j) for i, j in zip(mins, maxs))]
 
 
-def median_otsu(input_volume, vol_idx=None, median_radius=4, numpass=4,
-                autocrop=False, dilate=None):
+def median_otsu(input_volume, median_radius=4, numpass=4,
+                autocrop=False, vol_idx=None, dilate=None):
     """Simple brain extraction tool method for images from DWI data.
 
     It uses a median filter smoothing of the input_volumes `vol_idx` and an

--- a/doc/examples/brain_extraction_dwi.py
+++ b/doc/examples/brain_extraction_dwi.py
@@ -85,7 +85,8 @@ smaller. Auto-cropping in ``median_otsu`` is activated by setting the
 ``autocrop`` parameter to ``True``.
 """
 
-b0_mask_crop, mask_crop = median_otsu(data, median_radius=4, numpass=4, autocrop=True)
+b0_mask_crop, mask_crop = median_otsu(data, median_radius=4, numpass=4,
+                                      autocrop=True)
 
 """
 Saving cropped data using nibabel as demonstrated previously.

--- a/doc/examples/brain_extraction_dwi.py
+++ b/doc/examples/brain_extraction_dwi.py
@@ -38,7 +38,7 @@ parameters work well on most volumes. For this example, we used 2 as
 """
 
 from dipy.segment.mask import median_otsu
-b0_mask, mask = median_otsu(data, 2, 1)
+b0_mask, mask = median_otsu(data, median_radius=2, numpass=1)
 
 """
 Saving the segmentation results is very easy using nibabel. We need the
@@ -85,7 +85,7 @@ smaller. Auto-cropping in ``median_otsu`` is activated by setting the
 ``autocrop`` parameter to ``True``.
 """
 
-b0_mask_crop, mask_crop = median_otsu(data, 4, 4, autocrop=True)
+b0_mask_crop, mask_crop = median_otsu(data, median_radius=4, numpass=4, autocrop=True)
 
 """
 Saving cropped data using nibabel as demonstrated previously.

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -41,8 +41,8 @@ Remove most of the background using DIPY's mask module.
 from dipy.segment.mask import median_otsu
 
 
-maskdata, mask = median_otsu(data, 3, 1, True,
-                             vol_idx=range(10, 50), dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,
+                             autocrop=True, dilate=2)
 
 """
 We instantiate our CSA model with spherical harmonic order of 4

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -41,8 +41,8 @@ Remove most of the background using DIPY's mask module.
 from dipy.segment.mask import median_otsu
 
 
-maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,
-                             autocrop=True, dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3,
+                             numpass=1, autocrop=True, dilate=2)
 
 """
 We instantiate our CSA model with spherical harmonic order of 4

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -20,8 +20,8 @@ img, gtab = read_stanford_hardi()
 
 data = img.get_data()
 
-maskdata, mask = median_otsu(data, 3, 1, True,
-                             vol_idx=range(10, 50), dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,    
+                             autocrop=True, dilate=2)
 
 """
 We instantiate our CSA model with spherical harmonic order of 4

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -20,7 +20,7 @@ img, gtab = read_stanford_hardi()
 
 data = img.get_data()
 
-maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, 
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3,
                              numpass=1, autocrop=True, dilate=2)
 
 """

--- a/doc/examples/reconst_csa_parallel.py
+++ b/doc/examples/reconst_csa_parallel.py
@@ -20,8 +20,8 @@ img, gtab = read_stanford_hardi()
 
 data = img.get_data()
 
-maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,    
-                             autocrop=True, dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, 
+                             numpass=1, autocrop=True, dilate=2)
 
 """
 We instantiate our CSA model with spherical harmonic order of 4

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -22,8 +22,8 @@ data = img.get_data()
 
 from dipy.segment.mask import median_otsu
 
-maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,
-                             autocrop=False, dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3,
+                             numpass=1, autocrop=False, dilate=2)
 
 from dipy.reconst.csdeconv import auto_response
 

--- a/doc/examples/reconst_csd_parallel.py
+++ b/doc/examples/reconst_csd_parallel.py
@@ -22,8 +22,8 @@ data = img.get_data()
 
 from dipy.segment.mask import median_otsu
 
-maskdata, mask = median_otsu(data, 3, 1, False,
-                             vol_idx=range(10, 50), dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,
+                             autocrop=False, dilate=2)
 
 from dipy.reconst.csdeconv import auto_response
 

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -95,7 +95,8 @@ Before fitting the data, we preform some data pre-processing. We first compute
 a brain mask to avoid unnecessary calculations on the background of the image.
 """
 
-maskdata, mask = median_otsu(data, 4, 2, False, vol_idx=[0, 1], dilate=1)
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2,
+                             autocrop=False, dilate=1)
 
 """
 Since the diffusion kurtosis models involves the estimation of a large number

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -102,8 +102,8 @@ calculating Tensors on the background of the image. This is done using DIPY_'s
 
 from dipy.segment.mask import median_otsu
 
-maskdata, mask = median_otsu(data, 3, 1, True,
-                             vol_idx=range(10, 50), dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,
+                             autocrop=True, dilate=2)
 print('maskdata.shape (%d, %d, %d, %d)' % maskdata.shape)
 
 """

--- a/doc/examples/reconst_dti.py
+++ b/doc/examples/reconst_dti.py
@@ -102,8 +102,8 @@ calculating Tensors on the background of the image. This is done using DIPY_'s
 
 from dipy.segment.mask import median_otsu
 
-maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,
-                             autocrop=True, dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3,
+                             numpass=1, autocrop=True, dilate=2)
 print('maskdata.shape (%d, %d, %d, %d)' % maskdata.shape)
 
 """

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -70,7 +70,8 @@ The free water DTI model can take some minutes to process the full data set.
 Thus, we remove the background of the image to avoid unnecessary calculations.
 """
 
-maskdata, mask = median_otsu(data, 4, 2, False, vol_idx=[0, 1], dilate=1)
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2,
+                             autocrop=False, dilate=1)
 
 """
 Moreover, for illustration purposes we process only an axial slice of the

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -240,7 +240,8 @@ For example, some state of the art denoising algorithms are available in DIPY_
 local pca :ref:`example-denoise-localpca`).
 """
 
-maskdata, mask = median_otsu(data, 4, 2, False, vol_idx=[0, 1], dilate=1)
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2,
+                             autocrop=False, dilate=1)
 
 """
 Now that we have loaded and pre-processed the data we can go forward

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -149,7 +149,7 @@ data = np.array(b0.get_data(), dtype=np.float64)
 We first remove the skull from the b0 volume
 """
 
-b0_mask, mask = median_otsu(data, 4, 4)
+b0_mask, mask = median_otsu(data, median_radius=4, numpass=4)
 
 """
 And select two slices to try the 2D registration

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -42,9 +42,9 @@ We first remove the skull from the b0's
 """
 
 from dipy.segment.mask import median_otsu
-stanford_b0_masked, stanford_b0_mask = median_otsu(data, median_radius=4,
+stanford_b0_masked, stanford_b0_mask = median_otsu(stanford_b0, median_radius=4,
                                                    numpass=4)
-syn_b0_masked, syn_b0_mask = median_otsu(data, median_radius=4, numpass=4)
+syn_b0_masked, syn_b0_mask = median_otsu(syn_b0, median_radius=4, numpass=4)
 
 static = stanford_b0_masked
 static_affine = nib_stanford.affine

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -42,7 +42,8 @@ We first remove the skull from the b0's
 """
 
 from dipy.segment.mask import median_otsu
-stanford_b0_masked, stanford_b0_mask = median_otsu(data, median_radius=4, numpass=4)
+stanford_b0_masked, stanford_b0_mask = median_otsu(data, median_radius=4,
+                                                   numpass=4)
 syn_b0_masked, syn_b0_mask = median_otsu(data, median_radius=4, numpass=4)
 
 static = stanford_b0_masked

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -42,8 +42,8 @@ We first remove the skull from the b0's
 """
 
 from dipy.segment.mask import median_otsu
-stanford_b0_masked, stanford_b0_mask = median_otsu(stanford_b0, 4, 4)
-syn_b0_masked, syn_b0_mask = median_otsu(syn_b0, 4, 4)
+stanford_b0_masked, stanford_b0_mask = median_otsu(data, median_radius=4, numpass=4)
+syn_b0_masked, syn_b0_mask = median_otsu(data, median_radius=4, numpass=4)
 
 static = stanford_b0_masked
 static_affine = nib_stanford.affine

--- a/doc/examples/tracking_quick_start.py
+++ b/doc/examples/tracking_quick_start.py
@@ -50,8 +50,8 @@ default ``median_otsu`` parameters (see :ref:`example_brain_extraction_dwi`)
 therefore we use here more advanced options.
 """
 
-maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,    
-                             autocrop=False, dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3,
+                             numpass=1, autocrop=False, dilate=2)
 
 """
 For the Constrained Spherical Deconvolution we need to estimate the response

--- a/doc/examples/tracking_quick_start.py
+++ b/doc/examples/tracking_quick_start.py
@@ -50,8 +50,8 @@ default ``median_otsu`` parameters (see :ref:`example_brain_extraction_dwi`)
 therefore we use here more advanced options.
 """
 
-maskdata, mask = median_otsu(data, 3, 1, False,
-                             vol_idx=range(10, 50), dilate=2)
+maskdata, mask = median_otsu(data, vol_idx=range(10, 50), median_radius=3, numpass=1,    
+                             autocrop=False, dilate=2)
 
 """
 For the Constrained Spherical Deconvolution we need to estimate the response


### PR DESCRIPTION
The prior function declaration breaks all these tutorials that use median_otsu:
brain_extraction_dwi.py
reconst_msdki.py
reconst_dti.py
reconst_csa_parallel.py
reconst_fwdti.py
reconst_csa.py
reconst_csd_parallel.py
reconst_dki.py
syn_registration_2d.py
syn_registration_3d.py
tracking_quick_start.py

You can test this by running any of these scripts in dipy/doc/examples or here http://nipy.org/dipy/examples_built/reconst_csa.html. My modification corrects this so that all the tutorials still function normally.