### PR TITLE
Replace SingleTensor by single_tensor

### DIFF
--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -14,7 +14,7 @@ import gzip
 import numpy as np
 from dipy.core.gradients import GradientTable, gradient_table
 from dipy.core.sphere import Sphere, HemiSphere
-from dipy.sims.voxel import SticksAndBall
+from dipy.sims.voxel import sticks_and_ball
 from dipy.data.fetcher import (fetch_scil_b0,
                                read_scil_b0,
                                fetch_stanford_hardi,
@@ -326,13 +326,13 @@ def dsi_deconv_voxels():
     for ix in range(2):
         for iy in range(2):
             for iz in range(2):
-                data[ix, iy, iz], dirs = SticksAndBall(gtab,
-                                                       d=0.0015,
-                                                       S0=1.,
-                                                       angles=[(0, 0),
-                                                               (90, 0)],
-                                                       fractions=[50, 50],
-                                                       snr=None)
+                data[ix, iy, iz], dirs = sticks_and_ball(gtab,
+                                                         d=0.0015,
+                                                         S0=1.,
+                                                         angles=[(0, 0),
+                                                                 (90, 0)],
+                                                         fractions=[50, 50],
+                                                         snr=None)
     return data, gtab
 
 

--- a/dipy/data/__init__.py
+++ b/dipy/data/__init__.py
@@ -326,13 +326,13 @@ def dsi_deconv_voxels():
     for ix in range(2):
         for iy in range(2):
             for iz in range(2):
-                data[ix, iy, iz], dirs = sticks_and_ball(gtab,
-                                                         d=0.0015,
-                                                         S0=1.,
-                                                         angles=[(0, 0),
-                                                                 (90, 0)],
-                                                         fractions=[50, 50],
-                                                         snr=None)
+                data[ix, iy, iz], _ = sticks_and_ball(gtab,
+                                                      d=0.0015,
+                                                      S0=1.,
+                                                      angles=[(0, 0),
+                                                              (90, 0)],
+                                                      fractions=[50, 50],
+                                                      snr=None)
     return data, gtab
 
 

--- a/dipy/reconst/forecast.py
+++ b/dipy/reconst/forecast.py
@@ -114,16 +114,16 @@ class ForecastModel(OdfModel, Cache):
 
         >>> from dipy.data import get_sphere, get_3shell_gtab
         >>> gtab = get_3shell_gtab()
-        >>> from dipy.sims.voxel import MultiTensor
+        >>> from dipy.sims.voxel import multi_tensor
         >>> mevals = np.array(([0.0017, 0.0003, 0.0003], 
         ...                    [0.0017, 0.0003, 0.0003]))
         >>> angl = [(0, 0), (60, 0)]
-        >>> data, sticks = MultiTensor(gtab,
-        ...                            mevals,
-        ...                            S0=100.0,
-        ...                            angles=angl,
-        ...                            fractions=[50, 50],
-        ...                            snr=None)
+        >>> data, sticks = multi_tensor(gtab,
+        ...                             mevals,
+        ...                             S0=100.0,
+        ...                             angles=angl,
+        ...                             fractions=[50, 50],
+        ...                             snr=None)
         >>> from dipy.reconst.forecast import ForecastModel
         >>> fm = ForecastModel(gtab, sh_order=6)
         >>> f_fit = fm.fit(data)

--- a/dipy/reconst/mapmri.py
+++ b/dipy/reconst/mapmri.py
@@ -205,11 +205,12 @@ class MapmriModel(ReconstModel, Cache):
         >>> _, gtab_ = dsi_voxels()
         >>> gtab = gradient_table(gtab_.bvals, gtab_.bvecs,
         ...                       b0_threshold=gtab_.bvals.min())
-        >>> from dipy.sims.voxel import SticksAndBall
-        >>> data, golden_directions = SticksAndBall(
-        ...                                     gtab, d=0.0015,
-        ...                                     S0=1, angles=[(0, 0), (90, 0)],
-        ...                                     fractions=[50, 50], snr=None)
+        >>> from dipy.sims.voxel import sticks_and_ball
+        >>> data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=1,
+        ...                                           angles=[(0, 0),
+        ...                                                   (90, 0)],
+        ...                                           fractions=[50, 50],
+        ...                                           snr=None)
         >>> from dipy.reconst.mapmri import MapmriModel
         >>> radial_order = 4
         >>> map_model = MapmriModel(gtab, radial_order=radial_order)

