### PR TITLE
Remove deprecated parameter voxel_size

### DIFF
--- a/dipy/tracking/_utils.py
+++ b/dipy/tracking/_utils.py
@@ -5,13 +5,7 @@ from warnings import warn
 import numpy as np
 
 
-def _voxel_size_deprecated():
-    m = DeprecationWarning('the voxel_size argument to this function is '
-                           'deprecated, use the affine argument instead')
-    warn(m)
-
-
-def _mapping_to_voxel(affine, voxel_size):
+def _mapping_to_voxel(affine):
     """Inverts affine and returns a mapping so voxel coordinates. This
     function is an implementation detail and only meant to be used with
     ``_to_voxel_coordinates``.
@@ -21,8 +15,6 @@ def _mapping_to_voxel(affine, voxel_size):
     affine : array_like (4, 4)
         The mapping from voxel indices, [i, j, k], to real world coordinates.
         The inverse of this mapping is used unless `affine` is None.
-    voxel_size : array_like (3,)
-        Used to support deprecated trackvis space.
 
     Return
     ------
@@ -40,18 +32,14 @@ def _mapping_to_voxel(affine, voxel_size):
         If both affine and voxel_size are None.
 
     """
-    if affine is not None:
-        affine = np.array(affine, dtype=float)
-        inv_affine = np.linalg.inv(affine)
-        lin_T = inv_affine[:3, :3].T.copy()
-        offset = inv_affine[:3, 3] + .5
-    elif voxel_size is not None:
-        _voxel_size_deprecated()
-        voxel_size = np.asarray(voxel_size, dtype=float)
-        lin_T = np.diag(1. / voxel_size)
-        offset = 0.
-    else:
+    if affine is None:
         raise ValueError("no affine specified")
+
+    affine = np.array(affine, dtype=float)
+    inv_affine = np.linalg.inv(affine)
+    lin_T = inv_affine[:3, :3].T.copy()
+    offset = inv_affine[:3, 3] + .5
+
     return lin_T, offset
 
 

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_density_map():
     x = np.arange(10)
     expected = np.zeros(shape)
     expected[x, x, x] = 1.
-    dm = density_map(streamlines, vol_dims=shape, voxel_size=(1, 1, 1))
+    dm = density_map(streamlines, vol_dims=shape, affine=np.eye(4))
     npt.assert_array_equal(dm, expected)
 
     # add streamline, make voxel_size smaller. Each streamline should only be
@@ -57,10 +57,10 @@ def test_density_map():
     expected = np.zeros(shape)
     expected[x, x, x] = 1.
     expected[0, 0, 0] += 1
-    dm = density_map(streamlines, vol_dims=shape, voxel_size=(2, 2, 2))
+    dm = density_map(streamlines, vol_dims=shape, affine=np.eye(4)*2)
     npt.assert_array_equal(dm, expected)
     # should work with a generator
-    dm = density_map(iter(streamlines), vol_dims=shape, voxel_size=(2, 2, 2))
+    dm = density_map(iter(streamlines), vol_dims=shape, affine=np.eye(4)*2)
     npt.assert_array_equal(dm, expected)
 
     # Test passing affine
@@ -112,18 +112,21 @@ def test_connectivity_matrix():
     expected[3, 4] = 2
     expected[4, 3] = 1
     # Check basic Case
