### PR TITLE
A functional implementation of Random matrix local pca.

### DIFF
--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -10,7 +10,7 @@ except ImportError:
 from scipy.linalg import eigh
 
 
-def pca_classifier(L, m):
+def _pca_classifier(L, m):
     """ Classifies which PCA eigenvalues are related to noise and estimates the
     noise variance
 
@@ -21,10 +21,10 @@ def pca_classifier(L, m):
 
     Returns
     -------
-    c : int
-        Number of eigenvalues related to noise
     var : float
         Estimation of the noise variance
+    c : int
+        Number of eigenvalues related to noise
 
     Notes
     -----
@@ -44,7 +44,7 @@ def pca_classifier(L, m):
         var = np.mean(L[:c])
         c = c - 1
         r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / m) * var
-    return c, var
+    return var, c + 1
 
 
 def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
@@ -205,7 +205,7 @@ def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
 
                 if sigma is None:
                     # Random matrix theory
-                    c, this_var = pca_classifier(d, patch_size ** 3)
+                    this_var, c = _pca_classifier(d, patch_size ** 3)
                 else:
                     # Threshold by tau:
                     c = np.sum(d < tau)

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -50,21 +50,21 @@ def _pca_classifier(L, m):
 
 def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
              tau_factor=None, return_sigma=False, out_dtype=None):
-    r"""Local PCA-based denoising of diffusion datasets.
+    r"""General function to perform PCA-based denoising of diffusion datasets.
 
     Parameters
     ----------
     arr : 4D array
         Array of data to be denoised. The dimensions are (X, Y, Z, N), where N
         are the diffusion gradient directions.
-    mask : 3D boolean array (optional)
-        A mask with voxels that are true inside the brain and false outside of
-        it. The function denoises within the true part and returns zeros
-        outside of those voxels.
     sigma : float or 3D array (optional)
         Standard deviation of the noise estimated from the data. If no sigma
         is given, this will be estimated based on random matrix theory
         [1]_,[2]_
+    mask : 3D boolean array (optional)
+        A mask with voxels that are true inside the brain and false outside of
+        it. The function denoises within the true part and returns zeros
+        outside of those voxels.
     pca_method : 'eig' or 'svd' (optional)
         Use either eigenvalue decomposition (eig) or singular value
         decomposition (svd) for principal component analysis. The default
@@ -83,8 +83,7 @@ def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
 
         \tau_{factor} can be set to a predefined values (e.g. \tau_{factor} =
         2.3 [3]_), or automatically calculated using random matrix theory
-        (optimal value). The optimal value is used if \tau_{factor} is set to
-        None.
+        (in case that \tau_{factor} is set to None).
         Default: None.
     return_sigma : bool (optional)
         If true, the Standard deviation of the noise will be returned.

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -238,11 +238,11 @@ def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
 
     denoised_arr = thetax / theta
     denoised_arr.clip(min=0, out=denoised_arr)
-    denoised_arr[~mask] = 0
+    denoised_arr[mask == 0] = 0
     if return_sigma is True:
         if sigma is None:
             var = var / thetavar
-            var[~mask] = 0
+            var[mask == 0] = 0
             return denoised_arr.astype(out_dtype), np.sqrt(var)
         else:
             return denoised_arr.astype(out_dtype), sigma

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -10,6 +10,43 @@ except ImportError:
 from scipy.linalg import eigh
 
 
+def pca_classifier(L, m):
+    """ Classifies which PCA eigenvalues are related to noise and estimates the
+    noise variance
+
+    Parameters
+    ----------
+    L : array (n,)
+        Array containing the PCA eigenvalues in ascending order.
+
+    Returns
+    -------
+    c : int
+        Number of eigenvalues related to noise
+    var : float
+        Estimation of the noise variance
+
+    Notes
+    -----
+    This is based on the algorithm described in [1]_.
+
+    References
+    ----------
+    .. [1] Veraart J, Novikov DS, Christiaens D, Ades-aron B, Sijbers,
+           Fieremans E, 2016. Denoising of Diffusion MRI using random matrix
+           theory. Neuroimage 142:394-406.
+           doi: 10.1016/j.neuroimage.2016.08.016
+    """
+    var = np.mean(L)
+    c = L.size - 1
+    r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / m) * var
+    while r > 0:
+        var = np.mean(L[:c])
+        c = c - 1
+        r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / m) * var
+    return c, var
+
+
 def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
              tau_factor=2.3, out_dtype=None):
     r"""Local PCA-based denoising of diffusion datasets.

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -10,7 +10,7 @@ except ImportError:
 from scipy.linalg import eigh
 
 