--- a/dipy/reconst/shore.py
+++ b/dipy/reconst/shore.py
@@ -157,8 +157,8 @@ class ShoreModel(Cache):
         fimg, fbvals, fbvecs = get_fnames('ISBI_testing_2shells_table')
         bvals, bvecs = read_bvals_bvecs(fbvals, fbvecs)
         gtab = gradient_table(bvals, bvecs)
-        from dipy.sims.voxel import SticksAndBall
-        data, golden_directions = SticksAndBall(
+        from dipy.sims.voxel import sticks_and_ball
+        data, golden_directions = sticks_and_ball(
             gtab, d=0.0015, S0=1., angles=[(0, 0), (90, 0)],
             fractions=[50, 50], snr=None)
         from dipy.reconst.canal import ShoreModel

--- a/dipy/reconst/tests/test_dsi.py
+++ b/dipy/reconst/tests/test_dsi.py
@@ -4,15 +4,14 @@ from numpy.testing import (assert_equal,
                            run_module_suite,
                            assert_array_equal,
                            assert_raises)
-from dipy.data import get_fnames, dsi_voxels
+
+from dipy.data import get_fnames, dsi_voxels, get_sphere
 from dipy.reconst.dsi import DiffusionSpectrumModel
 from dipy.reconst.odf import gfa
 from dipy.direction.peaks import peak_directions
-from dipy.sims.voxel import SticksAndBall
+from dipy.sims.voxel import sticks_and_ball
 from dipy.core.sphere import Sphere
 from dipy.core.gradients import gradient_table
-from dipy.data import get_sphere
-from numpy.testing import assert_equal
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity
 
@@ -25,9 +24,9 @@ def test_dsi():
     sphere2 = create_unit_sphere(5)
     btable = np.loadtxt(get_fnames('dsi515btable'))
     gtab = gradient_table(btable[:, 0], btable[:, 1:])
-    data, golden_directions = SticksAndBall(gtab, d=0.0015,
-                                            S0=100, angles=[(0, 0), (90, 0)],
-                                            fractions=[50, 50], snr=None)
+    data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                              angles=[(0, 0), (90, 0)],
+                                              fractions=[50, 50], snr=None)
 
     ds = DiffusionSpectrumModel(gtab)
 
@@ -103,21 +102,21 @@ def test_multib0_dsi():
 
 def sticks_and_ball_dummies(gtab):
     sb_dummies = {}
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100,
-                              angles=[(0, 0)],
-                              fractions=[100], snr=None)
+    S, sticks = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                angles=[(0, 0)],
+                                fractions=[100], snr=None)
     sb_dummies['1fiber'] = (S, sticks)
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100,
-                              angles=[(0, 0), (90, 0)],
-                              fractions=[50, 50], snr=None)
+    S, sticks = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                angles=[(0, 0), (90, 0)],
+                                fractions=[50, 50], snr=None)
     sb_dummies['2fiber'] = (S, sticks)
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100,
-                              angles=[(0, 0), (90, 0), (90, 90)],
-                              fractions=[33, 33, 33], snr=None)
+    S, sticks = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                angles=[(0, 0), (90, 0), (90, 90)],
+                                fractions=[33, 33, 33], snr=None)
     sb_dummies['3fiber'] = (S, sticks)
-    S, sticks = SticksAndBall(gtab, d=0.0015, S0=100,
-                              angles=[(0, 0), (90, 0), (90, 90)],
-                              fractions=[0, 0, 0], snr=None)
+    S, sticks = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                angles=[(0, 0), (90, 0), (90, 90)],
+                                fractions=[0, 0, 0], snr=None)
     sb_dummies['isotropic'] = (S, sticks)
     return sb_dummies
 

--- a/dipy/reconst/tests/test_dsi_deconv.py
+++ b/dipy/reconst/tests/test_dsi_deconv.py
@@ -4,15 +4,13 @@ from numpy.testing import (assert_equal,
                            run_module_suite,
                            assert_array_equal,
                            assert_raises)
-from dipy.data import get_fnames, dsi_deconv_voxels
+from dipy.data import get_fnames, dsi_deconv_voxels, get_sphere
 from dipy.reconst.dsi import DiffusionSpectrumDeconvModel
 from dipy.reconst.odf import gfa
 from dipy.direction.peaks import peak_directions
-from dipy.sims.voxel import SticksAndBall
+from dipy.sims.voxel import sticks_and_ball
 from dipy.core.sphere import Sphere
 from dipy.core.gradients import gradient_table
