### PR TITLE
Update streamlines formats example

### DIFF
--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -408,6 +408,20 @@ fetch_cfin_multib = _make_fetcher(
          " More details about the data are available in their paper: " +
          " https://www.nature.com/articles/sdata201672"))
 
+fetch_file_formats = _make_fetcher(
+    "bundle_file_formats_example",
+    pjoin(dipy_home, 'bundle_file_formats_example'),
+    'https://zenodo.org/record/3352379/files/',
+    ['cc_m_sub.trk', 'laf_m_sub.tck', 'lpt_m_sub.fib',
+     'raf_m_sub.vtk', 'rpt_m_sub.dpy', 'template0.nii.gz'],
+    ['cc_m_sub.trk', 'laf_m_sub.tck', 'lpt_m_sub.fib',
+     'raf_m_sub.vtk', 'rpt_m_sub.dpy', 'template0.nii.gz'],
+    ['78ed7bead3e129fb4b4edd6da1d7e2d2', '20009796ccd43dc8d2d5403b25dff717',
+     '8afa8419e2efe04ede75cce1f53c77d8', '9edcbea30c7a83b467c3cdae6ce963c8',
+     '42bff2538a650a7ff1e57bfd9ed90ad6', '99c37a2134026d2c4bbb7add5088ddc6'],
+    doc="Download 5 bundles in various file formats and their reference",
+    data_size="25MB")
+
 fetch_bundle_atlas_hcp842 = _make_fetcher(
     "fetch_bundle_atlas_hcp842",
     pjoin(dipy_home, 'bundle_atlas_hcp842'),
@@ -1149,6 +1163,25 @@ def read_cfin_t1():
     return img  # , gtab
 
 
+def get_file_formats():
+    """
+    Returns
+    -------
+    bundles_list : all bundles (list)
+    ref_anat : reference
+    """
+    ref_anat = pjoin(dipy_home,
+                     'bundle_file_formats_example', 'template0.nii.gz')
+    bundles_list = []
+    for filename in ['cc_m_sub.trk', 'laf_m_sub.tck', 'lpt_m_sub.fib',
+                'raf_m_sub.vtk', 'rpt_m_sub.dpy']:
+        bundles_list.append(pjoin(dipy_home,
+                                  'bundle_file_formats_example',
+                                  filename))
+
+    return bundles_list, ref_anat
+
+
 def get_bundle_atlas_hcp842():
     """
     Returns
@@ -1156,13 +1189,13 @@ def get_bundle_atlas_hcp842():
     file1 : string
     file2 : string
     """
-    file1 = pjoin(dipy_home,
+    file1=pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'whole_brain',
                   'whole_brain_MNI.trk')
 
-    file2 = pjoin(dipy_home,
+    file2=pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'bundles',
@@ -1178,13 +1211,13 @@ def get_two_hcp842_bundles():
     file1 : string
     file2 : string
     """
-    file1 = pjoin(dipy_home,
+    file1=pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'bundles',
                   'AF_L.trk')
 
-    file2 = pjoin(dipy_home,
+    file2=pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'bundles',
@@ -1199,7 +1232,7 @@ def get_target_tractogram_hcp():
     -------
     file1 : string
     """
-    file1 = pjoin(dipy_home,
+    file1=pjoin(dipy_home,
                   'target_tractogram_hcp',
                   'hcp_tractogram',
                   'streamlines.trk')

--- a/dipy/data/fetcher.py
+++ b/dipy/data/fetcher.py
@@ -1174,7 +1174,7 @@ def get_file_formats():
                      'bundle_file_formats_example', 'template0.nii.gz')
     bundles_list = []
     for filename in ['cc_m_sub.trk', 'laf_m_sub.tck', 'lpt_m_sub.fib',
-                'raf_m_sub.vtk', 'rpt_m_sub.dpy']:
+                     'raf_m_sub.vtk', 'rpt_m_sub.dpy']:
         bundles_list.append(pjoin(dipy_home,
                                   'bundle_file_formats_example',
                                   filename))
@@ -1189,13 +1189,13 @@ def get_bundle_atlas_hcp842():
     file1 : string
     file2 : string
     """
-    file1=pjoin(dipy_home,
+    file1 = pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'whole_brain',
                   'whole_brain_MNI.trk')
 
-    file2=pjoin(dipy_home,
+    file2 = pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'bundles',
@@ -1211,13 +1211,13 @@ def get_two_hcp842_bundles():
     file1 : string
     file2 : string
     """
-    file1=pjoin(dipy_home,
+    file1 = pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'bundles',
                   'AF_L.trk')
 
-    file2=pjoin(dipy_home,
+    file2 = pjoin(dipy_home,
                   'bundle_atlas_hcp842',
                   'Atlas_80_Bundles',
                   'bundles',
@@ -1232,7 +1232,7 @@ def get_target_tractogram_hcp():
     -------
     file1 : string
     """
-    file1=pjoin(dipy_home,
+    file1 = pjoin(dipy_home,
                   'target_tractogram_hcp',
                   'hcp_tractogram',
                   'streamlines.trk')

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -39,7 +39,7 @@ class StatefulTractogram(object):
         streamlines : list or ArraySequence
             Streamlines of the tractogram
         reference : Nifti or Trk filename, Nifti1Image or TrkFile,
-            Nifti1Header or trk.header (dict)
+            Nifti1Header, trk.header (dict) or another Stateful Tractogram
             Reference that provides the spatial attribute.
             Typically a nifti-related object from the native diffusion used for
             streamlines generation
@@ -293,7 +293,8 @@ class StatefulTractogram(object):
         """ Remove streamlines with invalid coordinates from the object.
         Will also remove the data_per_point and data_per_streamlines.
         Invalid coordinates are any X,Y,Z values above the reference
-        dimensions or below zero         Returns
+        dimensions or below zero
+        Returns
         -------
         output : tuple
             Tuple of two list, indices_to_remove, indices_to_keep

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -291,7 +291,7 @@ class StatefulTractogram(object):
 
     def remove_invalid_streamlines(self):
         """ Remove streamlines with invalid coordinates from the object.
-        Will also remove the data_per_point and data_per_streamlines.
+        Will also remove the data_per_point and data_per_streamline.
         Invalid coordinates are any X,Y,Z values above the reference
         dimensions or below zero
         Returns

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -117,8 +117,13 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         logging.error('Space MUST be one of the 3 choices (Enum)')
         return False
 
-    if extension == '.trk' and reference == 'same':
-        reference = filename
+    if reference == 'same':
+        if extension == '.trk':
+            reference = filename
+        else:
+            logging.error('Reference must be provided, "same" is only ' +
+                          'available for Trk file.')
+            return False
 
     if trk_header_check and extension == '.trk':
         if not is_header_compatible(filename, reference):

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-from dipy.io.stateful_tractogram import StatefulTractogram
+import dipy
 import nibabel as nib
 from nibabel.streamlines import detect_format
 from nibabel import Nifti1Image
@@ -182,7 +182,7 @@ def get_reference_info(reference):
     elif isinstance(reference, dict) and 'magic_number' in reference:
         header = reference
         is_trk = True
-    elif isinstance(reference, StatefulTractogram):
+    elif isinstance(reference, dipy.io.stateful_tractogram.StatefulTractogram):
         is_sft = True
 
     if is_nifti:

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -2,11 +2,11 @@
 import logging
 import os
 
-import dipy
-import numpy as np
+from dipy.io.stateful_tractogram import StatefulTractogram
 import nibabel as nib
 from nibabel.streamlines import detect_format
 from nibabel import Nifti1Image
+import numpy as np
 
 
 def nifti1_symmat(image_data, *args, **kwargs):
@@ -182,7 +182,7 @@ def get_reference_info(reference):
     elif isinstance(reference, dict) and 'magic_number' in reference:
         header = reference
         is_trk = True
-    elif isinstance(reference, dipy.io.stateful_tractogram.StatefulTractogram):
+    elif isinstance(reference, StatefulTractogram):
         is_sft = True
 
     if is_nifti:

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -103,6 +103,9 @@ def density_map(streamlines, vol_dims, affine=None):
     the edges of the voxels are smaller than the steps of the streamlines.
 
     """
+    if affine is None:
+        affine = np.eye(4)
+
     lin_T, offset = _mapping_to_voxel(affine)
     counts = np.zeros(vol_dims, 'int')
     for sl in streamlines:

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -10,7 +10,7 @@ Overview
 DIPY_ can read and write many different file formats. In this example
 we give a short introduction on how to use it for loading or saving
 streamlines. The new statefull tractogram class was made to reduce errors
-cause by spatial transformation and complex file format convention.
+caused by spatial transformation and complex file format convention.
 
 Read :ref:`faq`
 
@@ -65,7 +65,7 @@ raf_sft = load_tractogram(bundles_filename[3], reference_anatomy)
 """
 These files contain invalid streamlines (negative values once in voxel space)
 This is not considered a valid tractography file, but it is possible to load
-it anyway
+it anyway.
 """
 
 lpt_sft = load_tractogram(bundles_filename[2], reference_anatomy,
@@ -106,11 +106,11 @@ print(is_header_compatible(reference_anatomy, bundles_filename[0]))
 
 """
 If a TRK was generated with a valid header, but the reference NIFTI was lost
-an header can be generated to then generate a fake NIFTI file.
+a header can be generated to then generate a fake NIFTI file.
 
 If you wish to manually save Trk and Tck file using nibabel streamlines
-API for more freedom of action (not recommended for beginner) you can
-create valid header using create_tractogram_header
+API for more freedom of action (not recommended for beginners) you can
+create a valid header using create_tractogram_header
 """
 
 nifti_header = create_nifti_header(affine, dimensions, voxel_sizes)
@@ -120,9 +120,11 @@ nib.save(reference_anatomy, os.path.basename(ref_anat_filename))
 
 """
 Once loaded, no matter the original file format, the stateful tractogram is
-self contained and maintain a valid state and can be easily be manipulated
-Let's save all file as TRK to visualize in TrackVis for example.
-However, when loaded the lpt and rpt files contains invalid streamlines and
+self-contained and maintains a valid state. By requiring a reference the 
+tractogram's spatial transformation can be easily manipulated.
+
+Let's save all files as TRK to visualize in TrackVis for example.
+However, when loaded the lpt and rpt files contain invalid streamlines and
 for particular operations/tools/functions it is safer to remove them
 """
 
@@ -141,14 +143,15 @@ print(rpt_sft.is_bbox_in_vox_valid())
 save_tractogram(rpt_sft, 'rpt.trk')
 
 """
-Some functions in dipy require streamlines to be in voxel space so computation
+Some functions in DIPY require streamlines to be in voxel space so computation
 can be perfomed on a grid (connectivity matrix, ROIs masking, density map).
-The stateful tractogram class provided safe function for such manipulation.
-These function can be called safely over and over, by knowing in which state
-the tractogram is the operation is computed only necessary.
+The stateful tractogram class provides safe functions for such manipulation.
+These functions can be called safely over and over, by knowing in which state
+the tractogram is operating, and compute only necessary transformations
 
-No matter the state, function such as saving or removing invalid coordinate
-can be called safely and the transformation are handle internally if needed.
+No matter the state, functions such as ``save_tractogram`` or 
+``removing_invalid_coordinates`` can be called safely and the transformations 
+are handled internally when needed.
 """
 
 cc_sft.to_voxmm()
@@ -189,16 +192,16 @@ rpt_density = density_map(rpt_streamlines_vox, dimensions)
 
 """
 Replacing streamlines is possible, but if the state was modified between
-operation such as this one is not recommended:
+operations such as this one is not recommended:
 -> cc_sft.streamlines = cc_streamlines_vox
 
 It is recommended to re-create a new StatefulTractogram object and
-explicitly specified in which space the streamlines are. Be careful to follow
+explicitly specify in which space the streamlines are. Be careful to follow
 the order of operations.
 
 If the tractogram was from a Trk file with metadata, this will be lost.
 If you wish to keep metadata while manipulating the number or the order
-look the function StatefulTractogram.remove_invalid_streamlines() for more
+look at the function StatefulTractogram.remove_invalid_streamlines() for more
 details
 
 It is important to mention that once the object is created in a consistent state

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -54,7 +54,7 @@ load_tck will simply be restricted to one file format
 
 TRK files contain their own header (when writen properly), so they
 technically do not need a reference. (See how below)
-cc_trk = load_tractogram(bundles_filename[0], 'same')
+cc_trk = ``load_tractogram``(bundles_filename[0], 'same')
 """
 
 cc_sft = load_tractogram(bundles_filename[0], reference_anatomy)
@@ -74,7 +74,7 @@ rpt_sft = load_tractogram(bundles_filename[4], reference_anatomy,
                           bbox_valid_check=False)
 
 """
-The function load_tractogram requires a reference, any of the following input
+The function ``load_tractogram`` requires a reference, any of the following input
 is considered valid (as long as they are in the same share space)
 - Nifti filename
 - Trk filename
@@ -99,7 +99,7 @@ print(voxel_order)
 If you have a Trk file that was generated using a particular anatomy,
 to be considered valid all fields must correspond between the headers.
 It can be easily verified using this function, which also accept
-the same variety of input as get_reference_info
+the same variety of input as ``get_reference_info``
 """
 
 print(is_header_compatible(reference_anatomy, bundles_filename[0]))
@@ -202,8 +202,8 @@ look the function StatefulTractogram.remove_invalid_streamlines() for more
 details
 
 It is important to mention that once the object is created in a consistent state
-the save_tractogram function will save a valid file. And then the function
-load_tractogram will load them in a valid state.
+the ``save_tractogram`` function will save a valid file. And then the function
+``load_tractogram`` will load them in a valid state.
 """
 
 cc_sft = StatefulTractogram(cc_streamlines_vox, reference_anatomy, Space.VOX)

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -9,7 +9,8 @@ Overview
 
 DIPY_ can read and write many different file formats. In this example
 we give a short introduction on how to use it for loading or saving
-streamlines.
+streamlines. The new statefull tractogram class was made to reduce errors
+cause by spatial transformation and complex file format convention.
 
 Read :ref:`faq`
 
@@ -24,49 +25,67 @@ from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 from dipy.io.utils import (create_nifti_header, create_tractogram_header,
                            get_reference_info, is_header_compatible)
-from dipy.tracking.streamline import Streamlines
+from dipy.tracking.streamline import select_random_set_of_streamlines
+from dipy.tracking.utils import density_map
 
 from dipy.data.fetcher import (fetch_file_formats,
                                get_file_formats)
+
+"""
+First fetch the dataset that contains 5 tractography file of 5 file formats:
+- cc_m_sub.trk
+- laf_m_sub.tck
+- lpt_m_sub.fib
+- raf_m_sub.vtk
+- rpt_m_sub.dpy
+
+And their reference anatomy, common to all 5 files:
+- template0.nii.gz
+"""
 
 fetch_file_formats()
 bundles_filename, ref_anat_filename = get_file_formats()
 for filename in bundles_filename:
     print(os.path.basename(filename))
-
-# Loading a Nifti1Image using nibabel
 reference_anatomy = nib.load(ref_anat_filename)
 
-# Load tractogram will support 5 file formats, function like load_trk or
-# load_tck will simply be restricted to one file format
-cc_trk = load_tractogram(bundles_filename[0], reference_anatomy)
+"""
+Load tractogram will support 5 file formats, functions like load_trk or
+load_tck will simply be restricted to one file format
 
-# TRK files contain their own header (when writen properly), so they
-# technically do not need a reference. (See how below)
-# cc_trk = load_tractogram(bundles_filename[0], 'same')
+TRK files contain their own header (when writen properly), so they
+technically do not need a reference. (See how below)
+cc_trk = load_tractogram(bundles_filename[0], 'same')
+"""
 
-laf_tck = load_tractogram(bundles_filename[1], reference_anatomy)
-raf_vtk = load_tractogram(bundles_filename[3], reference_anatomy)
+cc_sft = load_tractogram(bundles_filename[0], reference_anatomy)
+print(cc_sft)
+laf_sft = load_tractogram(bundles_filename[1], reference_anatomy)
+raf_sft = load_tractogram(bundles_filename[3], reference_anatomy)
 
-# These file contains invalid streamlines (negative values once in voxel space)
-# This is not considered a valid tractography file, but it is possible to load
-# it anyway
-lpt_fib = load_tractogram(bundles_filename[2], reference_anatomy,
+"""
+These files contain invalid streamlines (negative values once in voxel space)
+This is not considered a valid tractography file, but it is possible to load
+it anyway
+"""
+
+lpt_sft = load_tractogram(bundles_filename[2], reference_anatomy,
                           bbox_valid_check=False)
-rpt_dpy = load_tractogram(bundles_filename[4], reference_anatomy, 
-    bbox_valid_check=False)
+rpt_sft = load_tractogram(bundles_filename[4], reference_anatomy,
+                          bbox_valid_check=False)
 
 """
 The function load_tractogram requires a reference, any of the following input
-is considered valid:
+is considered valid (as long as they are in the same share space)
 - Nifti filename
 - Trk filename
 - nib.nifti1.Nifti1Image
 - nib.streamlines.trk.TrkFile
 - nib.nifti1.Nifti1Header
 - Trk header (dict)
+- Stateful Tractogram
 
-The reason why this parameters is required is to be sure all information
+The reason why this parameters is required is to guarantee all informations
 related to space attribute are always present.
 """
 
@@ -78,16 +97,136 @@ print(voxel_sizes)
 print(voxel_order)
 
 """
-If you have a TRK file that was generated using a particular anatomy,
-to be considered valid all fields must correspond in the header.
+If you have a Trk file that was generated using a particular anatomy,
+to be considered valid all fields must correspond between the headers.
 It can be easily verified using this function, which also accept
-the same variety of input as 
+the same variety of input as get_reference_info
 """
-print(is_header_compatible(reference_anatomy, bundles_filename[1]))
+
+print(is_header_compatible(reference_anatomy, bundles_filename[0]))
 
 """
 If a TRK was generated with a valid header, but the reference NIFTI was lost
 an header can be generated to then generate a fake NIFTI file.
+
+If you wish to manually save Trk and Tck file using nibabel streamlines
+API for more freedom of action (not recommanded for beginner) you can
+create valid header using create_tractogram_header
 """
-header = create_nifti_header(affine, dimension, voxel_size)
-nib.save(nib.Nifti1Image(np.zeros(dimensions), affine, header), 'fake.nii.gz')
+
+nifti_header = create_nifti_header(affine, dimensions, voxel_sizes)
+nib.save(nib.Nifti1Image(np.zeros(dimensions), affine, nifti_header),
+         'fake.nii.gz')
+nib.save(reference_anatomy, os.path.basename(ref_anat_filename))
+
+"""
+Once loaded, no matter the original file format, the stateful tractogram is 
+self contained and maintain a valid state and can be easily be manipulated
+Let's save all file as TRK to visualize in TrackVis for example.
+However, when loaded the lpt and rpt files contains invalid streamlines and
+for particular operations/tools/functions it is safer to remove them
+"""
+
+save_tractogram(cc_sft, 'cc.trk')
+save_tractogram(laf_sft, 'laf.trk')
+save_tractogram(raf_sft, 'raf.trk')
+
+print(lpt_sft.is_bbox_in_vox_valid())
+lpt_sft.remove_invalid_streamlines()
+print(lpt_sft.is_bbox_in_vox_valid())
+save_tractogram(lpt_sft, 'lpt.trk')
+
+print(rpt_sft.is_bbox_in_vox_valid())
+rpt_sft.remove_invalid_streamlines()
+print(rpt_sft.is_bbox_in_vox_valid())
+save_tractogram(rpt_sft, 'rpt.trk')
+
+"""
+Some functions in dipy require streamlines to be in voxel space so computation
+can be perfomed on a grid (connectivity matrix, ROIs masking, density map).
+The stateful tractogram class provided safe function for such manipulation.
+These function can be called safely over and over, by knowing in which state
+the tractogram is the operation is computed only necessary. 
+
+No matter the state, function such as saving or removing invalid coordinate
+can be called safely and the transformation are handle internally if needed.
+"""
+
+cc_sft.to_voxmm()
+print(cc_sft.space)
+cc_sft.to_rasmm()
+print(cc_sft.space)
+
+"""
+Now lets move them all to voxel space, subsample them to 100 streamlines,
+compute a density map and save everything for visualisation in another
+software such as Trackvis or MI-Brain.
+"""
+
+cc_sft.to_vox()
+laf_sft.to_vox()
+raf_sft.to_vox()
+lpt_sft.to_vox()
+rpt_sft.to_vox()
+
+cc_streamlines_vox = select_random_set_of_streamlines(cc_sft.streamlines,
+                                                      1000)
+laf_streamlines_vox = select_random_set_of_streamlines(laf_sft.streamlines,
+                                                       1000)
+raf_streamlines_vox = select_random_set_of_streamlines(raf_sft.streamlines,
+                                                       1000)
+lpt_streamlines_vox = select_random_set_of_streamlines(lpt_sft.streamlines,
+                                                       1000)
+rpt_streamlines_vox = select_random_set_of_streamlines(rpt_sft.streamlines,
+                                                       1000)
+
+# Same dimensions for every stateful tractogram, can be re-use
+affine, dimensions, voxel_sizes, voxel_order = cc_sft.space_attribute
+cc_density = density_map(cc_streamlines_vox, dimensions)
+laf_density = density_map(laf_streamlines_vox, dimensions)
+raf_density = density_map(raf_streamlines_vox, dimensions)
+lpt_density = density_map(lpt_streamlines_vox, dimensions)
+rpt_density = density_map(rpt_streamlines_vox, dimensions)
+
+"""
+Replacing streamlines is possible, but if the state was modified between
+operation such as this one is not recommanded:
+-> cc_sft.streamlines = cc_streamlines_vox
+
+It is recommanded to re-create a new StatefulTractogram object and
+explicitely specified in which space the streamline are. Be careful to follow
+the order of operations.
+
+If the tractogram was from a Trk file with metadata, this will be lost.
+If you wish to keep metadata while manipulating the number or the order
+look the function StatefulTractogram.remove_invalid_streamlines() for more
+details
+
+It is important to mention that once the object is created in a consistent state
+the save_tractogram function will save a valid file. And then the function 
+load_tractogram will load them in a valid state.
+"""
+
+cc_sft = StatefulTractogram(cc_streamlines_vox, reference_anatomy, Space.VOX)
+laf_sft = StatefulTractogram(laf_streamlines_vox, reference_anatomy, Space.VOX)
+raf_sft = StatefulTractogram(raf_streamlines_vox, reference_anatomy, Space.VOX)
+lpt_sft = StatefulTractogram(lpt_streamlines_vox, reference_anatomy, Space.VOX)
+rpt_sft = StatefulTractogram(rpt_streamlines_vox, reference_anatomy, Space.VOX)
+
+print(len(cc_sft), len(laf_sft), len(raf_sft), len(lpt_sft), len(rpt_sft))
+save_tractogram(cc_sft, 'cc_1000.trk')
+save_tractogram(laf_sft, 'laf_1000.trk')
+save_tractogram(raf_sft, 'raf_1000.trk')
+save_tractogram(lpt_sft, 'lpt_1000.trk')
+save_tractogram(rpt_sft, 'rpt_1000.trk')
+
+nib.save(nib.Nifti1Image(cc_density, affine, nifti_header),
+         'cc_density.nii.gz')
+nib.save(nib.Nifti1Image(laf_density, affine, nifti_header),
+         'laf_density.nii.gz')
+nib.save(nib.Nifti1Image(raf_density, affine, nifti_header),
+         'raf_density.nii.gz')
+nib.save(nib.Nifti1Image(lpt_density, affine, nifti_header),
+         'lpt_density.nii.gz')
+nib.save(nib.Nifti1Image(rpt_density, affine, nifti_header),
+         'rpt_density.nii.gz')

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -20,11 +20,10 @@ import os
 
 import nibabel as nib
 import numpy as np
-from dipy.data import get_fnames
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
-from dipy.io.utils import (create_nifti_header, create_tractogram_header,
-                           get_reference_info, is_header_compatible)
+from dipy.io.utils import (create_nifti_header, get_reference_info,
+                           is_header_compatible)
 from dipy.tracking.streamline import select_random_set_of_streamlines
 from dipy.tracking.utils import density_map
 
@@ -120,7 +119,7 @@ nib.save(nib.Nifti1Image(np.zeros(dimensions), affine, nifti_header),
 nib.save(reference_anatomy, os.path.basename(ref_anat_filename))
 
 """
-Once loaded, no matter the original file format, the stateful tractogram is 
+Once loaded, no matter the original file format, the stateful tractogram is
 self contained and maintain a valid state and can be easily be manipulated
 Let's save all file as TRK to visualize in TrackVis for example.
 However, when loaded the lpt and rpt files contains invalid streamlines and
@@ -146,7 +145,7 @@ Some functions in dipy require streamlines to be in voxel space so computation
 can be perfomed on a grid (connectivity matrix, ROIs masking, density map).
 The stateful tractogram class provided safe function for such manipulation.
 These function can be called safely over and over, by knowing in which state
-the tractogram is the operation is computed only necessary. 
+the tractogram is the operation is computed only necessary.
 
 No matter the state, function such as saving or removing invalid coordinate
 can be called safely and the transformation are handle internally if needed.
@@ -203,7 +202,7 @@ look the function StatefulTractogram.remove_invalid_streamlines() for more
 details
 
 It is important to mention that once the object is created in a consistent state
-the save_tractogram function will save a valid file. And then the function 
+the save_tractogram function will save a valid file. And then the function
 load_tractogram will load them in a valid state.
 """
 

--- a/doc/examples/streamline_formats.py
+++ b/doc/examples/streamline_formats.py
@@ -109,7 +109,7 @@ If a TRK was generated with a valid header, but the reference NIFTI was lost
 an header can be generated to then generate a fake NIFTI file.
 
 If you wish to manually save Trk and Tck file using nibabel streamlines
-API for more freedom of action (not recommanded for beginner) you can
+API for more freedom of action (not recommended for beginner) you can
 create valid header using create_tractogram_header
 """
 
@@ -189,11 +189,11 @@ rpt_density = density_map(rpt_streamlines_vox, dimensions)
 
 """
 Replacing streamlines is possible, but if the state was modified between
-operation such as this one is not recommanded:
+operation such as this one is not recommended:
 -> cc_sft.streamlines = cc_streamlines_vox
 
-It is recommanded to re-create a new StatefulTractogram object and
-explicitely specified in which space the streamline are. Be careful to follow
+It is recommended to re-create a new StatefulTractogram object and
+explicitly specified in which space the streamlines are. Be careful to follow
 the order of operations.
 
 If the tractogram was from a Trk file with metadata, this will be lost.


### PR DESCRIPTION
Considering the new StatefulTractogram and the fact that the old example only covered the Dpy format. This update now contain a more complete list of file format, the new API and new data that can be fetched.