-def _pca_classifier(L, m):
+def _pca_classifier(L, nvoxels):
     """ Classifies which PCA eigenvalues are related to noise and estimates the
     noise variance
 
@@ -18,6 +18,8 @@ def _pca_classifier(L, m):
     ----------
     L : array (n,)
         Array containing the PCA eigenvalues in ascending order.
+    wdim : int
+        Number of voxels used to compute L
 
     Returns
     -------
@@ -39,11 +41,11 @@ def _pca_classifier(L, m):
     """
     var = np.mean(L)
     c = L.size - 1
-    r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / m) * var
+    r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / nvoxels) * var
     while r > 0:
         var = np.mean(L[:c])
         c = c - 1
-        r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / m) * var
+        r = L[c] - L[0] - 4 * np.sqrt((c + 1.0) / nvoxels) * var
     ncomps = c + 1
     return var, ncomps
 

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -47,8 +47,8 @@ def pca_classifier(L, m):
     return c, var
 
 
-def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
-             tau_factor=2.3, out_dtype=None):
+def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
+             tau_factor=2.3, out_dtype=None, return_sigma=False):
     r"""Local PCA-based denoising of diffusion datasets.
 
     Parameters
@@ -56,21 +56,23 @@ def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
     arr : 4D array
         Array of data to be denoised. The dimensions are (X, Y, Z, N), where N
         are the diffusion gradient directions.
-    mask : 3D boolean array
+    mask : 3D boolean array (optional)
         A mask with voxels that are true inside the brain and false outside of
         it. The function denoises within the true part and returns zeros
         outside of those voxels.
-    sigma : float or 3D array
-        Standard deviation of the noise estimated from the data.
-    pca_method : 'eig' or 'svd'
+    sigma : float or 3D array (optional)
+        Standard deviation of the noise estimated from the data. If no sigma
+        is given, this will be estimated based on random matrix theory
+        [1]_,[2]_
+    pca_method : 'eig' or 'svd' (optional)
         Use either eigenvalue decomposition (eig) or singular value
         decomposition (svd) for principal component analysis. The default
         method is 'eig' which is faster. However, occasionally 'svd' might be
         more accurate.
-    patch_radius : int, optional
+    patch_radius : int (optional)
         The radius of the local patch to be taken around each voxel (in
         voxels). Default: 2 (denoise in blocks of 5x5x5 voxels).
-    tau_factor : float, optional
+    tau_factor : float (optional)
         Thresholding of PCA eigenvalues is done by nulling out eigenvalues that
         are smaller than:
 
@@ -78,10 +80,15 @@ def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
 
                 \tau = (\tau_{factor} \sigma)^2
 
-        Default: 2.3, based on the results described in [Manjon13]_.
-    out_dtype : str or dtype, optional
+        Default: 2.3, based on the results described in [3]_. Note that if
+        sigma is estimated using random matrix theory (i.e. sigma=None),
+        this threshold will be ignored.
+    out_dtype : str or dtype (optional)
         The dtype for the output array. Default: output has the same dtype as
         the input.
+    return_sigma : bool (optional)
+        If true, the Standard deviation of the noise will be returned
+        Default: False
 
     Returns
     -------
@@ -91,10 +98,17 @@ def localpca(arr, sigma, mask=None, pca_method='eig', patch_radius=2,
 
     References
     ----------
-    .. [Manjon13] Manjon JV, Coupe P, Concha L, Buades A, Collins DL (2013)
-                  Diffusion Weighted Image Denoising Using Overcomplete Local
-                  PCA. PLoS ONE 8(9): e73021.
-                  https://doi.org/10.1371/journal.pone.0073021
+    .. [1] Veraart J, Fieremans E, Novikov DS. 2016. Diffusion MRI noise
+           mapping using random matrix theory. Magnetic Resonance in Medicine.
+           doi: 10.1002/mrm.26059.
+    .. [2] Veraart J, Novikov DS, Christiaens D, Ades-aron B, Sijbers,
+           Fieremans E, 2016. Denoising of Diffusion MRI using random matrix
+           theory. Neuroimage 142:394-406.
+           doi: 10.1016/j.neuroimage.2016.08.016
+    .. [3] Manjon JV, Coupe P, Concha L, Buades A, Collins DL (2013)
+           Diffusion Weighted Image Denoising Using Overcomplete Local
+           PCA. PLoS ONE 8(9): e73021.
+           https://doi.org/10.1371/journal.pone.0073021
     """
     if mask is None:
         # If mask is not specified, use the whole volume

--- a/dipy/denoise/localpca.py
+++ b/dipy/denoise/localpca.py
@@ -87,7 +87,7 @@ def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
         The dtype for the output array. Default: output has the same dtype as
         the input.
     return_sigma : bool (optional)
-        If true, the Standard deviation of the noise will be returned
+        If true, the Standard deviation of the noise will be returned.
         Default: False
 
     Returns
@@ -162,7 +162,8 @@ def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
     dim = arr.shape[-1]
 
     if return_sigma is True and sigma is None:
-        var = np.zeros(arr.shape, dtype=calc_dtype)
+        var = np.zeros(arr.shape[:-1], dtype=calc_dtype)
+        thetavar = np.zeros(arr.shape[:-1], dtype=calc_dtype)
 
     # loop around and find the 3D patch for each direction at each pixel
     for k in range(patch_radius, arr.shape[2] - patch_radius):
@@ -221,13 +222,14 @@ def localpca(arr, sigma=None, mask=None, pca_method='eig', patch_radius=2,
                 thetax[ix1:ix2, jx1:jx2, kx1:kx2] += Xest * this_theta
                 if return_sigma is True and sigma is None:
                     var[ix1:ix2, jx1:jx2, kx1:kx2] += this_var * this_theta
+                    thetavar[ix1:ix2, jx1:jx2, kx1:kx2] += this_theta
 
     denoised_arr = thetax / theta
     denoised_arr.clip(min=0, out=denoised_arr)
     denoised_arr[~mask] = 0
     if return_sigma is True:
         if sigma is None:
-            var = var / theta
+            var = var / thetavar
             var[~mask] = 0
             return denoised_arr.astype(out_dtype), np.sqrt(var)
         else:

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -306,18 +306,23 @@ def test_lpca_returned_sigma():
     std_gt = 0.02
     noise = std_gt*np.random.standard_normal(DWIgt.shape)
     DWInoise = DWIgt + noise
-    DWIden = localpca(DWInoise, patch_radius=2)
 
     # Case that sigma is estimated using mpPCA
-    DWIden, sigma = localpca(DWInoise, patch_radius=2, return_sigma=True)
+    DWIden0, sigma = localpca(DWInoise, patch_radius=2, return_sigma=True)
     msigma = np.mean(sigma)
     std_error = abs(msigma - std_gt)/std_gt * 100
     assert_(std_error < 5)
 
-    # Case that sigma is inputed (sigma outputed should be the same)
-    DWIden, rsigma = localpca(DWInoise, sigma=sigma,
-                              patch_radius=2, return_sigma=True)
+    # Case that sigma is inputed (sigma outputed should be the same as the one
+    # inputed)
+    DWIden1, rsigma = localpca(DWInoise, sigma=sigma,
+                               patch_radius=2, return_sigma=True)
     assert_array_almost_equal(rsigma, sigma)
+
+    # DWIden1 should be very similar to DWIden0
+    rmse_den = np.sum(np.abs(DWIden1 - DWIden0)) / np.sum(np.abs(DWIden0))
+    rmse_ref = np.sum(np.abs(DWIden1 - DWIgt)) / np.sum(np.abs(DWIgt))
+    assert_(rmse_den < rmse_ref)
 
 
 if __name__ == '__main__':

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -5,7 +5,7 @@ from numpy.testing import (run_module_suite,
                            assert_equal,
                            assert_raises,
                            assert_array_almost_equal)
-from dipy.denoise.localpca import (localpca, _pca_classifier)
+from dipy.denoise.localpca import (localpca, mppca, genpca, _pca_classifier)
 from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import gradient_table, generate_bvecs
 
@@ -288,12 +288,12 @@ def test_pca_classifier():
     assert_(std_error < 5)
 
 
-def test_mpPCA_in_phantom():
+def test_mppca_in_phantom():
     DWIgt = rfiw_phantom(gtab, snr=None)
     std_gt = 0.02
     noise = std_gt*np.random.standard_normal(DWIgt.shape)
     DWInoise = DWIgt + noise
-    DWIden = localpca(DWInoise, patch_radius=2)
+    DWIden = mppca(DWInoise, patch_radius=2)
 
     # Test if denoised data is closer to ground truth than noisy data
     rmse_den = np.sum(np.abs(DWIgt - DWIden)) / np.sum(np.abs(DWIgt))
@@ -301,21 +301,21 @@ def test_mpPCA_in_phantom():
     assert_(rmse_den < rmse_noisy)
 
 
-def test_lpca_returned_sigma():
+def test_mppca_returned_sigma():
     DWIgt = rfiw_phantom(gtab, snr=None)
     std_gt = 0.02
     noise = std_gt*np.random.standard_normal(DWIgt.shape)
     DWInoise = DWIgt + noise
 
     # Case that sigma is estimated using mpPCA
-    DWIden0, sigma = localpca(DWInoise, patch_radius=2, return_sigma=True)
+    DWIden0, sigma = mppca(DWInoise, patch_radius=2, return_sigma=True)
     msigma = np.mean(sigma)
     std_error = abs(msigma - std_gt)/std_gt * 100
     assert_(std_error < 5)
 
     # Case that sigma is inputed (sigma outputed should be the same as the one
     # inputed)
-    DWIden1, rsigma = localpca(DWInoise, sigma=sigma,
+    DWIden1, rsigma = genpca(DWInoise, sigma=sigma, tau_factor=None,
                                patch_radius=2, return_sigma=True)
     assert_array_almost_equal(rsigma, sigma)
 

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -291,5 +291,19 @@ def test_pca_classifier():
     assert_(std_error < 10)
 
 
+def test_mpPCA_in_phantom():
+    gtab = gen_gtab()
+    DWIgt = rfiw_phantom(gtab, snr=None)
+    std_gt = 0.02
+    noise = std_gt*np.random.standard_normal(DWIgt.shape)
+    DWInoise = DWIgt + noise
+    DWIden = localpca(DWInoise, patch_radius=2)
+
+    # Test if denoised data is closer to ground truth than noisy data
+    rmse_den = np.sum(np.abs(DWIgt - DWIden)) / np.sum(np.abs(DWIgt))
+    rmse_noisy = np.sum(np.abs(DWIgt - DWInoise)) / np.sum(np.abs(DWIgt))
+    assert_(rmse_den < rmse_noisy)
+
+
 if __name__ == '__main__':
     run_module_suite()

--- a/dipy/denoise/tests/test_lpca.py
+++ b/dipy/denoise/tests/test_lpca.py
@@ -5,7 +5,7 @@ from numpy.testing import (run_module_suite,
                            assert_equal,
                            assert_raises,
                            assert_array_almost_equal)
-from dipy.denoise.localpca import (localpca, pca_classifier)
+from dipy.denoise.localpca import (localpca, _pca_classifier)
 from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import gradient_table, generate_bvecs
 
@@ -273,14 +273,14 @@ def test_pca_classifier():
     [L, W] = np.linalg.eigh(np.dot(X.T, X)/125)
 
     # Find number of noise related eigenvalues
-    c, var = pca_classifier(L, 125)
+    var, c = _pca_classifier(L, 125)
     std = np.sqrt(var)
 
-    # Expected number of signal components is 1 because phantom only has one
-    # voxel type. Therefore, expected noise components is (L.size - 1).
+    # Expected number of signal components is 0 because phantom only has one
+    # voxel type and that information is campured by the mean of X.
+    # Therefore, expected noise components should be equal to size of L.
     # To allow some margin of error let's assess if c is higher than
-    # L.size - 3. Note that algorithm is tuned to be conservative (i.e.
-    # preserve the signal information as much as posible).
+    # L.size - 3.
     assert_(c > L.size-3)
 
     # Let's check if noise std estimate as an error less than 5%

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -72,7 +72,7 @@ estimate.
 
 t = time()
 
-denoised_arr = localpca(data, sigma=None, patch_radius=2)
+denoised_arr = localpca(data, sigma=sigma, patch_radius=2)
 
 print("Time taken for local PCA (slow)", -t + time())
 

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -72,7 +72,7 @@ estimate.
 
 t = time()
 
-denoised_arr = localpca(data, sigma=sigma, patch_radius=2)
+denoised_arr = localpca(data, sigma=None, patch_radius=2)
 
 print("Time taken for local PCA (slow)", -t + time())
 

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -1,6 +1,6 @@
 """
 =======================================================
-Denoise images using Local PCA and empirical thresholds
+Denoise images using Local PCA via empirical thresholds
 =======================================================
 
 PCA-based denoising algorithms are effective denoising methods because they

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -1,14 +1,15 @@
 """
-===============================
-Denoise images using Local PCA
-===============================
+=======================================================
+Denoise images using Local PCA and empirical thresholds
+=======================================================
 
-The local PCA based denoising algorithm [Manjon2013]_ is an effective denoising
-method because it takes into account the directional information in diffusion
-data.
+PCA-based denoising algorithms are effective denoising methods because they
+explore the redundancy of the multi-dimensional information of
+diffusion-weighted datasets. In this example, we will show how to
+perform the PCA-based denoising using the algorithm proposed by Manjon et al.
+[Manjon2013]_.
 
-The basic idea behind local PCA based diffusion denoising can be explained in
-the following three basic steps:
+This algorithm involves the following steps:
 
 * First, we estimate the local noise variance at each voxel.
 
@@ -17,6 +18,10 @@ the following three basic steps:
 
 * Finally, we threshold the eigenvalues based on the local estimate of sigma
   and then do a PCA reconstruction
+
+
+To perform PCA denoising without a prior noise standard deviation estimate
+please see the following example instead: :ref:`denoise_mppca`
 
 Let's load the necessary modules
 """
@@ -44,12 +49,14 @@ affine = img.affine
 print("Input Volume", data.shape)
 
 """
+## Estimate the noise standard deviation
 
 We use the ``pca_noise_estimate`` method to estimate the value of sigma to be
-used in local PCA algorithm. It takes both data and the gradient table object
-as input and returns an estimate of local noise standard deviation as a 3D
-array. We return a smoothed version, where a Gaussian filter with radius
-3 voxels has been applied to the estimate of the noise before returning it.
+used in local PCA algorithm proposed by Manjon et al. [Manjon2013]_.
+It takes both data and the gradient table object as input and returns an
+estimate of local noise standard deviation as a 3D array. We return a smoothed
+version, where a Gaussian filter with radius 3 voxels has been applied to the
+estimate of the noise before returning it.
 
 We correct for the bias due to Rician noise, based on an equation developed by
 Koay and Basser [Koay2006]_.
@@ -61,24 +68,29 @@ sigma = pca_noise_estimate(data, gtab, correct_bias=True, smooth=3)
 print("Sigma estimation time", time() - t)
 
 """
-Perform the localPCA using the function localpca.
+## Perform the localPCA using the function localpca.
 
-The localpca algorithm takes into account for the directional
-information in the diffusion MR data. It performs PCA on local 4D patch and
-then thresholds it using the local variance estimate done by noise estimation
-function, then performing PCA reconstruction on it gives us the deniosed
-estimate.
+The localpca algorithm takes into account the multi-dimensional information of
+the diffusion MR data. It performs PCA on local 4D patch and
+then removes the noise components by thresholding the lowest eigenvalues.
+The eigenvalue threshold will be computed from the local variance estimate
+performed by the ``pca_noise_estimate`` function, if this is inputted in the
+main ``localpca`` function. The relationship between the noise variance
+estimate and the eigenvalue threshold can be adjusted using the input parameter
+``tau_factor``. According to Manjon et al. [Manjon2013]_, this parameter is set
+to 2.3.
 """
 
 t = time()
 
-denoised_arr = localpca(data, sigma=sigma, patch_radius=2)
+denoised_arr = localpca(data, sigma=sigma, tau_factor=2.3, patch_radius=2)
 
 print("Time taken for local PCA (slow)", -t + time())
 
 """
-Let us plot the axial slice of the original and denoised data.
-We visualize all the slices (22 in total)
+The ``localpca`` function returns the denoised data which is plotted below
+(middle panel) together with the original version of the data (left panel) and
+the algorithm residual (right panel) .
 """
 
 sli = data.shape[2] // 2
@@ -105,7 +117,7 @@ print("The result saved in denoised_localpca.png")
 .. figure:: denoised_localpca.png
    :align: center
 
-   Showing the middle axial slice of the local PCA denoised output.
+Below we show how the denoised data can be saved.
 """
 
 nib.save(nib.Nifti1Image(denoised_arr,

--- a/doc/examples/denoise_localpca.py
+++ b/doc/examples/denoise_localpca.py
@@ -83,7 +83,7 @@ to 2.3.
 
 t = time()
 
-denoised_arr = localpca(data, sigma=sigma, tau_factor=2.3, patch_radius=2)
+denoised_arr = localpca(data, sigma, tau_factor=2.3, patch_radius=2)
 
 print("Time taken for local PCA (slow)", -t + time())
 

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -1,0 +1,206 @@
+"""
+==========================================================
+Denoise images using the Marcenko and Pastur PCA algorithm
+==========================================================
+
+The local PCA based denoising algorithm is an effective denoising
+method because it exploits the redundancy across the diffusion-weighted images
+[Manjon2013]_, [Veraart2016a]_. This algorithm has been shown to provide an
+optimal compromise between noise suppression and loss of anatomical information
+for different techniques such as DTI [Manjon2013]_, spherical deconvolution
+[Veraart2016a] and DKI [Henri2018]_.
+
+The basic idea behind local PCA based diffusion denoising is to remove the
+data's principal components mostly related to noise. The classification of
+the principal components can be performed based on prior noise variance
+estimates and empirical thresholds [Manjon2013]_ or based on random matrix
+theory [Veraa2016a]. In addition to noise suppression, local PCA can be used
+to estimate the noise variance [Veraa2016b].
+
+In the following example, we show how to denoise diffusion MRI images and
+estimate the noise variance using the local PCA algorithm.
+
+Let's load the necessary modules
+"""
+
+# load general modules
+import numpy as np
+import nibabel as nib
+import matplotlib.pyplot as plt
+from time import time
+
+# load main localpca function
+from dipy.denoise.localpca import localpca
+
+# load functions to fetch data for this example
+from dipy.data import (fetch_cfin_multib, read_cfin_dwi)
+
+# load other dipy's functions that will be used for auxiliar analysis
+from dipy.core.gradients import gradient_table
+from dipy.segment.mask import median_otsu
+import dipy.reconst.dki as dki
+
+"""
+For this example, we use fetch to download a multi-shell dataset which was
+kindly provided by Hansen and Jespersen (more details about the data are
+provided in their paper [Hansen2016]_). The total size of the downloaded data
+is 192 MBytes, however you only need to fetch it once.
+"""
+
+fetch_cfin_multib()
+
+img, gtab = read_cfin_dwi()
+
+data = img.get_data()
+
+affine = img.affine
+
+"""
+For the sake of simplicity, we only select two non-zero b-values of this
+extensive dataset.
+"""
+
+bvals = gtab.bvals
+
+bvecs = gtab.bvecs
+
+sel_b = np.logical_or(np.logical_or(bvals == 0, bvals == 1000), bvals == 2000)
+
+data = data[..., sel_b]
+
+gtab = gradient_table(bvals[sel_b], bvecs[sel_b])
+
+print(data.shape)
+
+"""
+As one can see from its shape, the selected data contains a total of 67
+volumes of images corresponding to all the diffusion gradient directions
+of the selected b-values.
+
+Local PCA denoising can be performed by running the following command:
+""" 
+
+t = time()
+
+denoised_arr = localpca(data, patch_radius=2)
+
+print("Time taken for local PCA ", -t + time())
+
+"""
+Internally, the ``localpca`` algorithm locally denoises the 4D data using
+a 3D sliding window which is defined by the variable patch_radius (number of
+comprising voxels around the center of the window). In total, this window
+should comprise a larger number of voxels than the number of diffusion-weighted
+volumes. Since our data has a total of 67 volumes, the patch_radius is set to
+2 which corresponds to a 5x5x5 sliding window comprising a total of 125 voxels.
+
+To assess the performance of the ``localpca`` algorithm, an axial slice of the
+original, denoised data, and their difference are ploted below:
+"""
+
+sli = data.shape[2] // 2
+gra = data.shape[3] - 1
+orig = data[:, :, sli, gra]
+den = denoised_arr[:, :, sli, gra]
+rms_diff = np.sqrt((orig - den) ** 2)
+
+fig1, ax = plt.subplots(1, 3, figsize=(12, 6),
+                        subplot_kw={'xticks': [], 'yticks': []})
+
+fig1.subplots_adjust(hspace=0.3, wspace=0.05)
+
+ax.flat[0].imshow(orig.T, cmap='gray', interpolation='none',
+                  origin='lower')
+ax.flat[0].set_title('Original')
+ax.flat[1].imshow(den.T, cmap='gray', interpolation='none',
+                  origin='lower')
+ax.flat[1].set_title('Debiused Output')
+ax.flat[2].imshow(rms_diff.T, cmap='gray', interpolation='none',
+                  origin='lower')
+ax.flat[2].set_title('denoised_localpca.png', bbox_inches='tight')
+
+print("The result saved in denoised_localpca.png")
+
+"""
+.. figure:: denoised_localpca.png
+   :align: center
+
+   Showing the middle axial slice of the local PCA denoised output.
+"""
+
+nib.save(nib.Nifti1Image(denoised_arr,
+                         affine), 'denoised_localpca.nii.gz')
+
+print("Entire denoised data saved in denoised_localpca.nii.gz")
+
+"""
+
+
+"""
+
+import dipy.reconst.dki as dki
+dkimodel = dki.DiffusionKurtosisModel(gtab)
+
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2,
+                             autocrop=False, dilate=1)
+
+dki_orig = dkimodel.fit(data, mask=mask)
+dki_den = dkimodel.fit(denoised_arr, mask=mask)
+
+FA_orig = dki_orig.fa
+FA_den = dki_den.fa
+MD_orig = dki_orig.md
+MD_den = dki_den.md
+MK_orig = dki_orig.mk(0, 3)
+MK_den = dki_den.mk(0, 3)
+
+
+fig1, ax = plt.subplots(2, 3, figsize=(10, 10),
+                        subplot_kw={'xticks': [], 'yticks': []})
+
+fig1.subplots_adjust(hspace=0.3, wspace=0.03)
+
+ax.flat[0].imshow(MD_orig[:, :, sli].T, cmap='gray', vmin=0, vmax=2.0e-3,
+                  origin='lower')
+ax.flat[0].set_title('MD (DKI)')
+ax.flat[1].imshow(FA_orig[:, :, sli].T, cmap='gray', vmin=0, vmax=0.7,
+                  origin='lower')
+ax.flat[1].set_title('FA (DKI)')
+ax.flat[2].imshow(MK_orig[:, :, sli].T, cmap='gray', vmin=0, vmax=1.5,
+                  origin='lower')
+ax.flat[2].set_title('AD (DKI)')
+ax.flat[3].imshow(MD_den[:, :, sli].T, cmap='gray', vmin=0, vmax=2.0e-3,
+                  origin='lower')
+ax.flat[3].set_title('MD (DKI)')
+ax.flat[4].imshow(FA_den[:, :, sli].T, cmap='gray', vmin=0, vmax=0.7,
+                  origin='lower')
+ax.flat[4].set_title('FA (DKI)')
+ax.flat[5].imshow(MK_den[:, :, sli].T, cmap='gray', vmin=0, vmax=1.5,
+                  origin='lower')
+ax.flat[5].set_title('AD (DKI)')
+plt.show()
+fig1.savefig('Diffusion_tensor_measures_from_DTI_and_DKI.png')
+
+"""
+References
+----------
+
+.. [Manjon2013] Manjon JV, Coupe P, Concha L, Buades A, Collins DL "Diffusion
+                Weighted Image Denoising Using Overcomplete Local PCA" (2013).
+                PLoS ONE 8(9): e73021. doi:10.1371/journal.pone.0073021.
+
+.. [Veraa2016a] Veraart J, Fieremans E, Novikov DS. 2016. Diffusion MRI noise
+                mapping using random matrix theory. Magnetic Resonance in
+                Medicine. doi: 10.1002/mrm.26059.
+
+.. [Henri2018] Henriques, R., 2018. Advanced Methods for Diffusion MRI Data
+               Analysis and their Application to the Healthy Ageing Brain
+               (Doctoral thesis). https://doi.org/10.17863/CAM.29356
+
+.. [Veraa2016b] Veraart J, Novikov DS, Christiaens D, Ades-aron B, Sijbers,
+                Fieremans E, 2016. Denoising of Diffusion MRI using random
+                matrix theory. Neuroimage 142:394-406.
+                doi: 10.1016/j.neuroimage.2016.08.016
+
+.. include:: ../links_names.inc
+"""

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -9,13 +9,13 @@ been shown to provide an optimal compromise between noise suppression and loss
 of anatomical information for different techniques such as DTI [Manjon2013]_,
 spherical deconvolution [Veraart2016a] and DKI [Henri2018]_.
 
-The basic idea behind the PCA-based denoising algorithm is to remove the
-data's principal components classified being mostly related to noise.
-The principal components classification can be performed based on prior noise
-variance estimates [Manjon2013]_ (see :ref:`denoise_localpca`)or automatically
-based on the Marcenko-Pastur distribution [Veraa2016a]_. In addition to noise
-suppression, the PCA algorithm can be used to estimate the noise standard
-deviation [Veraa2016b].
+The basic idea behind the PCA-based denoising algorithms is to remove the
+components of the data that are classified as noise. The Principal Components
+classification can be performed based on prior noise variance estimates
+[Manjon2013]_ (see :ref:`denoise_localpca`)or automatically based on the
+Marcenko-Pastur distribution [Veraa2016a]_. In addition to noise
+suppression, the PCA algorithm can be used to get the standard deviation of
+the noise[Veraa2016b]_.
 
 In the following example, we show how to denoise diffusion MRI images and
 estimate the noise standard deviation using the PCA algorithm based
@@ -146,7 +146,7 @@ nib.save(nib.Nifti1Image(denoised_arr,
 print("Entire denoised data saved in denoised_mppca.nii.gz")
 
 """
-Additionally, we show on this example how the PCA denoising algorithm effects
+Additionally, we show in this example how the PCA denoising algorithm affects
 different diffusion measurements. For this, we run the diffusion kurtosis model
 below on both original and denoised versions of the data:
 """

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -12,10 +12,10 @@ spherical deconvolution [Veraart2016a] and DKI [Henri2018]_.
 The basic idea behind the PCA-based denoising algorithms is to remove the
 components of the data that are classified as noise. The Principal Components
 classification can be performed based on prior noise variance estimates
-[Manjon2013]_ (see :ref:`denoise_localpca`)or automatically based on the
+[Manjon2013]_ (see :ref:`denoise_localpca`) or automatically based on the
 Marcenko-Pastur distribution [Veraa2016a]_. In addition to noise
 suppression, the PCA algorithm can be used to get the standard deviation of
-the noise[Veraa2016b]_.
+the noise [Veraa2016b]_.
 
 In the following example, we show how to denoise diffusion MRI images and
 estimate the noise standard deviation using the PCA algorithm based
@@ -30,8 +30,8 @@ import nibabel as nib
 import matplotlib.pyplot as plt
 from time import time
 
-# load main localpca function
-from dipy.denoise.localpca import localpca
+# load main pca function using Marcenko-Pastur distribution
+from dipy.denoise.localpca import mppca
 
 # load functions to fetch data for this example
 from dipy.data import (fetch_cfin_multib, read_cfin_dwi)
@@ -78,24 +78,23 @@ As one can see from its shape, the selected data contains a total of 67
 volumes of images corresponding to all the diffusion gradient directions
 of the selected b-values.
 
-The local PCA denoising based on the Marcenko and Pastur distribution
-can be performed by calling the function ``localpca`` without specifying a
-prior estimate to the noise standard deviation:
+The PCA denoising using the Marcenko-Pastur distribution can be performed by
+calling the function ``mppca``:
 """
 
 t = time()
 
-denoised_arr = localpca(data, sigma=None, patch_radius=2)
+denoised_arr = mppca(data, patch_radius=2)
 
-print("Time taken for local PCA ", -t + time())
+print("Time taken for local MP-PCA ", -t + time())
 
 """
-Internally, the ``localpca`` algorithm locally denoises the
-diffusion-weighted data using a 3D sliding window which is defined by the
-variable patch_radius. In total, this window should comprise a larger number
-of voxels than the number of diffusion-weighted volumes. Since our data has a
-total of 67 volumes, the patch_radius is set to 2 which corresponds to a 5x5x5
-sliding window comprising a total of 125 voxels.
+Internally, the ``mppca`` algorithm denoises the diffusion-weighted data
+using a 3D sliding window which is defined by the variable patch_radius.
+In total, this window should comprise a larger number of voxels than the number
+of diffusion-weighted volumes. Since our data has a total of 67 volumes, the
+patch_radius is set to 2 which corresponds to a 5x5x5 sliding window
+comprising a total of 125 voxels.
 
 To assess the performance of the Marcenko-Pastur PCA denosing algorithm,
 an axial slice of the original data, denoised data, and residuals are plotted
@@ -135,7 +134,7 @@ The noise suppressing can be visually appreciated by comparing the original
 data slice (left panel) to its denoised version (middle panel). The difference
 between original and denoised data showing only random noise indicates that
 the data's structural information is preserved by the PCA denoising algorithm
-(left panel).
+(right panel).
 
 Below we show how the denoised data can be saved.
 """
@@ -146,8 +145,8 @@ nib.save(nib.Nifti1Image(denoised_arr,
 print("Entire denoised data saved in denoised_mppca.nii.gz")
 
 """
-Additionally, we show in this example how the PCA denoising algorithm affects
-different diffusion measurements. For this, we run the diffusion kurtosis model
+Additionally, we show how the PCA denoising algorithm affects different
+diffusion measurements. For this, we run the diffusion kurtosis model
 below on both original and denoised versions of the data:
 """
 
@@ -213,12 +212,11 @@ visually appreciated, particularly for the FA and MK estimates.
 
 As mentioned above, the Marcenko-Pastur PCA algorithm can also be used to
 estimate the image's noise standard deviation (std). The noise std
-automatically computed from the ``localpca`` function can be returned by
+automatically computed from the ``mppca`` function can be returned by
 setting the optional input parameter ``return_sigma`` to True.
 """
 
-denoised_arr, sigma = localpca(data, sigma=None, patch_radius=2,
-                               return_sigma=True)
+denoised_arr, sigma = mppca(data, patch_radius=2, return_sigma=True)
 
 """ Let's plot the noise standard deviation estimate """
 
@@ -244,7 +242,7 @@ mean_sigma = np.mean(sigma[mask])
 print(mean_sigma)
 
 """
-Below we use this mean noise std value to estimate the data's nominal SNR
+Below we use this mean noise level estimate to compute the data's nominal SNR
 (i.e. SNR at b-value=0):
 """
 

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -36,6 +36,7 @@
  linear_fascicle_evaluation.py
  denoise_nlmeans.py
  denoise_localpca.py
+ denoise_mppca.py
  denoise_gibbs.py
  fiber_to_bundle_coherence.py
 # denoise_ascm.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -44,6 +44,7 @@ Denoising
 
 - :ref:`example_denoise_nlmeans`
 - :ref:`example_denoise_localpca`
+- :ref:`example_denoise_mppca`
 - :ref:`example_denoise_gibbs`
 
 Reslice


### PR DESCRIPTION
Hi all! I am working on a functional implementation of the Random matrix local PCA for Dipy's next release. I've already added the classifier based on the moments of the Marchenko–Pastur probability distribution according to [Veraart et al., 2016](https://www.ncbi.nlm.nih.gov/pubmed/27523449) -  which seems to pass my added tests. Now, I just need to:

- [x] Add a test of the main localpca function.

- [x] Update the example (If you want to start playing with the new procedure, you can run it in the current example by skipping the sigma estimation part and setting the sigma parameter to None when calling the localpca function - results are looking good and example runs in a couple of minutes). 

In the meantime, I need our opinion on the follow aspect - The new feature does not require the estimation of noise sigma, so what should I do with the previous implemented noise estimate procedure? @arokem, @skoudoro did you mentioned that this procedure is not working well? The current version of the code is still compatible with this previous procedure; however if it is not working I don't mind removing it to simplified a bit the code. 

PS: Also I hope this work helps the future integration of the code in PR#1781 in a future release.