-from dipy.data import get_sphere
-from numpy.testing import assert_equal
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
@@ -25,9 +23,9 @@ def test_dsi():
     sphere2 = create_unit_sphere(5)
     btable = np.loadtxt(get_fnames('dsi515btable'))
     gtab = gradient_table(btable[:, 0], btable[:, 1:])
-    data, golden_directions = SticksAndBall(gtab, d=0.0015,
-                                            S0=100, angles=[(0, 0), (90, 0)],
-                                            fractions=[50, 50], snr=None)
+    data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                              angles=[(0, 0), (90, 0)],
+                                              fractions=[50, 50], snr=None)
 
     ds = DiffusionSpectrumDeconvModel(gtab)
 

--- a/dipy/reconst/tests/test_dsi_metrics.py
+++ b/dipy/reconst/tests/test_dsi_metrics.py
@@ -2,18 +2,16 @@ import numpy as np
 from dipy.reconst.dsi import DiffusionSpectrumModel
 from dipy.data import get_fnames
 from dipy.core.gradients import gradient_table
-from numpy.testing import (assert_almost_equal,
-                           run_module_suite)
-from dipy.sims.voxel import (SticksAndBall,
-                             MultiTensor)
+from numpy.testing import assert_almost_equal, run_module_suite
+from dipy.sims.voxel import sticks_and_ball, multi_tensor
 
 
 def test_dsi_metrics():
     btable = np.loadtxt(get_fnames('dsi4169btable'))
     gtab = gradient_table(btable[:, 0], btable[:, 1:])
-    data, golden_directions = SticksAndBall(gtab, d=0.0015, S0=100,
-                                            angles=[(0, 0), (60, 0)],
-                                            fractions=[50, 50], snr=None)
+    data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                              angles=[(0, 0), (60, 0)],
+                                              fractions=[50, 50], snr=None)
 
     dsmodel = DiffusionSpectrumModel(gtab, qgrid_size=21, filter_width=4500)
     rtop_signal_norm = dsmodel.fit(data).rtop_signal()
@@ -22,12 +20,12 @@ def test_dsi_metrics():
     assert_almost_equal(rtop_signal_norm, rtop_pdf, 6)
     dsmodel = DiffusionSpectrumModel(gtab, qgrid_size=21, filter_width=4500)
     mevals = np.array(([0.0015, 0.0003, 0.0003], [0.0015, 0.0003, 0.0003]))
-    S_0, sticks_0 = MultiTensor(gtab, mevals, S0=100,
-                                angles=[(0, 0), (60, 0)],
-                                fractions=[50, 50], snr=None)
-    S_1, sticks_0 = MultiTensor(gtab, mevals * 2.0, S0=100,
-                                angles=[(0, 0), (60, 0)],
-                                fractions=[50, 50], snr=None)
+    S_0, sticks_0 = multi_tensor(gtab, mevals, S0=100,
+                                 angles=[(0, 0), (60, 0)],
+                                 fractions=[50, 50], snr=None)
+    S_1, sticks_0 = multi_tensor(gtab, mevals * 2.0, S0=100,
+                                 angles=[(0, 0), (60, 0)],
+                                 fractions=[50, 50], snr=None)
     MSD_norm_0 = dsmodel.fit(S_0).msd_discrete(normalized=True)
     MSD_norm_1 = dsmodel.fit(S_1).msd_discrete(normalized=True)
     assert_almost_equal(MSD_norm_0, 0.5 * MSD_norm_1, 4)

--- a/dipy/reconst/tests/test_dsi_metrics.py
+++ b/dipy/reconst/tests/test_dsi_metrics.py
@@ -9,9 +9,9 @@ from dipy.sims.voxel import sticks_and_ball, multi_tensor
 def test_dsi_metrics():
     btable = np.loadtxt(get_fnames('dsi4169btable'))
     gtab = gradient_table(btable[:, 0], btable[:, 1:])
-    data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=100,
-                                              angles=[(0, 0), (60, 0)],
-                                              fractions=[50, 50], snr=None)
+    data, _ = sticks_and_ball(gtab, d=0.0015, S0=100,
+                              angles=[(0, 0), (60, 0)],
+                              fractions=[50, 50], snr=None)
 
     dsmodel = DiffusionSpectrumModel(gtab, qgrid_size=21, filter_width=4500)
     rtop_signal_norm = dsmodel.fit(data).rtop_signal()
