### PR TITLE
Clean up: Remove streamlines memory patch

### DIFF
--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -7,7 +7,8 @@ from scipy.spatial.distance import cdist
 import numpy as np
 from nibabel.affines import apply_affine
 from nibabel.streamlines import ArraySequence as Streamlines
-from dipy.tracking.streamlinespeed import set_number_of_points, length
+from dipy.tracking.streamlinespeed import (set_number_of_points, length,
+                                           compress_streamlines)
 from dipy.tracking.distances import bundles_distances_mdf
 import dipy.tracking.utils as ut
 from dipy.core.geometry import dist_to_corner

--- a/dipy/tracking/streamline.py
+++ b/dipy/tracking/streamline.py
@@ -2,163 +2,16 @@ from copy import deepcopy
 from warnings import warn
 import types
 
-from distutils.version import LooseVersion
 from scipy.spatial.distance import cdist
 
 import numpy as np
-import nibabel as nib
 from nibabel.affines import apply_affine
-from dipy.tracking.streamlinespeed import set_number_of_points
-from dipy.tracking.streamlinespeed import length
+from nibabel.streamlines import ArraySequence as Streamlines
+from dipy.tracking.streamlinespeed import set_number_of_points, length
 from dipy.tracking.distances import bundles_distances_mdf
-from dipy.tracking.streamlinespeed import compress_streamlines
 import dipy.tracking.utils as ut
-from dipy.tracking.utils import streamline_near_roi
 from dipy.core.geometry import dist_to_corner
 import dipy.align.vector_fields as vfu
