### PR TITLE
[Fix] removing minmax_norm parameter from peak_direction

### DIFF
--- a/dipy/direction/peaks.py
+++ b/dipy/direction/peaks.py
@@ -89,7 +89,7 @@ def peak_directions_nl(sphere_eval, relative_peak_threshold=.25,
 
 
 def peak_directions(odf, sphere, relative_peak_threshold=.5,
-                    min_separation_angle=25, minmax_norm=True):
+                    min_separation_angle=25):
     """Get the directions of odf peaks.
 
     Peaks are defined as points on the odf that are greater than at least one

--- a/dipy/tracking/tests/test_life.py
+++ b/dipy/tracking/tests/test_life.py
@@ -162,7 +162,7 @@ def test_fit_data():
     gtab = grad.gradient_table(fbval, fbvec)
     ni_data = nib.load(fdata)
     data = ni_data.get_data()
-    tensor_streamlines, _ = load_tractogram(fstreamlines)
+    tensor_streamlines = nib.streamlines.load(fstreamlines).streamlines
     tensor_streamlines = move_streamlines(tensor_streamlines, np.eye(4),
                                           ni_data.affine)
     life_model = life.FiberModel(gtab)

--- a/dipy/tracking/tests/test_life.py
+++ b/dipy/tracking/tests/test_life.py
@@ -11,7 +11,6 @@ import dipy.reconst.dti as dti
 import dipy.tracking.life as life
 
 from dipy.io.gradients import read_bvals_bvecs
-from dipy.io.streamline import load_tractogram
 from dipy.tracking.utils import move_streamlines
 
 THIS_DIR = op.dirname(__file__)


### PR DESCRIPTION
The goal of this PR is to fix #389.  I use the opportunity to fix one test not related