@@ -20,12 +20,12 @@ def test_dsi_metrics():
     assert_almost_equal(rtop_signal_norm, rtop_pdf, 6)
     dsmodel = DiffusionSpectrumModel(gtab, qgrid_size=21, filter_width=4500)
     mevals = np.array(([0.0015, 0.0003, 0.0003], [0.0015, 0.0003, 0.0003]))
-    S_0, sticks_0 = multi_tensor(gtab, mevals, S0=100,
-                                 angles=[(0, 0), (60, 0)],
-                                 fractions=[50, 50], snr=None)
-    S_1, sticks_0 = multi_tensor(gtab, mevals * 2.0, S0=100,
-                                 angles=[(0, 0), (60, 0)],
-                                 fractions=[50, 50], snr=None)
+    S_0, _ = multi_tensor(gtab, mevals, S0=100,
+                          angles=[(0, 0), (60, 0)],
+                          fractions=[50, 50], snr=None)
+    S_1, _ = multi_tensor(gtab, mevals * 2.0, S0=100,
+                          angles=[(0, 0), (60, 0)],
+                          fractions=[50, 50], snr=None)
     MSD_norm_0 = dsmodel.fit(S_0).msd_discrete(normalized=True)
     MSD_norm_1 = dsmodel.fit(S_1).msd_discrete(normalized=True)
     assert_almost_equal(MSD_norm_0, 0.5 * MSD_norm_1, 4)

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from dipy.data import get_sphere, get_3shell_gtab
 from dipy.reconst.forecast import ForecastModel
-from dipy.sims.voxel import MultiTensor
+from dipy.sims.voxel import multi_tensor
 
 from numpy.testing import (assert_almost_equal,
                            assert_equal,
@@ -29,9 +29,9 @@ def setup():
     data.mevals = np.array(([0.0017, 0.0003, 0.0003],
                             [0.0017, 0.0003, 0.0003]))
     data.angl = [(0, 0), (60, 0)]
-    data.S, data.sticks = MultiTensor(
-        data.gtab, data.mevals, S0=100.0, angles=data.angl,
-        fractions=[50, 50], snr=None)
+    data.S, data.sticks = multi_tensor(data.gtab, data.mevals, S0=100.0,
+                                       angles=data.angl, fractions=[50, 50],
+                                       snr=None)
     data.sh_order = 6
     data.lambda_lb = 1e-8
     data.lambda_csd = 1.0
@@ -146,9 +146,8 @@ def test_forecast_indices():
     mevals = np.array(([0.003, 0.003, 0.003],
                        [0.003, 0.003, 0.003]))
     data.angl = [(0, 0), (60, 0)]
-    S, sticks = MultiTensor(
-        data.gtab, mevals, S0=100.0, angles=data.angl,
-        fractions=[50, 50], snr=None)
+    S, sticks = multi_tensor(data.gtab, mevals, S0=100.0, angles=data.angl,
+                             fractions=[50, 50], snr=None)
 
     fm = ForecastModel(data.gtab, sh_order=data.sh_order,
                        lambda_lb=data.lambda_lb, dec_alg='WLS')
@@ -186,15 +185,12 @@ def test_multivox_forecast():
     angl3 = [(0, 0), (90, 0)]
 
     S = np.zeros((3, 1, 1, len(gtab.bvals)))
-    S[0, 0, 0], sticks = MultiTensor(
-        gtab, mevals, S0=1.0, angles=angl1,
-        fractions=[50, 50], snr=None)
-    S[1, 0, 0], sticks = MultiTensor(
-        gtab, mevals, S0=1.0, angles=angl2,
-        fractions=[50, 50], snr=None)
-    S[2, 0, 0], sticks = MultiTensor(
-        gtab, mevals, S0=1.0, angles=angl3,
-        fractions=[50, 50], snr=None)
+    S[0, 0, 0], sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl1,
+                                      fractions=[50, 50], snr=None)
+    S[1, 0, 0], sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl2,
+                                      fractions=[50, 50], snr=None)
+    S[2, 0, 0], sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl3,
+                                      fractions=[50, 50], snr=None)
 
     fm = ForecastModel(gtab, sh_order=8,
                        dec_alg='CSD')

--- a/dipy/reconst/tests/test_forecast.py
+++ b/dipy/reconst/tests/test_forecast.py
@@ -185,12 +185,12 @@ def test_multivox_forecast():
     angl3 = [(0, 0), (90, 0)]
 
     S = np.zeros((3, 1, 1, len(gtab.bvals)))