-    matrix = connectivity_matrix(streamlines, label_volume, (1, 1, 1),
+    matrix = connectivity_matrix(streamlines, label_volume, affine=np.eye(4),
                                  symmetric=False)
     npt.assert_array_equal(matrix, expected)
     # Test mapping
-    matrix, mapping = connectivity_matrix(streamlines, label_volume, (1, 1, 1),
-                                          symmetric=False, return_mapping=True)
+    matrix, mapping = connectivity_matrix(streamlines, label_volume,
+                                          affine=np.eye(4),
+                                          symmetric=False,
+                                          return_mapping=True)
     npt.assert_array_equal(matrix, expected)
     npt.assert_equal(mapping[3, 4], [0, 1])
     npt.assert_equal(mapping[4, 3], [2])
     npt.assert_equal(mapping.get((0, 0)), None)
     # Test mapping and symmetric
-    matrix, mapping = connectivity_matrix(streamlines, label_volume, (1, 1, 1),
+    matrix, mapping = connectivity_matrix(streamlines, label_volume,
+                                          affine=np.eye(4),
                                           symmetric=True, return_mapping=True)
     npt.assert_equal(mapping[3, 4], [0, 1, 2])
     # When symmetric only (3,4) is a key, not (4, 3)
@@ -132,7 +135,8 @@ def test_connectivity_matrix():
     expected = expected + expected.T
     npt.assert_array_equal(matrix, expected)
     # Test mapping_as_streamlines, mapping dict has lists of streamlines
-    matrix, mapping = connectivity_matrix(streamlines, label_volume, (1, 1, 1),
+    matrix, mapping = connectivity_matrix(streamlines, label_volume,
+                                          affine=np.eye(4),
                                           symmetric=False,
                                           return_mapping=True,
                                           mapping_as_streamlines=True)
@@ -437,12 +441,12 @@ def test_streamline_mapping():
     streamlines = [np.array([[0, 0, 0], [0, 0, 0], [0, 2, 2]], 'float'),
                    np.array([[0, 0, 0], [0, 1, 1], [0, 2, 2]], 'float'),
                    np.array([[0, 2, 2], [0, 1, 1], [0, 0, 0]], 'float')]
-    mapping = streamline_mapping(streamlines, (1, 1, 1))
+    mapping = streamline_mapping(streamlines, affine=np.eye(4))
     expected = {(0, 0, 0): [0, 1, 2], (0, 2, 2): [0, 1, 2],
                 (0, 1, 1): [1, 2]}
     npt.assert_equal(mapping, expected)
 
-    mapping = streamline_mapping(streamlines, (1, 1, 1),
+    mapping = streamline_mapping(streamlines, affine=np.eye(4),
                                  mapping_as_streamlines=True)
     expected = dict((k, [streamlines[i] for i in indices])
                     for k, indices in expected.items())

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -57,10 +57,12 @@ def test_density_map():
     expected = np.zeros(shape)
     expected[x, x, x] = 1.
     expected[0, 0, 0] += 1
-    dm = density_map(streamlines, vol_dims=shape, affine=np.eye(4)*2)
+    affine = np.eye(4) * 2
+    affine[:3, 3] = 0.05
+    dm = density_map(streamlines, vol_dims=shape, affine=affine)
     npt.assert_array_equal(dm, expected)
     # should work with a generator
-    dm = density_map(iter(streamlines), vol_dims=shape, affine=np.eye(4)*2)
+    dm = density_map(iter(streamlines), vol_dims=shape, affine=affine)
     npt.assert_array_equal(dm, expected)
 
     # Test passing affine

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -71,7 +71,7 @@ from dipy.io.bvectxt import orientation_from_string
 import nibabel as nib
 
 
-def density_map(streamlines, vol_dims, voxel_size=None, affine=None):
+def density_map(streamlines, vol_dims, affine=None):
     """Counts the number of unique streamlines that pass through each voxel.
 
     Parameters
@@ -82,8 +82,6 @@ def density_map(streamlines, vol_dims, voxel_size=None, affine=None):
     vol_dims : 3 ints
         The shape of the volume to be returned containing the streamlines
         counts
-    voxel_size :
-        This argument is deprecated.
     affine : array_like (4, 4)
         The mapping from voxel coordinates to streamline points.
 
@@ -105,7 +103,7 @@ def density_map(streamlines, vol_dims, voxel_size=None, affine=None):
     the edges of the voxels are smaller than the steps of the streamlines.
 
     """
-    lin_T, offset = _mapping_to_voxel(affine, voxel_size)
+    lin_T, offset = _mapping_to_voxel(affine)
     counts = np.zeros(vol_dims, 'int')
     for sl in streamlines:
         inds = _to_voxel_coordinates(sl, lin_T, offset)
@@ -116,8 +114,8 @@ def density_map(streamlines, vol_dims, voxel_size=None, affine=None):
     return counts
 
 
-def connectivity_matrix(streamlines, label_volume, voxel_size=None,
-                        affine=None, symmetric=True, return_mapping=False,
+def connectivity_matrix(streamlines, label_volume, affine=None,
+                        symmetric=True, return_mapping=False,
                         mapping_as_streamlines=False):
     """Counts the streamlines that start and end at each label pair.
 
@@ -128,8 +126,6 @@ def connectivity_matrix(streamlines, label_volume, voxel_size=None,
     label_volume : ndarray
         An image volume with an integer data type, where the intensities in the
         volume map to anatomical structures.
-    voxel_size :
-        This argument is deprecated.
     affine : array_like (4, 4)
         The mapping from voxel coordinates to streamline coordinates.
     symmetric : bool, True by default
@@ -170,7 +166,7 @@ def connectivity_matrix(streamlines, label_volume, voxel_size=None,
     endpoints = [sl[0::len(sl)-1] for sl in streamlines]
 
     # Map the streamlines coordinates to voxel coordinates
-    lin_T, offset = _mapping_to_voxel(affine, voxel_size)
+    lin_T, offset = _mapping_to_voxel(affine)
     endpoints = _to_voxel_coordinates(endpoints, lin_T, offset)
 
     # get labels for label_volume
@@ -568,7 +564,7 @@ def target(streamlines, target_mask, affine, include=True):
 
     """
     target_mask = np.array(target_mask, dtype=bool, copy=True)
-    lin_T, offset = _mapping_to_voxel(affine, voxel_size=None)
+    lin_T, offset = _mapping_to_voxel(affine)
     yield
     # End of initialization
 
@@ -624,7 +620,7 @@ def target_line_based(streamlines, target_mask, affine=None, include=True):
     dipy.tracking.streamline.compress_streamlines
     """
     target_mask = np.array(target_mask, dtype=np.uint8, copy=True)
-    lin_T, offset = _mapping_to_voxel(affine, voxel_size=None)
+    lin_T, offset = _mapping_to_voxel(affine)
     streamline_index = _streamlines_in_mask(
         streamlines, target_mask, lin_T, offset)
     yield
@@ -1116,7 +1112,7 @@ def path_length(streamlines, aoi, affine, fill_value=-1):
     # path length map
     plm = np.empty(aoi.shape, dtype=float)
     plm[:] = np.inf
-    lin_T, offset = _mapping_to_voxel(affine, None)
+    lin_T, offset = _mapping_to_voxel(affine)
     for sl in streamlines:
         seg_ind = _to_voxel_coordinates(sl, lin_T, offset)
         i, j, k = seg_ind.T

--- a/dipy/tracking/vox2track.pyx
+++ b/dipy/tracking/vox2track.pyx
@@ -74,7 +74,7 @@ def _voxel2streamline(sl,
     return v2f ,v2fn
 
 
-def streamline_mapping(streamlines, voxel_size=None, affine=None,
+def streamline_mapping(streamlines, affine=None,
                        mapping_as_streamlines=False):
     """Creates a mapping from voxel indices to streamlines.
 
@@ -85,14 +85,11 @@ def streamline_mapping(streamlines, voxel_size=None, affine=None,
     ----------
     streamlines : sequence
         A sequence of streamlines.
-    voxel_size : array_like (3,), optional
-        The size of the voxels in the image volume. This is ignored if affine
-        is set.
     affine : array_like (4, 4), optional
-        The mapping from voxel coordinates to streamline coordinates. If
-        neither `affine` or `voxel_size` is set, the streamline values are
-        assumed to be in voxel coordinates. IE ``[0, 0, 0]`` is the center of
-        the first voxel and the voxel size is ``[1, 1, 1]``.
+        The mapping from voxel coordinates to streamline coordinates.
+        The streamline values are assumed to be in voxel coordinates.
+        IE ``[0, 0, 0]`` is the center of the first voxel and the voxel size
+        is ``[1, 1, 1]``.
     mapping_as_streamlines : bool, optional, False by default
         If True voxel indices map to lists of streamline objects. Otherwise
         voxel indices map to lists of integers.
@@ -110,7 +107,7 @@ def streamline_mapping(streamlines, voxel_size=None, affine=None,
     ...                          [2., 3., 4.]]),
     ...                np.array([[0., 0., 0.],
     ...                          [1., 2., 3.]])]
-    >>> mapping = streamline_mapping(streamlines, (1, 1, 1))
+    >>> mapping = streamline_mapping(streamlines, affine=np.eye(4))
     >>> mapping[0, 0, 0]
     [0, 1]
     >>> mapping[1, 1, 1]
@@ -119,7 +116,7 @@ def streamline_mapping(streamlines, voxel_size=None, affine=None,
     [1]
     >>> mapping.get((3, 2, 1), 'no streamlines')
     'no streamlines'
-    >>> mapping = streamline_mapping(streamlines, (1, 1, 1),
+    >>> mapping = streamline_mapping(streamlines, affine=np.eye(4),
     ...                              mapping_as_streamlines=True)
     >>> mapping[1, 2, 3][0] is streamlines[1]
     True
@@ -128,7 +125,7 @@ def streamline_mapping(streamlines, voxel_size=None, affine=None,
     cdef:
         cnp.ndarray[cnp.int_t, ndim=2, mode='strided'] voxel_indices
 
-    lin, offset = _mapping_to_voxel(affine, voxel_size)
+    lin, offset = _mapping_to_voxel(affine)
     if mapping_as_streamlines:
         streamlines = list(streamlines)
     mapping = {}

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -24,10 +24,17 @@ The order of parameters has also changed.
 
 **Simulation**
 
-``dipy.sims.voxel.SingleTensor`` has been replaced by ``dipy.sims.voxel.single_tensor``
-``dipy.sims.voxel.MultiTensor`` has been replaced by ``dipy.sims.voxel.multi_tensor``
-``dipy.sims.voxel.SticksAndBall`` has been replaced by ``dipy.sims.voxel.sticks_and_ball``
+- ``dipy.sims.voxel.SingleTensor`` has been replaced by ``dipy.sims.voxel.single_tensor``
+- ``dipy.sims.voxel.MultiTensor`` has been replaced by ``dipy.sims.voxel.multi_tensor``
+- ``dipy.sims.voxel.SticksAndBall`` has been replaced by ``dipy.sims.voxel.sticks_and_ball``
 
+**Tracking**
+
+The `voxel_size` parameter has been removed from the following function:
+    ``dipy.tracking.utils.connectivity_matrix``
+    ``dipy.tracking.utils.density_map``
+    ``dipy.tracking.utils.stremline_mapping``
+    ``dipy.tracking._util._mapping_to_voxel``
 
 DIPY 0.16 Changes
 -----------------


### PR DESCRIPTION
Since `voxel_size` was deprecated since a long time, this parameter has been removed from the following function:
    ``dipy.tracking.utils.connectivity_matrix``
    ``dipy.tracking.utils.density_map``
    ``dipy.tracking.utils.streamline_mapping``
    ``dipy.tracking._util._mapping_to_voxel``