### PR TITLE
Clean up: Remove NUMPY_LESS_0.8.x

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import scipy.optimize as opt
 
-from dipy.utils.arrfuncs import pinv, eigh
+from dipy.utils.arrfuncs import pinv
 from dipy.data import get_sphere
 from dipy.core.gradients import gradient_table
 from dipy.core.geometry import vector_norm
@@ -1945,7 +1945,7 @@ def decompose_tensor(tensor, min_diffusivity=0):
 
     """
     # outputs multiplicity as well so need to unique
-    eigenvals, eigenvecs = eigh(tensor)
+    eigenvals, eigenvecs = np.linalg.eigh(tensor)
 
     # need to sort the eigenvalues and associated eigenvectors
     if eigenvals.ndim == 1:

--- a/dipy/utils/arrfuncs.py
+++ b/dipy/utils/arrfuncs.py
@@ -66,37 +66,3 @@ def pinv(a, rcond=1e-15):
     return np.einsum('...ij,...jk',
                      np.transpose(v, swap) * s[..., None, :],
                      np.transpose(u, swap))
-
-
-def eigh(a, UPLO='L'):
-    """Iterate over `np.linalg.eigh` if it doesn't support vectorized operation
-
-    Parameters
-    ----------
-    a : array_like (..., M, M)
-        Hermitian/Symmetric matrices whose eigenvalues and
-        eigenvectors are to be computed.
-    UPLO : {'L', 'U'}, optional
-        Specifies whether the calculation is done with the lower triangular
-        part of `a` ('L', default) or the upper triangular part ('U').
-
-    Returns
-    -------
-    w : ndarray (..., M)
-        The eigenvalues in ascending order, each repeated according to
-        its multiplicity.
-    v : ndarray (..., M, M)
-        The column ``v[..., :, i]`` is the normalized eigenvector corresponding
-        to the eigenvalue ``w[..., i]``.
-
-    Raises
-    ------
-    LinAlgError
-        If the eigenvalue computation does not converge.
-
-    See Also
-    --------
-    np.linalg.eigh
-    """
-    a = np.asarray(a)
-    return np.linalg.eigh(a, UPLO)

--- a/dipy/utils/tests/test_arrfuncs.py
+++ b/dipy/utils/tests/test_arrfuncs.py
@@ -1,14 +1,13 @@
-""" Testing array utilities
-"""
+"""Testing array utilities."""
 
 import sys
 
 import numpy as np
 
-from dipy.utils.arrfuncs import as_native_array, pinv, eigh
+from dipy.utils.arrfuncs import as_native_array, pinv
 
 from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_array_equal, assert_raises)
+                           assert_array_equal)
 from dipy.testing import assert_true, assert_false
 
 NATIVE_ORDER = '<' if sys.byteorder == 'little' else '>'
@@ -37,21 +36,3 @@ def test_pinv():
             for k in range(4):
                 assert_array_almost_equal(_pinv[i, j, k],
                                           np.linalg.pinv(arr[i, j, k]))
-
-
-def test_eigh():
-    for i in range(10):
-        arr = np.random.randn(7, 7)
-        evals1, evecs1 = eigh(arr)
-        evals2, evecs2 = np.linalg.eigh(arr)
-        assert_array_almost_equal(evals1, evals2)
-        assert_array_almost_equal(evecs1, evecs2)
-
-    arr = np.random.randn(4, 4, 4, 7, 7)
-    evals, evecs = eigh(arr)
-    for i in range(4):
-        for j in range(4):
-            for k in range(4):
-                evals_vox, evecs_vox = np.linalg.eigh(arr[i, j, k])
-                assert_array_almost_equal(evals[i, j, k], evals_vox)
-                assert_array_almost_equal(evecs[i, j, k], evecs_vox)


### PR DESCRIPTION
As a follow up of #1877, this PR remove NUMPY_LESS_0.8.x and `eigh` function