### PR TITLE
Spherical deconvolution model CANNOT be constructed without specifying a response

### DIFF
--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -14,6 +14,7 @@ from dipy.sims.voxel import single_tensor, multi_tensor
 
 
 DEFAULT_SH = 4
+response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
 
 
 def test_bdg_initial_direction():
@@ -114,7 +115,7 @@ def test_bdg_residual():
     voxel = np.concatenate((np.zeros(1), sphere_func))
     data = np.tile(voxel, (3, 3, 3, 1))
 
-    csd_model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=6)
+    csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
     boot_pmf_gen = BootPmfGen(data, model=csd_model, sphere=hsph_updated,
                               sh_order=6)
 
@@ -134,8 +135,9 @@ def test_bdg_residual():
     # test with a gtab with two shells and assert you get an error
     bvals[-1] = 2000
     gtab = gradient_table(bvals, bvecs)
-    csd_model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=6)
+    csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
     npt.assert_raises(ValueError, BootPmfGen, data, csd_model, hsph_updated, 6)
+
 
 if __name__ == '__main__':
     npt.run_module_suite()

--- a/dipy/direction/tests/test_pmf.py
+++ b/dipy/direction/tests/test_pmf.py
@@ -10,6 +10,8 @@ from dipy.reconst.csdeconv import ConstrainedSphericalDeconvModel
 from dipy.reconst.dti import TensorModel
 from dipy.sims.voxel import single_tensor
 
+response = (np.array([1.5e3, 0.3e3, 0.3e3]), 1)
+
 
 def test_pmf_from_sh():
     sphere = HemiSphere.from_sphere(unit_octahedron)
@@ -44,6 +46,7 @@ def test_pmf_from_array():
         ValueError,
         lambda: SimplePmfGen(np.ones([2, 2, 2, len(sphere.vertices)])*-1))
 
+
 def test_boot_pmf():
     """This tests the local model used for the bootstrapping.
     """
@@ -70,7 +73,8 @@ def test_boot_pmf():
     # test model spherical harmonic order different than bootstrap order
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always", category=UserWarning)
-        csd_model = ConstrainedSphericalDeconvModel(gtab, None, sh_order=6)
+        csd_model = ConstrainedSphericalDeconvModel(gtab, response,
+                                                    sh_order=6)
         assert_greater(len([lw for lw in w if issubclass(lw.category,
                                                          UserWarning)]), 0)
 

--- a/dipy/reconst/csdeconv.py
+++ b/dipy/reconst/csdeconv.py
@@ -60,8 +60,8 @@ class AxSymShResponse(object):
 
 class ConstrainedSphericalDeconvModel(SphHarmModel):
 
-    def __init__(self, gtab, response, reg_sphere=None, sh_order=8, lambda_=1,
-                 tau=0.1, convergence=50):
+    def __init__(self, gtab, response, reg_sphere=None, sh_order=8,
+                 lambda_=1, tau=0.1, convergence=50):
         r""" Constrained Spherical Deconvolution (CSD) [1]_.
 
         Spherical deconvolution computes a fiber orientation distribution
@@ -82,9 +82,9 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
         response : tuple or AxSymShResponse object
             A tuple with two elements. The first is the eigen-values as an (3,)
             ndarray and the second is the signal value for the response
-            function without diffusion weighting.  This is to be able to
-            generate a single fiber synthetic signal. The response function
-            will be used as deconvolution kernel ([1]_)
+            function without diffusion weighting (i.e. S0).  This is to be able
+            to generate a single fiber synthetic signal. The response function
+            will be used as deconvolution kernel ([1]_).
         reg_sphere : Sphere (optional)
             sphere used to build the regularization B matrix.
             Default: 'symmetric362'.
@@ -100,7 +100,8 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             set to tau*100 % of the mean fODF amplitude (here, 10% by default)
             (see [1]_). Default: 0.1
         convergence : int
-            Maximum number of iterations to allow the deconvolution to converge.
+            Maximum number of iterations to allow the deconvolution to
+            converge.
 
         References
         ----------
@@ -147,9 +148,6 @@ class ConstrainedSphericalDeconvModel(SphHarmModel):
             self.sphere.z
         )
         self.B_reg = real_sph_harm(m, n, theta[:, None], phi[:, None])
-
-        if response is None:
-            response = (np.array([0.0015, 0.0003, 0.0003]), 1)
 
         self.response = response
         if isinstance(response, AxSymShResponse):
@@ -383,6 +381,7 @@ def forward_sdt_deconv_mat(ratio, n, r2_term=False):
     .. [1] Descoteaux, M. PhD Thesis. INRIA Sophia-Antipolis. 2008.
 
     """
+
     if np.any(n % 2):
         raise ValueError("n has odd degrees, expecting only even degrees")
     n_degrees = n.max() // 2 + 1
@@ -601,9 +600,11 @@ def odf_deconv(odf_sh, R, B_reg, lambda_=1., tau=0.1, r2_term=False):
     odf_sh : ndarray (``(sh_order + 1)*(sh_order + 2)/2``,)
          ndarray of SH coefficients for the ODF spherical function to be
          deconvolved
-    R : ndarray (``(sh_order + 1)(sh_order + 2)/2``, ``(sh_order + 1)(sh_order + 2)/2``)
+    R : ndarray (``(sh_order + 1)(sh_order + 2)/2``,
+         ``(sh_order + 1)(sh_order + 2)/2``)
          SDT matrix in SH basis
