### PR TITLE
NF: Add is_hemispherical test

### DIFF
--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -1,6 +1,7 @@
 """ Utility functions for algebra etc """
 from __future__ import division, print_function, absolute_import
 
+import itertools
 import math
 import numpy as np
 import numpy.linalg as npl
@@ -1025,3 +1026,59 @@ def dist_to_corner(affine):
     R = affine[0:3, 0:3]
     vox_dim = np.diag(np.linalg.cholesky(R.T.dot(R)))
     return np.sqrt(np.sum((vox_dim / 2) ** 2))
+
+
+def is_hemispherical(vecs):
+    """Test whether all points on a unit sphere lie in the same hemisphere.
+
+    Parameters
+    ----------
+    vecs : numpy.ndarray
+        2D numpy array with shape (N, 3) where N is the number of points.
+        All points must lie on the unit sphere.
+
+    Returns
+    -------
+    is_hemi : bool
+        If True, one can find a hemisphere that contains all the points.
+        If False, then the points do not lie in any hemisphere
+
+    pole : numpy.ndarray
+        If `is_hemi == True`, then pole is the "central" pole of the
+        input vectors. Otherwise, pole is the zero vector.
+
+    References
+    ----------
+    https://rstudio-pubs-static.s3.amazonaws.com/27121_a22e51b47c544980bad594d5e0bb2d04.html  # noqa
+    """
+    if vecs.shape[1] != 3:
+        raise ValueError("Input vectors must be 3D vectors")
+    if not np.allclose(1, np.linalg.norm(vecs, axis=1)):
+        raise ValueError("Input vectors must be unit vectors")
+
+    # Generate all pairwise cross products
+    v0, v1 = zip(*[p for p in itertools.permutations(vecs, 2)])
+    cross_prods = np.cross(v0, v1)
+
+    # Normalize them
+    cross_prods /= np.linalg.norm(cross_prods, axis=1)[:, np.newaxis]
+
+    # `cross_prods` now contains all candidate vertex points for "the polygon"
+    # in the reference. "The polygon" is a subset. Find which points belong to
+    # the polygon using a dot product test with each of the original vectors
+    angles = np.arccos(np.dot(cross_prods, vecs.transpose()))
+
+    # And test whether it is orthogonal or less
+    dot_prod_test = angles <= np.pi / 2.0
+
+    # If there is at least one point that is orthogonal or less to each
+    # input vector, then the points lie on some hemisphere
+    is_hemi = len(vecs) in np.sum(dot_prod_test.astype(int), axis=1)
+
+    if is_hemi:
+        vertices = cross_prods[np.sum(dot_prod_test.astype(int), axis=1) == len(vecs)]
+        pole = np.mean(vertices, axis=0)
+        pole /= np.linalg.norm(pole)
+    else:
+        pole = np.array([0.0, 0.0, 0.0])
+    return is_hemi, pole

--- a/dipy/core/geometry.py
+++ b/dipy/core/geometry.py
@@ -1076,7 +1076,10 @@ def is_hemispherical(vecs):
     is_hemi = len(vecs) in np.sum(dot_prod_test.astype(int), axis=1)
 
     if is_hemi:
-        vertices = cross_prods[np.sum(dot_prod_test.astype(int), axis=1) == len(vecs)]
+        vertices = cross_prods[
+            np.sum(dot_prod_test.astype(int), axis=1) == len(vecs)
+        ]
+
         pole = np.mean(vertices, axis=0)
         pole /= np.linalg.norm(pole)
     else:

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -318,13 +318,22 @@ def test_dist_to_corner():
 
 
 def test_is_hemispherical():
+    # Smoke test the ValueError for non-3D vectors
+    assert_raises(ValueError, is_hemispherical, np.array(
+        [[1, 2, 3, 4], [5, 6, 7, 8]]
+    ))
+
+    # Test on hemispherical input
     xyz = random_uniform_on_sphere(n=100, coords='xyz')
     xyz = xyz[xyz[:, 2] > 0]
     assert is_hemispherical(xyz)[0]
 
+    # Test on spherical input
     xyz = random_uniform_on_sphere(n=100, coords='xyz')
     assert not is_hemispherical(xyz)[0]
 
+    # Smoke test the ValueError for non unit-vectors
+    assert_raises(ValueError, is_hemispherical, xyz * 2.0)
 
 
 if __name__ == '__main__':

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -19,13 +19,15 @@ from dipy.core.geometry import (sphere2cart, cart2sphere,
                                 compose_matrix,
                                 decompose_matrix,
                                 perpendicular_directions,
-                                dist_to_corner)
+                                dist_to_corner,
+                                is_hemispherical)
 
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_equal, assert_raises, assert_almost_equal,
                            run_module_suite)
 
 from dipy.testing.spherepoints import sphere_points
+from dipy.core.sphere_stats import random_uniform_on_sphere
 from itertools import permutations
 
 
@@ -313,6 +315,16 @@ def test_dist_to_corner():
     R = _rotation_from_angles(np.random.randn(3) * np.pi)
     new_aff = np.vstack([np.dot(R, affine[:3, :]), [0, 0, 0, 1]])
     assert_array_almost_equal(dist_to_corner(new_aff), pythagoras)
+
+
+def test_is_hemispherical():
+    xyz = random_uniform_on_sphere(n=100, coords='xyz')
+    xyz = xyz[xyz[:, 2] > 0]
+    assert is_hemispherical(xyz)[0]
+
+    xyz = random_uniform_on_sphere(n=100, coords='xyz')
+    assert not is_hemispherical(xyz)[0]
+
 
 
 if __name__ == '__main__':

--- a/dipy/core/tests/test_geometry.py
+++ b/dipy/core/tests/test_geometry.py
@@ -326,11 +326,11 @@ def test_is_hemispherical():
     # Test on hemispherical input
     xyz = random_uniform_on_sphere(n=100, coords='xyz')
     xyz = xyz[xyz[:, 2] > 0]
-    assert is_hemispherical(xyz)[0]
+    assert_equal(is_hemispherical(xyz)[0], True)
 
     # Test on spherical input
     xyz = random_uniform_on_sphere(n=100, coords='xyz')
-    assert not is_hemispherical(xyz)[0]
+    assert_equal(is_hemispherical(xyz)[0], False)
 
     # Smoke test the ValueError for non unit-vectors
     assert_raises(ValueError, is_hemispherical, xyz * 2.0)


### PR DESCRIPTION
This PR adds the `is_hemispherical()` function to `dipy.core.geometry` and adds associated unit tests. We found this function usefull in [dmriprep](https://github.com/nipy/dmriprep) to see if bvecs were collected from all points on a sphere or only hemispherically. @arokem suggested that it might by useful in other contexts and that I should add it to DIPY.