### PR TITLE
Adds control for number of iterations in CSD recon

### DIFF
--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -61,7 +61,7 @@ class AxSymShResponse(object):
 class ConstrainedSphericalDeconvModel(SphHarmModel):
 
     def __init__(self, gtab, response, reg_sphere=None, sh_order=8, lambda_=1,
-                 tau=0.1):
+                 tau=0.1, convergence=50):
         r""" Constrained Spherical Deconvolution (CSD) [1]_.
 
         Spherical deconvolution computes a fiber orientation distribution
@@ -99,6 +99,8 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             zero. However, to improve the stability of the algorithm, tau is
             set to tau*100 % of the mean fODF amplitude (here, 10% by default)
             (see [1]_). Default: 0.1
+        convergence : int
+            Maximum number of iterations to allow the deconvolution to converge.
 
         References
         ----------
@@ -174,6 +176,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         self.B_reg *= lambda_
         self.sh_order = sh_order
         self.tau = tau
+        self.convergence = convergence
         self._X = X = self.R.diagonal() * self.B_dwi
         self._P = np.dot(X.T, X)
 
@@ -181,7 +184,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
     def fit(self, data):
         dwi_data = data[self._where_dwi]
         shm_coeff, _ = csdeconv(dwi_data, self._X, self.B_reg, self.tau,
-                                P=self._P)
+                                convergence=self.convergence, P=self._P)
         return SphHarmFit(self, shm_coeff, None)
 
     def predict(self, sh_coeff, gtab=None, S0=1.):

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -577,6 +577,18 @@ def test_csd_superres():
     assert_(all(cos_sim > .99))
 
 
+def test_csd_convergence():
+    """ Check existence of `convergence` keyword in CSD model """
+    _, fbvals, fbvecs = get_fnames('small_64D')
+    bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
+    gtab = gradient_table(bvals, bvecs)
+
+    evals = np.array([[1.5, .3, .3]]) * [[1.], [1.]] / 1000.
+
+    model = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
+                                            sh_order=8, convergence=50)
+
+
 if __name__ == '__main__':
     # run_module_suite()
     test_csdeconv()

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -586,9 +586,12 @@ def test_csd_convergence():
     evals = np.array([[1.5, .3, .3]]) * [[1.], [1.]] / 1000.
     S, sticks = multi_tensor(gtab, evals, snr=None, fractions=[55., 45.])
 
-    model = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
-                                            sh_order=8, convergence=50)
-    fit = model.fit(S)
+    model_w_conv = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
+                                                   sh_order=8, convergence=50)
+    model_wo_conv = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
+                                                    sh_order=8)
+
+    assert_equal(model_w_conv.fit(S).shm_coeff, model_wo_conv.fit(S).shm_coeff)
 
 
 if __name__ == '__main__':

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -584,9 +584,11 @@ def test_csd_convergence():
     gtab = gradient_table(bvals, bvecs)
 
     evals = np.array([[1.5, .3, .3]]) * [[1.], [1.]] / 1000.
+    S, sticks = multi_tensor(gtab, evals, snr=None, fractions=[55., 45.])
 
     model = ConstrainedSphericalDeconvModel(gtab, (evals[0], 3.),
                                             sh_order=8, convergence=50)
+    fit = model.fit(S)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows the user to pass the maximum number of iterations as an argument when setting up a CSD model. This functionality already existed in the `csdeconv` function, but was not accessible with a standard workflow of setting up a CSD model object, then calling the `fit` method. 