### PR TITLE
DOC: Improve documentation

### DIFF
--- a/dipy/align/crosscorr.pyx
+++ b/dipy/align/crosscorr.pyx
@@ -169,7 +169,7 @@ def precompute_cc_factors_3d(floating[:, :, :] static,
         Cross-Correlation: Evaluating Automated Labeling of Elderly and
         Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
     .. [Avants2011]_ Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-        Normalization Tools ( ANTS ), 1-35.
+        Normalization Tools (ANTS), 1-35.
     """
     cdef:
         cnp.npy_intp ns = static.shape[0]
@@ -387,7 +387,7 @@ def compute_cc_forward_step_3d(floating[:, :, :, :] grad_static,
         Cross-Correlation: Evaluating Automated Labeling of Elderly and
         Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
     .. [Avants2011]_ Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-        Normalization Tools ( ANTS ), 1-35.
+        Normalization Tools (ANTS), 1-35.
     """
     cdef:
         cnp.npy_intp ns = grad_static.shape[0]
@@ -459,7 +459,7 @@ def compute_cc_backward_step_3d(floating[:, :, :, :] grad_moving,
                Cross-Correlation: Evaluating Automated Labeling of Elderly and
                Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
     [Avants11]_ Avants, B. B., Tustison, N., & Song, G. (2011).
-               Advanced Normalization Tools ( ANTS ), 1-35.
+               Advanced Normalization Tools (ANTS), 1-35.
     """
     ftype = np.asarray(grad_moving).dtype
     cdef:
@@ -534,7 +534,7 @@ def precompute_cc_factors_2d(floating[:, :] static, floating[:, :] moving,
         Cross-Correlation: Evaluating Automated Labeling of Elderly and
         Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
     .. [Avants2011]_ Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-        Normalization Tools ( ANTS ), 1-35.
+        Normalization Tools (ANTS), 1-35.
     """
     ftype = np.asarray(static).dtype
     cdef:
@@ -709,7 +709,7 @@ def compute_cc_forward_step_2d(floating[:, :, :] grad_static,
         Cross-Correlation: Evaluating Automated Labeling of Elderly and
         Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
     .. [Avants2011]_ Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-        Normalization Tools ( ANTS ), 1-35.
+        Normalization Tools (ANTS), 1-35.
     """
     cdef:
         cnp.npy_intp nr = grad_static.shape[0]
@@ -775,7 +775,7 @@ def compute_cc_backward_step_2d(floating[:, :, :] grad_moving,
         Cross-Correlation: Evaluating Automated Labeling of Elderly and
         Neurodegenerative Brain, Med Image Anal. 12(1), 26-41.
     .. [Avants2011]_ Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-        Normalization Tools ( ANTS ), 1-35.
+        Normalization Tools (ANTS), 1-35.
     """
     ftype = np.asarray(grad_moving).dtype
     cdef:

--- a/dipy/core/sphere.py
+++ b/dipy/core/sphere.py
@@ -547,7 +547,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
     if norm == "angle":
         norm = angle
     elif norm == "euclidean_norm":
-        w_s = "The Eucldian norm used for interpolation is inaccurate "
+        w_s = "The Euclidean norm used for interpolation is inaccurate "
         w_s += "and will be deprecated in future versions. Please consider "
         w_s += "using the 'angle' norm instead"
         warnings.warn(w_s, DeprecationWarning)

--- a/dipy/denoise/nlmeans.py
+++ b/dipy/denoise/nlmeans.py
@@ -39,7 +39,7 @@ def nlmeans(arr, sigma, mask=None, patch_radius=1, block_radius=5,
 
     References
     ----------
-    .. [Descoteaux08] Descoteaux, Maxim and Wiest-Daessle`, Nicolas and Prima,
+    .. [Descoteaux08] Descoteaux, Maxime and Wiest-Daesslé, Nicolas and Prima,
                       Sylvain and Barillot, Christian and Deriche, Rachid
                       Impact of Rician Adapted Non-Local Means Filtering on
                       HARDI, MICCAI 2008

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -109,7 +109,7 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         .. [2] Descoteaux, M., et al. IEEE TMI 2009. Deterministic and
                Probabilistic Tractography Based on Complex Fibre Orientation
                Distributions
-        .. [3] C\^ot\'e, M-A., et al. Medical Image Analysis 2013. Tractometer:
+        .. [3] Côté, M-A., et al. Medical Image Analysis 2013. Tractometer:
                Towards validation of tractography pipelines
         .. [4] Tournier, J.D, et al. Imaging Systems and Technology
                2012. MRtrix: Diffusion Tractography in Crossing Fiber Regions

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -281,7 +281,7 @@ regtools.overlay_slices(static, transformed, None, 2,
               free-form deformations. IEEE Transactions on Medical Imaging,
               22(1), 120-8.
 .. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-              Normalization Tools ( ANTS ), 1-35.
+              Normalization Tools (ANTS), 1-35.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/syn_registration_2d.py
+++ b/doc/examples/syn_registration_2d.py
@@ -4,7 +4,7 @@ Symmetric Diffeomorphic Registration in 2D
 ==========================================
 This example explains how to register 2D images using the Symmetric Normalization 
 (SyN) algorithm proposed by Avants et al. [Avants09]_ (also implemented in
-the ANTS software [Avants11]_)
+the ANTs software [Avants11]_)
 
 We will perform the classic Circle-To-C experiment for diffeomorphic registration
 """
@@ -242,12 +242,12 @@ References
 ----------
 
 .. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009).
-   Symmetric Diffeomorphic Image Registration with Cross- Correlation:
+   Symmetric Diffeomorphic Image Registration with Cross-Correlation:
    Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1),
    26-41.
 
 .. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-   Normalization Tools ( ANTS ), 1-35.
+   Normalization Tools (ANTS), 1-35.
 
 .. include:: ../links_names.inc
 

--- a/doc/examples/syn_registration_3d.py
+++ b/doc/examples/syn_registration_3d.py
@@ -4,7 +4,7 @@ Symmetric Diffeomorphic Registration in 3D
 ==========================================
 This example explains how to register 3D volumes using the Symmetric Normalization 
 (SyN) algorithm proposed by Avants et al. [Avants09]_ (also implemented in
-the ANTS software [Avants11]_)
+the ANTs software [Avants11]_)
 
 We will register two 3D volumes from the same modality using SyN with the Cross
 Correlation (CC) metric.
@@ -155,12 +155,12 @@ References
 ----------
 
 .. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009).
-   Symmetric Diffeomorphic Image Registration with Cross- Correlation:
+   Symmetric Diffeomorphic Image Registration with Cross-Correlation:
    Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1),
    26-41.
 
 .. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
-   Normalization Tools ( ANTS ), 1-35.
+   Normalization Tools (ANTS), 1-35.
 
 .. include:: ../links_names.inc
 


### PR DESCRIPTION
Improve documentation:
- Fix typos in authors names/use accented characters.
- Use `ANTs` for the Advanced Normalization Tools software acronym, as
  authors do.
- Fix typos.
- Remove some spare whitespaces.