-    S[0, 0, 0], sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl1,
-                                      fractions=[50, 50], snr=None)
-    S[1, 0, 0], sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl2,
-                                      fractions=[50, 50], snr=None)
-    S[2, 0, 0], sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl3,
-                                      fractions=[50, 50], snr=None)
+    S[0, 0, 0], _ = multi_tensor(gtab, mevals, S0=1.0, angles=angl1,
+                                 fractions=[50, 50], snr=None)
+    S[1, 0, 0], _ = multi_tensor(gtab, mevals, S0=1.0, angles=angl2,
+                                 fractions=[50, 50], snr=None)
+    S[2, 0, 0], _ = multi_tensor(gtab, mevals, S0=1.0, angles=angl3,
+                                 fractions=[50, 50], snr=None)
 
     fm = ForecastModel(gtab, sh_order=8,
                        dec_alg='CSD')

--- a/dipy/reconst/tests/test_gqi.py
+++ b/dipy/reconst/tests/test_gqi.py
@@ -1,18 +1,20 @@
 import numpy as np
-from dipy.data import get_fnames, dsi_voxels
+from dipy.data import get_fnames, dsi_voxels, get_sphere
 from dipy.core.sphere import Sphere
 from dipy.core.gradients import gradient_table
-from dipy.sims.voxel import SticksAndBall
+from dipy.core.subdivide_octahedron import create_unit_sphere
+from dipy.core.sphere_stats import angular_similarity
+from dipy.sims.voxel import sticks_and_ball
 from dipy.reconst.gqi import GeneralizedQSamplingModel
-from dipy.data import get_sphere
+from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
+from dipy.reconst.odf import gfa
+from dipy.direction.peaks import peak_directions
+
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            run_module_suite)
-from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
-from dipy.core.subdivide_octahedron import create_unit_sphere
-from dipy.core.sphere_stats import angular_similarity
-from dipy.reconst.odf import gfa
-from dipy.direction.peaks import peak_directions
+
+
 
 
 def test_gqi():
@@ -24,9 +26,9 @@ def test_gqi():
     bvals = btable[:, 0]
     bvecs = btable[:, 1:]
     gtab = gradient_table(bvals, bvecs)
-    data, golden_directions = SticksAndBall(gtab, d=0.0015,
-                                            S0=100, angles=[(0, 0), (90, 0)],
-                                            fractions=[50, 50], snr=None)
+    data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                              angles=[(0, 0), (90, 0)],
+                                              fractions=[50, 50], snr=None)
     gq = GeneralizedQSamplingModel(gtab, method='gqi2', sampling_length=1.4)
 
     # symmetric724

--- a/dipy/reconst/tests/test_mapmri.py
+++ b/dipy/reconst/tests/test_mapmri.py
@@ -14,10 +14,8 @@ from numpy.testing import (assert_almost_equal,
 from dipy.data import get_gtab_taiwan_dsi
 from dipy.reconst.mapmri import MapmriModel, mapmri_index_matrix
 from dipy.reconst import dti, mapmri
-from dipy.sims.voxel import (MultiTensor,
-                             multi_tensor_pdf,
-                             single_tensor,
-                             cylinders_and_ball_soderman)
+from dipy.sims.voxel import (multi_tensor, multi_tensor_pdf,
+                             single_tensor, cylinders_and_ball_soderman)
 from dipy.data import get_sphere
 from dipy.sims.voxel import add_noise
 from dipy.core.sphere_stats import angular_similarity
@@ -36,8 +34,8 @@ def generate_signal_crossing(gtab, lambda1, lambda2, lambda3, angle2=60):
     mevals = np.array(([lambda1, lambda2, lambda3],
                        [lambda1, lambda2, lambda3]))
     angl = [(0, 0), (angle2, 0)]
-    S, sticks = MultiTensor(gtab, mevals, S0=100.0, angles=angl,
-                            fractions=[50, 50], snr=None)
+    S, sticks = multi_tensor(gtab, mevals, S0=100.0, angles=angl,
+                             fractions=[50, 50], snr=None)
     return S, sticks
 
 

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -1,17 +1,19 @@
 import numpy as np
-from dipy.data import get_gtab_taiwan_dsi
+import scipy.integrate as integrate
+
 from numpy.testing import (assert_,
                            assert_almost_equal,
                            assert_array_almost_equal,
                            assert_equal,
                            assert_raises,
                            run_module_suite)
-from dipy.reconst import qtdmri, mapmri
-from dipy.sims.voxel import MultiTensor
-from dipy.data import get_sphere
-from dipy.sims.voxel import add_noise
-import scipy.integrate as integrate
+
 from dipy.core.gradients import gradient_table_from_qvals_bvecs
+from dipy.data import get_gtab_taiwan_dsi, get_sphere
+from dipy.reconst import qtdmri, mapmri
+from dipy.sims.voxel import multi_tensor, add_noise
+
+
 
 
 def generate_gtab4D(number_of_tau_shells=4, delta=0.01):
@@ -35,8 +37,8 @@ def generate_signal_crossing(gtab, lambda1, lambda2, lambda3, angle2=60):
     mevals = np.array(([lambda1, lambda2, lambda3],
                        [lambda1, lambda2, lambda3]))
     angl = [(0, 0), (angle2, 0)]
-    S, sticks = MultiTensor(gtab, mevals, S0=1.0, angles=angl,
-                            fractions=[50, 50], snr=None)
+    S, sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl,
+                             fractions=[50, 50], snr=None)
     return S
 
 