-    B_reg : ndarray (``(sh_order + 1)(sh_order + 2)/2``, ``(sh_order + 1)(sh_order + 2)/2``)
+    B_reg : ndarray (``(sh_order + 1)(sh_order + 2)/2``,
+         ``(sh_order + 1)(sh_order + 2)/2``)
          SH basis matrix used for deconvolution
     lambda_ : float
          lambda parameter in minimization equation (default 1.0)
@@ -784,7 +785,8 @@ def fa_superior(FA, fa_thr):
 
         Returns
         -------
-        True when the FA value is greater than the FA threshold, otherwise False.
+        True when the FA value is greater than the FA threshold, otherwise
+        False.
     """
     return FA > fa_thr
 

--- a/dipy/reconst/tests/test_csdeconv.py
+++ b/dipy/reconst/tests/test_csdeconv.py
@@ -25,12 +25,10 @@ from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
 from dipy.direction.peaks import peak_directions
 from dipy.core.sphere_stats import angular_similarity
 from dipy.reconst.dti import TensorModel, fractional_anisotropy
-from dipy.reconst.shm import (CsaOdfModel, QballModel, sf_to_sh, sh_to_sf,
+from dipy.reconst.shm import (QballModel, sf_to_sh, sh_to_sf,
                               real_sym_sh_basis, sph_harm_ind_list)
 from dipy.reconst.shm import lazy_index
-from dipy.core.geometry import cart2sphere
 import dipy.reconst.dti as dti
-from dipy.reconst.dti import fractional_anisotropy
 from dipy.core.sphere import Sphere
 from dipy.io.gradients import read_bvals_bvecs
 
@@ -521,6 +519,7 @@ def test_sphere_scaling_csdmodel():
     csd_fit_hemi = model_hemi.fit(S)
 
     assert_array_almost_equal(csd_fit_full.shm_coeff, csd_fit_hemi.shm_coeff)
+
 
 expected_lambda = {4: 27.5230088, 8: 82.5713865, 16: 216.0843135}
 

--- a/doc/examples/reconst_csd.py
+++ b/doc/examples/reconst_csd.py
@@ -14,8 +14,10 @@ a spherical grid.
 
 The basic idea with this method is that if we could estimate the response
 function of a single fiber then we could deconvolve the measured signal and
-obtain the underlying fiber distribution. The reconstruction of the fiber
-orientation distribution function (fODF) in CSD involves, therefore, two steps:
+obtain the underlying fiber distribution.
+
+In this way, the reconstruction of the fiber orientation distribution function
+(fODF) in CSD involves two steps:
     1. Estimation of the fiber response function
     2. Use the response function to reconstruct the fODF
 
@@ -33,23 +35,23 @@ img, gtab = read_stanford_hardi()
 data = img.get_data()
 
 """
-You can verify the b-values of the datasets by looking at the attribute
-``gtab.bvals``. Now that we loaded a datasets with multiple gradient directions
-on a sphere, code to perform the two CSD steps is presented below:
+You can verify the b-values of the dataset by looking at the attribute
+``gtab.bvals``. Now that a datasets with multiple gradient directions is
+loaded, we can proceed with the two steps of CSD.
 
 ## Step 1. Estimation of the fiber response function.
 
 There are many strategies to estimate the fiber response function. Here two
 different strategies are presented.
 
-**Strategy 1 - response function from a local brain region** One simple
-way to estimate the fiber response function is to look for regions of the brain
-where it is known that there are single coherent fiber populations.
-For example, if we use an ROI at the center of the brain, we will find single
-fibers from the corpus callosum. The ``auto_response`` function will calculate
-FA for an ROI of radius equal to ``roi_radius`` in the center of the volume and
-return the response function estimated in that region for the voxels with FA
-higher than 0.7.
+**Strategy 1 - response function estimates from a local brain region**
+One simple way to estimate the fiber response function is to look for regions
+of the brain where it is known that there are single coherent fiber
+populations. For example, if we use an ROI at the center of the brain, we will
+find single fibers from the corpus callosum. The ``auto_response`` function
+will calculate FA for an ROI of radius equal to ``roi_radius`` in the center
+of the volume and return the response function estimated in that region for
+the voxels with FA higher than 0.7.
 """
 
 from dipy.reconst.csdeconv import auto_response
@@ -118,7 +120,7 @@ if interactive:
 ren.rm(response_actor)
 
 """
-**Strategy 2 - response function from global brain** Depending
+**Strategy 2 - data-driven calibration of response function** Depending
 on the dataset, FA threshold may not be the best way to find the best possible
 response function. For one, it depends on the diffusion tensor
 (FA and first eigenvector), which has lower accuracy at high


### PR DESCRIPTION
I've created this PR basically to address issue #283. 

After analysing the issue, I've decided that the best solution is to remove the response=None option. If one wants to use a predefined response function, it can just defined it on its own risk by calling:
response=(np.array([AD, RD, RD]), S0)

Using an None option is not ideal also because it does not allows the adjustment of S0. At the current version of the CSD implementation, data is normalised based on this inputed S0 estimate, so having it properly estimated might be crucial for the estimation of the fODF shape. 

After revising  the CSD example, I've noticed that it might be hard to ready for non diffusion MRI experts. For instance, it might not be clear that the time consuming response function calibration procedure is optional. To make the example easier to read, I've added some sub-headings. Please let me know your comments and suggestions on this issue.
