### PR TITLE
DOC: Add single-module test/coverage instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ coverage in each module: the percentage of coverage and also the lines of code
 that are not run in the tests. You can also see the test coverage in the Travis
 run corresponding to the PR (in the log for the machine with ``COVERAGE=1``).
 
+If your contributions are to a single module, you can see test and
+coverage results for only that module without running all of the DIPY
+tests. For example, if you are adding code to ``dipy/core/geometry.py``,
+you can use:
+
+    coverage run --source=dipy.core.geometry -m pytest -s --doctest-modules --verbose dipy/core/tests/test_geometry.py
+
+You can then use ``coverage report`` to view the results, or use
+``coverage html`` and open htmlcov/index.html in your browser for a
+nicely formatted interactive coverage report.
+
 Contributions to tests that extend test coverage in older modules that are not
 fully covered are very welcome!
 


### PR DESCRIPTION
This PR adds instructions for running tests and coverage reports for a single module without running the entire DIPY test suite. I found this useful for my first DIPY contributions since I was running into a lot of test errors for parts of the code base that I hadn't touched. These instructions might be more inviting to first-time contributors.