--- a/dipy/reconst/tests/test_qtdmri.py
+++ b/dipy/reconst/tests/test_qtdmri.py
@@ -37,8 +37,8 @@ def generate_signal_crossing(gtab, lambda1, lambda2, lambda3, angle2=60):
     mevals = np.array(([lambda1, lambda2, lambda3],
                        [lambda1, lambda2, lambda3]))
     angl = [(0, 0), (angle2, 0)]
-    S, sticks = multi_tensor(gtab, mevals, S0=1.0, angles=angl,
-                             fractions=[50, 50], snr=None)
+    S, _ = multi_tensor(gtab, mevals, S0=1.0, angles=angl,
+                        fractions=[50, 50], snr=None)
     return S
 
 

--- a/dipy/reconst/tests/test_shore.py
+++ b/dipy/reconst/tests/test_shore.py
@@ -7,7 +7,7 @@ from scipy.special import genlaguerre, gamma
 
 from dipy.data import get_gtab_taiwan_dsi
 from dipy.reconst.shore import ShoreModel
-from dipy.sims.voxel import MultiTensor
+from dipy.sims.voxel import multi_tensor
 
 from numpy.testing import (assert_almost_equal,
                            assert_equal,
@@ -31,9 +31,9 @@ def setup():
     data.mevals = np.array(([0.0015, 0.0003, 0.0003],
                             [0.0015, 0.0003, 0.0003]))
     data.angl = [(0, 0), (60, 0)]
-    data.S, sticks = MultiTensor(
-        data.gtab, data.mevals, S0=100.0, angles=data.angl,
-        fractions=[50, 50], snr=None)
+    data.S, sticks = multi_tensor(data.gtab, data.mevals, S0=100.0,
+                                  angles=data.angl, fractions=[50, 50],
+                                  snr=None)
     data.radial_order = 6
     data.zeta = 700
     data.lambdaN = 1e-12

--- a/dipy/reconst/tests/test_shore_metrics.py
+++ b/dipy/reconst/tests/test_shore_metrics.py
@@ -1,17 +1,19 @@
 import numpy as np
-from dipy.data import get_gtab_taiwan_dsi
+from scipy.special import genlaguerre
+
 from numpy.testing import (assert_almost_equal,
                            assert_equal,
                            run_module_suite)
+
+from dipy.data import get_gtab_taiwan_dsi, get_sphere
 from dipy.reconst.shore import (ShoreModel,
                                 shore_matrix,
                                 shore_indices,
                                 shore_order)
-from dipy.sims.voxel import (
-    MultiTensor, all_tensor_evecs, multi_tensor_odf, single_tensor_odf,
-    multi_tensor_rtop, multi_tensor_msd, multi_tensor_pdf)
-from dipy.data import get_sphere
-from scipy.special import genlaguerre
+from dipy.sims.voxel import (multi_tensor, all_tensor_evecs, multi_tensor_odf,
+                             single_tensor_odf, multi_tensor_rtop,
+                             multi_tensor_msd, multi_tensor_pdf)
+
 
 
 def test_shore_metrics():
@@ -19,8 +21,8 @@ def test_shore_metrics():
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
     angl = [(0, 0), (60, 0)]
-    S, sticks = MultiTensor(gtab, mevals, S0=100.0, angles=angl,
-                            fractions=[50, 50], snr=None)
+    S, sticks = multi_tensor(gtab, mevals, S0=100.0, angles=angl,
+                             fractions=[50, 50], snr=None)
 
     # test shore_indices
     n = 7

--- a/dipy/reconst/tests/test_shore_metrics.py
+++ b/dipy/reconst/tests/test_shore_metrics.py
@@ -11,8 +11,8 @@ from dipy.reconst.shore import (ShoreModel,
                                 shore_indices,
                                 shore_order)
 from dipy.sims.voxel import (multi_tensor, all_tensor_evecs, multi_tensor_odf,
-                             single_tensor_odf, multi_tensor_rtop,
-                             multi_tensor_msd, multi_tensor_pdf)
+                             multi_tensor_rtop, multi_tensor_msd,
+                             multi_tensor_pdf)
 
 
 
