### PR TITLE
DOC: Fix examples documentation generation warnings

### DIFF
--- a/doc/devel/gitwash/index.rst
+++ b/doc/devel/gitwash/index.rst
@@ -1,7 +1,7 @@
 .. _using-git:
 
 Working with DIPY source code
-================================================
+=============================
 
 Contents:
 
@@ -14,5 +14,3 @@ Contents:
    patching
    git_development
    git_resources
-
-

--- a/doc/examples/affine_registration_3d.py
+++ b/doc/examples/affine_registration_3d.py
@@ -1,7 +1,7 @@
 """
-==========================================
+=========================
 Affine Registration in 3D
-==========================================
+=========================
 This example explains how to compute an affine transformation to register two
 3D volumes by maximization of their Mutual Information [Mattes03]_. The
 optimization strategy is similar to that implemented in ANTS [Avants11]_.

--- a/doc/examples/afq_tract_profiles.py
+++ b/doc/examples/afq_tract_profiles.py
@@ -1,7 +1,7 @@
 """
-========================================================
-Extracting AFQ tract profiles from segmented bundles.
-========================================================
+====================================================
+Extracting AFQ tract profiles from segmented bundles
+====================================================
 
 In this example, we will we will extract the values of a statistic from a
 volume, using the coordinates along the length of a bundle. These are called

--- a/doc/examples/cluster_confidence.py
+++ b/doc/examples/cluster_confidence.py
@@ -1,7 +1,7 @@
 """
-==================================
+=====================================================
 Calculation of Outliers with Cluster Confidence Index
-==================================
+=====================================================
 
 This is an outlier scoring method that compares the pathways of each streamline
 in a bundle (pairwise) and scores each streamline by how many other streamlines

--- a/doc/examples/combined_workflow_creation.py
+++ b/doc/examples/combined_workflow_creation.py
@@ -1,7 +1,7 @@
 """
-============================================================
-Creating a new combined workflow.
-============================================================
+================================
+Creating a new combined workflow
+================================
 
 A ``CombinedWorkflow`` is a series of DIPY_ workflows organized together in a
 way that the output of a workflow serves as input for the next one.

--- a/doc/examples/contextual_enhancement.py
+++ b/doc/examples/contextual_enhancement.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-==============================================
+==========================================
 Crossing-preserving contextual enhancement
-==============================================
+==========================================
 
 This demo presents an example of crossing-preserving contextual enhancement of
 FOD/ODF fields [Meesters2016]_, implementing the contextual PDE framework

--- a/doc/examples/linear_fascicle_evaluation.py
+++ b/doc/examples/linear_fascicle_evaluation.py
@@ -1,7 +1,7 @@
 """
-=================================================
+=================================
 Linear fascicle evaluation (LiFE)
-=================================================
+=================================
 
 Evaluating the results of tractography algorithms is one of the biggest
 challenges for diffusion MRI. One proposal for evaluation of tractography

--- a/doc/examples/particle_filtering_fiber_tracking.py
+++ b/doc/examples/particle_filtering_fiber_tracking.py
@@ -1,7 +1,7 @@
 """
-=================================================
+===============================
 Particle Filtering Tractography
-=================================================
+===============================
 Particle Filtering Tractography (PFT) [Girard2014]_ uses tissue partial
 volume estimation (PVE) to reconstruct trajectories connecting the gray matter,
 and not incorrectly stopping in the white matter or in the corticospinal fluid.