-
-if LooseVersion(nib.__version__) >= '2.3':
-    from nibabel.streamlines import ArraySequence as Streamlines
-else:
-    # This patch fix a streamline bug on windows machine.
-    # For more information, look at https://github.com/nipy/nibabel/pull/597
-    # This patch can be removed when nibabel minimal version is updated to 2.3
-    # Currently, nibabel 2.3 does not exist.
-    from nibabel.streamlines import ArraySequence
-    from functools import reduce
-    from operator import mul
-
-    MEGABYTE = 1024 * 1024
-
-    class _BuildCache(object):
-        def __init__(self, arr_seq, common_shape, dtype):
-            self.offsets = list(arr_seq._offsets)
-            self.lengths = list(arr_seq._lengths)
-            self.next_offset = arr_seq._get_next_offset()
-            self.bytes_per_buf = arr_seq._buffer_size * MEGABYTE
-            # Use the passed dtype only if null data array
-            if arr_seq._data.size == 0:
-                self.dtype = dtype
-            else:
-                arr_seq._data.dtype
-            if (arr_seq.common_shape != () and
-                    common_shape != arr_seq.common_shape):
-                raise ValueError(
-                    "All dimensions, except the first one, must match exactly")
-            self.common_shape = common_shape
-            n_in_row = reduce(mul, common_shape, 1)
-            bytes_per_row = n_in_row * dtype.itemsize
-            self.rows_per_buf = max(1, self.bytes_per_buf // bytes_per_row)
-
-        def update_seq(self, arr_seq):
-            arr_seq._offsets = np.array(self.offsets)
-            arr_seq._lengths = np.array(self.lengths)
-
-    class Streamlines(ArraySequence):
-        def __init__(self, *args, **kwargs):
-            super(Streamlines, self).__init__(*args, **kwargs)
-
-        def append(self, element, cache_build=False):
-            """
-            Appends `element` to this array sequence.
-
-            Append can be a lot faster if it knows that it is appending several
-            elements instead of a single element.  In that case it can cache
-            the parameters it uses between append operations, in a "build
-            cache". To tell append to do this, use ``cache_build=True``.  If
-            you use ``cache_build=True``, you need to finalize the append
-            operations with :meth:`finalize_append`.
-
-            Parameters
-            ----------
-            element : ndarray Element to append. The shape must match already
-                inserted elements shape except for the first dimension.
-                cache_build : {False, True} Whether to save the build cache
-                from this append routine.  If True, append can assume it is the
-                only player updating `self`, and the caller must finalize
-                `self` after all append operations, with
-                ``self.finalize_append()``. Returns
-            -------
-            None Notes
-            -----
-            If you need to add multiple elements you should consider
-            `ArraySequence.extend`.
-            """
-            element = np.asarray(element)
-            if element.size == 0:
-                return
-            el_shape = element.shape
-            n_items, common_shape = el_shape[0], el_shape[1:]
-            build_cache = self._build_cache
-            in_cached_build = build_cache is not None
-            if not in_cached_build:  # One shot append, not part of sequence
-                build_cache = _BuildCache(self, common_shape, element.dtype)
-            next_offset = build_cache.next_offset
-            req_rows = next_offset + n_items
-            if self._data.shape[0] < req_rows:
-                self._resize_data_to(req_rows, build_cache)
-            self._data[next_offset:req_rows] = element
-            build_cache.offsets.append(next_offset)
-            build_cache.lengths.append(n_items)
-            build_cache.next_offset = req_rows
-            if in_cached_build:
-                return
-            if cache_build:
-                self._build_cache = build_cache
-            else:
-                build_cache.update_seq(self)
-
-        def finalize_append(self):
-            """ Finalize process of appending several elements to `self`
-            :meth:`append` can be a lot faster if it knows that it is appending
-            several elements instead of a single element.  To tell the append
-            method this is the case, use ``cache_build=True``.  This method
-            finalizes the series of append operations after a call to
-            :meth:`append` with ``cache_build=True``.
-            """
-            if self._build_cache is None:
-                return
-            self._build_cache.update_seq(self)
-            self._build_cache = None
-            self.shrink_data()
-
-        def extend(self, elements):
-            """ Appends all `elements` to this array sequence.
-            Parameters
-            ----------
-            elements : iterable of ndarrays or :class:`ArraySequence` instance
-
-                If iterable of ndarrays, each ndarray will be concatenated
-                along the first dimension then appended to the data of this
-                ArraySequence.
-                If :class:`ArraySequence` object, its data are simply appended
-                to the data of this ArraySequence.
-
-            Returns
-            -------
-            None Notes
-            -----
-            The shape of the elements to be added must match the one of the
-            data of this :class:`ArraySequence` except for the first dimension.
-            """
-            # If possible try pre-allocating memory.
-            try:
-                iter_len = len(elements)
-            except TypeError:
-                pass
-            else:  # We do know the iterable length
-                if iter_len == 0:
-                    return
-                e0 = np.asarray(elements[0])
-                n_elements = np.sum([len(e) for e in elements])
-                self._build_cache = _BuildCache(self, e0.shape[1:], e0.dtype)
-                self._resize_data_to(self._get_next_offset() + n_elements,
-                                     self._build_cache)
-
-            for e in elements:
-                self.append(e, cache_build=True)
-
-            self.finalize_append()
 
 
 def unlist_streamlines(streamlines):
@@ -462,10 +315,10 @@ def select_by_rois(streamlines, rois, include, mode=None, affine=None,
     if mode is None:
         mode = "any"
     for sl in streamlines:
-        include = streamline_near_roi(sl, x_include_roi_coords, tol=tol,
-                                      mode=mode)
-        exclude = streamline_near_roi(sl, x_exclude_roi_coords, tol=tol,
-                                      mode=mode)
+        include = ut.streamline_near_roi(sl, x_include_roi_coords, tol=tol,
+                                         mode=mode)
+        exclude = ut.streamline_near_roi(sl, x_exclude_roi_coords, tol=tol,
+                                         mode=mode)
         if include & ~exclude:
             yield sl
 
@@ -720,7 +573,7 @@ def orient_by_streamline(streamlines, standard, n_points=12, in_place=False,
     """
     # Start by resampling, so that distance calculation is easy:
     fgarray = set_number_of_points(streamlines,  n_points)
-    std_array =  set_number_of_points([standard],  n_points)
+    std_array = set_number_of_points([standard],  n_points)
 
     if as_generator:
         if in_place:


### PR DESCRIPTION
Since our Nibabel minimum version is 2.4, we do not need this patch anymore. This patch was fixing a memory issue on streamlines API and has been fixed on Nibabel 2.3