@@ -21,8 +21,8 @@ def test_shore_metrics():
     mevals = np.array(([0.0015, 0.0003, 0.0003],
                        [0.0015, 0.0003, 0.0003]))
     angl = [(0, 0), (60, 0)]
-    S, sticks = multi_tensor(gtab, mevals, S0=100.0, angles=angl,
-                             fractions=[50, 50], snr=None)
+    S, _ = multi_tensor(gtab, mevals, S0=100.0, angles=angl,
+                        fractions=[50, 50], snr=None)
 
     # test shore_indices
     n = 7

--- a/dipy/reconst/tests/test_shore_odf.py
+++ b/dipy/reconst/tests/test_shore_odf.py
@@ -7,7 +7,7 @@ from dipy.reconst.odf import gfa
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            run_module_suite)
-from dipy.sims.voxel import SticksAndBall
+from dipy.sims.voxel import sticks_and_ball
 from dipy.core.subdivide_octahedron import create_unit_sphere
 from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.tests.test_dsi import sticks_and_ball_dummies
@@ -21,9 +21,9 @@ def test_shore_odf():
 
     # load icosahedron sphere
     sphere2 = create_unit_sphere(5)
-    data, golden_directions = SticksAndBall(gtab, d=0.0015,
-                                            S0=100, angles=[(0, 0), (90, 0)],
-                                            fractions=[50, 50], snr=None)
+    data, golden_directions = sticks_and_ball(gtab, d=0.0015, S0=100,
+                                              angles=[(0, 0), (90, 0)],
+                                              fractions=[50, 50], snr=None)
     asm = ShoreModel(gtab, radial_order=6,
                      zeta=700, lambdaN=1e-8, lambdaL=1e-8)
     # symmetric724

--- a/dipy/sims/phantom.py
+++ b/dipy/sims/phantom.py
@@ -1,7 +1,7 @@
 import numpy as np
 # import scipy.stats as stats
 
-from dipy.sims.voxel import SingleTensor, diffusion_evals
+from dipy.sims.voxel import single_tensor, diffusion_evals
 import dipy.sims.voxel as vox
 from dipy.core.geometry import vec2vec_rotmat
 from dipy.data import get_fnames
@@ -173,7 +173,7 @@ def orbital_phantom(gtab=None,
 
     for i in range(len(dx)):
         evecs, R = diff2eigenvectors(dx[i], dy[i], dz[i])
-        S = SingleTensor(gtab, S0, evals, evecs, snr=None)
+        S = single_tensor(gtab, S0, evals, evecs, snr=None)
 
         vol[int(x[i]), int(y[i]), int(z[i]), :] += S
 

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -125,9 +125,9 @@ def test_multi_tensor():
 
     Ssingle = 0.5*s1 + 0.5*s2
 
-    S, sticks = multi_tensor(gtab, mevals, S0=100,
-                             angles=[(90, 45), (45, 90)],
-                             fractions=[50, 50], snr=None)
+    S, _ = multi_tensor(gtab, mevals, S0=100,
+                        angles=[(90, 45), (45, 90)],
+                        fractions=[50, 50], snr=None)
 
     assert_array_almost_equal(S, Ssingle)
 

--- a/dipy/sims/tests/test_voxel.py
+++ b/dipy/sims/tests/test_voxel.py
@@ -3,10 +3,9 @@ import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_, assert_almost_equal)
 