@@ -57,7 +57,7 @@ dg = ProbabilisticDirectionGetter.from_shcoeff(csd_fit.shm_coeff,
 
 """
 CMC/ACT Tissue Classifiers
----------------------
+==========================
 Continuous map criterion (CMC) [Girard2014]_ and Anatomically-constrained
 tractography (ACT) [Smith2012]_ both uses PVEs information from
 anatomical images to determine when the tractography stops.

--- a/doc/examples/path_length_map.py
+++ b/doc/examples/path_length_map.py
@@ -1,7 +1,7 @@
 """
-==================================
+=========================
 Calculate Path Length Map
-==================================
+=========================
 
 We show how to calculate a Path Length Map for Anisotropic Radiation Therapy
 Contours given a set of streamlines and a region of interest (ROI).

--- a/doc/examples/reconst_csa.py
+++ b/doc/examples/reconst_csa.py
@@ -1,7 +1,7 @@
 """
-=================================================
+==============================================
 Reconstruct with Constant Solid Angle (Q-Ball)
-=================================================
+==============================================
 
 We show how to apply a Constant Solid Angle ODF (Q-Ball) model from Aganj et
 al. [Aganj2010]_ to your datasets.

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -1,7 +1,7 @@
 """
-==========================================================================
+=========================================================================
 Using the free water elimination model to remove free water contamination
-==========================================================================
+=========================================================================
 
 As shown previously (see :ref:`example_reconst_dti`), the diffusion tensor
 model is a simple way to characterize diffusion anisotropy. However, in regions

--- a/doc/examples/reconst_ivim.py
+++ b/doc/examples/reconst_ivim.py
@@ -1,7 +1,7 @@
 """
-============================================================
+============================
 Intravoxel incoherent motion
-============================================================
+============================
 The intravoxel incoherent motion (IVIM) model describes diffusion
 and perfusion in the signal acquired with a diffusion MRI sequence
 that contains multiple low b-values. The IVIM model can be understood

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-===============================================================================
+==============================================
 Mean signal diffusion kurtosis imaging (MSDKI)
-===============================================================================
+==============================================
 
 Several microstructural models have been proposed to increase the specificity
 of diffusion-weighted data; however, improper model assumptions are known to
@@ -53,9 +53,8 @@ from dipy.data import read_cfin_dwi
 from dipy.segment.mask import median_otsu
 
 """
-===============================================================================
 Testing MSDKI in synthetic data
-===============================================================================
+===============================
 
 We simulate representative diffusion-weighted signals using MultiTensor
 simulations (for more information on this type of simulations see
@@ -211,9 +210,8 @@ intersection angle.
 """
 
 """
-===============================================================================
 Reconstructing diffusion data using MSDKI
-===============================================================================
+=========================================
 
 Now that the properties of MSDKI were illustrated, let's apply MSDKI to in-vivo
 diffusion-weighted data. As the example for the standard DKI

--- a/doc/examples/reconst_qtdmri.py
+++ b/doc/examples/reconst_qtdmri.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-================================================================
+=================================================================
 Estimating diffusion time dependent q-space indices using qt-dMRI
-================================================================
+=================================================================
 Effective representation of the four-dimensional diffusion MRI signal --
 varying over three-dimensional q-space and diffusion time -- is a sought-after
 and still unsolved challenge in diffusion MRI (dMRI). We propose a functional

--- a/doc/examples/register_binary_fuzzy.py
+++ b/doc/examples/register_binary_fuzzy.py
@@ -1,7 +1,7 @@
 """
-=========================================================
+=======================================================
 Diffeomorphic Registration with binary and fuzzy images
-=========================================================
+=======================================================
 
 This example demonstrates registration of a binary and a fuzzy image.
 This could be seen as aligning a fuzzy (sensed) image to a binary

--- a/doc/examples/sfm_tracking.py
+++ b/doc/examples/sfm_tracking.py
@@ -1,9 +1,9 @@
 """
 .. _sfm-track:
 
-==================================================
+=======================================
 Tracking with the Sparse Fascicle Model
-==================================================
+=======================================
 
 Tracking requires a per-voxel model. Here, the model is the Sparse Fascicle
 Model (SFM), described in [Rokem2015]_. This model reconstructs the diffusion

--- a/doc/examples/snr_in_cc.py
+++ b/doc/examples/snr_in_cc.py
@@ -1,8 +1,8 @@
 """
 
-=============================================
+============================================
 SNR estimation for Diffusion-Weighted Images
-=============================================
+============================================
 
 Computing the Signal-to-Noise-Ratio (SNR) of DW images is still an open
 question, as SNR depends on the white matter structure of interest as well as

--- a/doc/examples/streamline_length.py
+++ b/doc/examples/streamline_length.py
@@ -1,7 +1,7 @@
 """
-=====================================
+====================================
 Streamline length and size reduction
-=====================================
+====================================
 
 This example shows how to calculate the lengths of a set of streamlines and
 also how to compress the streamlines without considerably reducing their

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -1,7 +1,7 @@
 """
-=================================================
+====================================================
 Bootstrap and Closest Peak Direction Getters Example
-=================================================
+====================================================
 
 This example shows how choices in direction-getter impact fiber
 tracking results by demonstrating the bootstrap direction getter (a type of

--- a/doc/examples/tracking_tissue_classifier.py
+++ b/doc/examples/tracking_tissue_classifier.py
@@ -63,7 +63,7 @@ dg = DeterministicMaximumDirectionGetter.from_shcoeff(csd_fit.shm_coeff,
 
 """
 Threshold Tissue Classifier
----------------------------
+===========================
 A scalar map can be used to define where the tracking stops. The threshold
 tissue classifier uses a scalar map to stop the tracking whenever the
 interpolated scalar value is lower than a fixed threshold. Here, we show
@@ -146,7 +146,7 @@ if have_fury:
 
 """
 Binary Tissue Classifier
-------------------------
+========================
 A binary mask can be used to define where the tracking stops. The binary
 tissue classifier stops the tracking whenever the tracking position is outside
 the mask. Here, we show how to obtain the binary tissue classifier from
@@ -218,7 +218,7 @@ if have_fury:
 
 """
 ACT Tissue Classifier
----------------------
+=====================
 Anatomically-constrained tractography (ACT) [Smith2012]_ uses information from
 anatomical images to determine when the tractography stops. The ``include_map``
 defines when the streamline reached a 'valid' stopping region (e.g. gray

--- a/doc/examples/viz_bundles.py
+++ b/doc/examples/viz_bundles.py
@@ -192,7 +192,8 @@ window.record(renderer, out_path='bundle5.png', size=(600, 600))
 """
 .. figure:: bundle5.png
    :align: center
-   **Color every streamline by the length of the streamline **
+
+   Color every streamline by the length of the streamline
 
 
 Show every point of every streamline with a different color

--- a/doc/examples/viz_roi_contour.py
+++ b/doc/examples/viz_roi_contour.py
@@ -1,7 +1,7 @@
 """
-==================================
+======================================================
 Visualization of ROI Surface Rendered with Streamlines
-==================================
+======================================================
 
 Here is a simple tutorial following the probabilistic CSA Tracking Example in
 which we generate a dataset of streamlines from a corpus callosum ROI, and

--- a/doc/examples/viz_slice.py
+++ b/doc/examples/viz_slice.py
@@ -212,7 +212,7 @@ fa_actor.AddObserver('LeftButtonPressEvent', left_click_callback, 1.0)
 
 """
 Create a mosaic
-================
+===============
 
 By using the ``copy`` and ``display`` method of the ``slice_actor`` becomes
 easy and efficient to create a mosaic of all the slices.

--- a/doc/examples/viz_timers.py
+++ b/doc/examples/viz_timers.py
@@ -1,7 +1,7 @@
 """
-===============
+=============
 Using a timer
-===============
+=============
 
 This example shows how to create a simple animation using a timer callback.
 

--- a/doc/examples/viz_ui.py
+++ b/doc/examples/viz_ui.py
@@ -252,7 +252,7 @@ listbox.on_change = display_element
 
 """
 Show Manager
-==================================
+============
 
 Now that all the elements have been initialised, we add them to the show
 manager.

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -61,7 +61,7 @@ Constrained Spherical Deconvolution
 - :ref:`example_reconst_csd`
 
 Fiber Orientation Estimated using Continuous Axially Symmetric Tensors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_reconst_forecast`
 
@@ -82,7 +82,7 @@ Studying diffusion time-dependence using qt-dMRI
 - :ref:`example_reconst_qtdmri`
 
 Diffusion Tensor Imaging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_reconst_dti`
 - :ref:`example_restore_dti`
@@ -90,7 +90,8 @@ Diffusion Tensor Imaging
 
 
 Diffusion Kurtosis Imaging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 - :ref:`example_reconst_dki`
 - :ref:`example_reconst_msdki`
 
@@ -119,12 +120,12 @@ DSI with Deconvolution
 - :ref:`example_reconst_dsid`
 
 Sparse Fascicle Model
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_sfm_reconst`
 
 Intravoxel incoherent motion (IVIM)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_reconst_ivim`
 
@@ -134,9 +135,9 @@ Statistical evaluation
 
 - :ref:`example_kfold_xval`
 
-------------------------------------------------
+----------------------
 Contextual enhancement
-------------------------------------------------
+----------------------
 
 - :ref:`example_contextual_enhancement`
 - :ref:`example_fiber_to_bundle_coherence`
@@ -153,9 +154,9 @@ Fiber tracking
 - :ref:`example_particle_filtering_fiber_tracking`
 - :ref:`example_sfm_tracking`
 
--------------------------------------
+-------------------------
 Fiber tracking evaluation
--------------------------------------
+-------------------------
 
 - :ref:`example_linear_fascicle_evaluation`
 
@@ -169,19 +170,21 @@ Streamline analysis and connectivity
 - :ref:`example_path_length_map`
 - :ref:`example_afq_tract_profiles`
 
-------------------
+------------
 Registration
-------------------
+------------
 
 Image-based Registration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 - :ref:`example_affine_registration_3d`
 - :ref:`example_syn_registration_2d`
 - :ref:`example_syn_registration_3d`
 - :ref:`example_register_binary_fuzzy`
 
 Streamline-based Registration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 - :ref:`example_bundle_registration`
 
 ------------
@@ -207,7 +210,7 @@ Tissue Classification
 - :ref:`example_tissue_classification`
 
 Bundle Extraction
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 - :ref:`example_bundle_extraction`
 
@@ -232,9 +235,9 @@ File Formats
 
 - :ref:`example_streamline_formats`
 
--------------------
+-------------
 Visualization
--------------------
+-------------
 
 - :ref:`example_viz_advanced`
 - :ref:`example_viz_slice`
@@ -244,8 +247,9 @@ Visualization
 - :ref:`example_viz_ui`
 - :ref:`example_viz_timers`
 
----------------
+---------
 Workflows
----------------
+---------
+
 - :ref:`example_workflow_creation`
 - :ref:`example_combined_workflow_creation`


### PR DESCRIPTION
Fix examples documentation generation warnings.

Fixes:
```
WARNING: Title overline too short.
```

and
```
/doc/examples_built/viz_bundles.rst:209: WARNING: Error in "figure"
directive:
invalid option block.

.. figure:: bundle5.png
   :align: center
   **Color every streamline by the length of the streamline **
```

warnings reported in
https://buildd.debian.org/status/fetch.php?pkg=dipy&arch=s390x&ver=0.14.0-1&stamp=1526401155&raw=0

Take advantage of the commit to increase consistency in titles:
- Use the same pattern for sections.
- Limit punctuation characters to the length of the text.