-from dipy.sims.voxel import (_check_directions, SingleTensor, MultiTensor,
-                             all_tensor_evecs, add_noise, single_tensor,
-                             sticks_and_ball, multi_tensor_dki,
-                             kurtosis_element, dki_signal)
+from dipy.sims.voxel import (_check_directions, all_tensor_evecs, add_noise,
+                             single_tensor, sticks_and_ball, multi_tensor_dki,
+                             kurtosis_element, dki_signal, multi_tensor)
 # from dipy.core.geometry import vec2vec_rotmat
 from dipy.data import get_fnames, get_sphere
 from dipy.core.gradients import gradient_table
@@ -85,16 +84,16 @@ def test_sticks_and_ball():
     S, sticks = sticks_and_ball(gtab, d=d, S0=1, angles=[(0, 0), ],
                                 fractions=[100], snr=None)
     assert_array_equal(sticks, [[0, 0, 1]])
-    S_st = SingleTensor(gtab, 1, evals=[d, 0, 0], evecs=[[0, 0, 0],
-                                                         [0, 0, 0],
-                                                         [1, 0, 0]])
+    S_st = single_tensor(gtab, 1, evals=[d, 0, 0], evecs=[[0, 0, 0],
+                                                          [0, 0, 0],
+                                                          [1, 0, 0]])
     assert_array_almost_equal(S, S_st)
 
 
 def test_single_tensor():
     evals = np.array([1.4, .35, .35]) * 10 ** (-3)
     evecs = np.eye(3)
-    S = SingleTensor(gtab, 100, evals, evecs, snr=None)
+    S = single_tensor(gtab, 100, evals, evecs, snr=None)
     assert_array_almost_equal(S[gtab.b0s_mask], 100)
     assert_(np.mean(S[~gtab.b0s_mask]) < 100)
 
@@ -126,8 +125,9 @@ def test_multi_tensor():
 
     Ssingle = 0.5*s1 + 0.5*s2
 
-    S, sticks = MultiTensor(gtab, mevals, S0=100, angles=[(90, 45), (45, 90)],
-                            fractions=[50, 50], snr=None)
+    S, sticks = multi_tensor(gtab, mevals, S0=100,
+                             angles=[(90, 45), (45, 90)],
+                             fractions=[50, 50], snr=None)
 
     assert_array_almost_equal(S, Ssingle)
 

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -1001,5 +1001,4 @@ def multi_tensor_msd(mf, mevals=None, tau=1 / (4 * np.pi ** 2)):
 # Use standard naming convention, but keep old names
 # for backward compatibility
 SticksAndBall = sticks_and_ball
-SingleTensor = single_tensor
 MultiTensor = multi_tensor

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -996,8 +996,3 @@ def multi_tensor_msd(mf, mevals=None, tau=1 / (4 * np.pi ** 2)):
     for j, f in enumerate(mf):
         msd += f * single_tensor_msd(mevals[j], tau=tau)
     return msd
-
-
-# Use standard naming convention, but keep old names
-# for backward compatibility
-SticksAndBall = sticks_and_ball

--- a/dipy/sims/voxel.py
+++ b/dipy/sims/voxel.py
@@ -1001,4 +1001,3 @@ def multi_tensor_msd(mf, mevals=None, tau=1 / (4 * np.pi ** 2)):
 # Use standard naming convention, but keep old names
 # for backward compatibility
 SticksAndBall = sticks_and_ball
-MultiTensor = multi_tensor

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -16,6 +16,12 @@ The API of ``dipy.segment.mask.median_otsu`` has changed in the following ways:
 if you are providing a 4D volume, `vol_idx` is now a required argument.
 The order of parameters has also changed.
 
+**Simulation**
+
+``dipy.sims.voxel.SingleTensor`` has been replaced by ``dipy.sims.voxel.single_tensor``
+``dipy.sims.voxel.MultiTensor`` has been replaced by ``dipy.sims.voxel.multi_tensor``
+``dipy.sims.voxel.SticksAndBall`` has been replaced by ``dipy.sims.voxel.sticks_and_ball``
+
 
 DIPY 0.16 Changes
 -----------------


### PR DESCRIPTION
This PR removes the backward compatibilities with `SingleTensor`, `MultiTensor` and StickAndBall`.

`dipy.sims.voxel.SingleTensor` has been replaced by `dipy.sims.voxel.single_tensor`
`dipy.sims.voxel.MultiTensor` has been replaced by `dipy.sims.voxel.multi_tensor`
`dipy.sims.voxel.SticksAndBall` has been replaced by `dipy.sims.voxel.sticks_and_ball`

This should fix #844 