### PR TITLE
[Upcoming] Release 1.0 for wednesday

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -24,7 +24,8 @@ Ian Nimmo-Smith <iannimmosmith@gmail.com> Ian Nimmo-Smith <ian@devel07.(none)>
 Ian Nimmo-Smith <iannimmosmith@gmail.com> iannimmosmith <ian@monksilver.com>
 Ian Nimmo-Smith <iannimmosmith@gmail.com> Ian Nimmo-Smith <ian.nimmo-smith@mrc-cbu.cam.ac.uk>
 Matthew Brett <matthew.brett@gmail.com> Matthew Brett <matthew@devel07.(none)>
-Jon Haitz Legarreta Gorroño <jhlegarreta@vicomtech.org> Jon Haitz Legarreta <jhlegarreta@vicomtech.org>
+Jon Haitz Legarreta Gorroño <jon.haitz.legarreta@gmail.com> Jon Haitz Legarreta Gorroño <jhlegarreta@vicomtech.org>
+Jon Haitz Legarreta Gorroño <jon.haitz.legarreta@gmail.com> Jon Haitz Legarreta <jhlegarreta@vicomtech.org>
 Omar Ocegueda <jomaroceguedag@gmail.com> omarocegueda <jomaroceguedag@gmail.com>
 Omar Ocegueda <jomaroceguedag@gmail.com> omarocegueda <jomarocegueda@gmail.com>
 Omar Ocegueda <jomaroceguedag@gmail.com> Omar Ocegueda Gonzalez <jegonz@microsoft.com>
@@ -79,7 +80,11 @@ Adam Rybinski <adam.rybinski@outlook.com>
 Bennet Fauber <justbennet@users.noreply.github.com>
 Aman Arya <aman.arya524@gmail.com>
 Ricci Woo <ricciwoo@gmail.com> RicciWoo <ricciwoo@gmail.com>
-Francois Rheault <francois.m.rheault@usherbrooke>
+Francois Rheault <francois.m.rheault@usherbrooke> Francois Rheault <francois.m.rheault@usherbrooke.ca>
+Francois Rheault <francois.m.rheault@usherbrooke> frheault <francois.m.rheault@usherbrooke.ca>
+Francois Rheault <francois.m.rheault@usherbrooke> frheault <francois.m.rheault@usherbrooke>
+Antoine Theberge <antoine.theberge@usherbrooke.ca> AntoineTheb <antoine.theberge@usherbrooke.ca>
+Antoine Theberge <antoine.theberge@usherbrooke.ca> AntoineTheb <theberge.antoine.cem@gmail.com>
 David Hunt <davhunt@indiana.edu> David <davhunt@indiana.edu>
 David Hunt <davhunt@indiana.edu> davhunt <davhunt@indiana.edu>
 Parichit Sharma <parichitsharma08@gmail.com> Parichit Sharma <schmuck@149-161-162-17.dhcp-bl.indiana.edu>
@@ -93,3 +98,4 @@ Bramsh Qamar <bramshq@gmail.com> Bramsh Qamar <bramshqamar@Bramshs-MacBook-Pro.l
 Yash Sherry <yash14123@iiitd.ac.in>
 endolith <endolith@gmail.com>
 ArjitJ <32598699+ArjitJ@users.noreply.github.com>
+Kevin Sitek <sitek.kevin@gmail.com>

--- a/Changelog
+++ b/Changelog
@@ -47,7 +47,7 @@ The code found in Dipy was created by the people found in the AUTHOR file.
 - Many tutorials added or updated (5 New).
 - Large documentation update.
 - Moved visualization module to a new library: FURY.
-- Closed 287 issues and merged 93 pull requests.   
+- Closed 287 issues and merged 93 pull requests.
 
 * 0.14 (Tuesday, 1 May 2018)
 

--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -65,7 +65,7 @@ def interp_rbf(data, sphere_origin, sphere_target,
         w_s = "The Eucldian norm used for interpolation is inaccurate "
         w_s += "and will be deprecated in future versions. Please consider "
         w_s += "using the 'angle' norm instead"
-        warnings.warn(w_s, DeprecationWarning)
+        warnings.warn(w_s, PendingDeprecationWarning)
         norm = euclidean_norm
 
     # Workaround for bug in older versions of SciPy that don't allow

--- a/dipy/core/tests/test_interpolation.py
+++ b/dipy/core/tests/test_interpolation.py
@@ -405,7 +405,7 @@ def test_interp_rbf():
         warnings.simplefilter("always")
         interp_rbf(data, s0, s1, norm="euclidean_norm")
         npt.assert_(len(w) == 1)
-        npt.assert_(issubclass(w[-1].category, DeprecationWarning))
+        npt.assert_(issubclass(w[-1].category, PendingDeprecationWarning))
         npt.assert_("deprecated" in str(w[-1].message))
 
 

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -8,7 +8,7 @@ renamed or are deprecated (not recommended) during different release circles.
 DIPY 1.0 changes
 ----------------
 Some of the changes introduced in the 1.0 release will break backwards
-compatibility with previous versions.
+compatibility with previous versions. This release is compatible with Python 3.5+
 
 **Reconstruction**
 
@@ -16,8 +16,8 @@ The spherical harmonics bases `mrtrix` and `fibernav` have been renamed to
 `tournier07` and `descoteaux07` after the deprecation cycle started in the
 0.15 release.
 
-We change ``dipy.data.default_sphere`` from symmetric724 to repulsion724. If you want to keep the
-previous behavior, make sure to initialize the sphere parameter on some functions.
+We changed ``dipy.data.default_sphere`` from symmetric724 to repulsion724 which is
+more evenly distributed.
 
 **Segmentation**
 
@@ -35,25 +35,26 @@ guarantee proper spatial transformation handling.
 **Spatial transformation handling**
 
 Functions from ``dipy.tracking.streamlines`` were modified to enforce the
-affine parameter and uniformize docstring. ``deform_streamlines``
-``select_by_rois``, ``orient_by_rois``, ``_extract_vals`` 
+affine parameter and uniform docstrings. ``deform_streamlines``
+``select_by_rois``, ``orient_by_rois``, ``_extract_vals``
 and ``values_from_volume``.
 
 Functions from ``dipy.tracking.utils`` were modified to enforce the
-affine parameter and uniformize docstring. ``density_map``
+affine parameter and uniform docstring. ``density_map``
 ``connectivity_matrix``, ``seeds_from_mask``, ``random_seeds_from_mask``,
 ``target``, ``target_line_based``, ``near_roi``, ``length`` and
 ``path_length`` were all modified.
+
 The function ``affine_for_trackvis``, ``move_streamlines``,
 ``flexi_tvis_affine`` and ``get_flexi_tvis_affine`` were deleted.
 
 Functions from ``dipy.tracking.life`` were modified to enforce the
-affine parameter and uniformize docstring. ``voxel2streamline``,
+affine parameter and uniform docstring. ``voxel2streamline``,
 ``setup`` and ``fit`` from class ``FiberModel`` were all modified.
 
 ``afq_profile`` from ``dipy.stats.analysis`` was modified in a similar way.
 
-**Simulation**
+**Simulations**
 
 - ``dipy.sims.voxel.SingleTensor`` has been replaced by ``dipy.sims.voxel.single_tensor``
 - ``dipy.sims.voxel.MultiTensor`` has been replaced by ``dipy.sims.voxel.multi_tensor``
@@ -61,7 +62,7 @@ affine parameter and uniformize docstring. ``voxel2streamline``,
 
 **Interpolation**
 
-All interpolation functions has been moved to a new module name `dipy.core.interpolation`
+All interpolation functions have been moved to a new module name `dipy.core.interpolation`
 
 **Tracking**
 
@@ -93,7 +94,7 @@ They now need to be imported from ``dipy.tracking.stopping_criterion``.
 - `CmcTissueClassifier` -> `CmcStoppingCriterion`
 
 The ``dipy.tracking.local.tissue_classifier.TissueClass`` was renamed
-``dipy.tracking.stopping_criterion.StreamlineStatus`.
+``dipy.tracking.stopping_criterion.StreamlineStatus``.
 
 The `EuDX` tracking function has been removed. EuDX tractography can be
 performed using ``dipy.tracking.local_tracking`` using
@@ -103,10 +104,13 @@ performed using ``dipy.tracking.local_tracking`` using
 
 ``dipy.io.trackvis`` has been removed. Use ``dipy.io.streamline`` instead.
 
-**Notes**
+**Other**
 
-- ``dipy.external`` package has been removed
-- ``dipy.fixes`` package has been removed
+- ``dipy.external`` package has been removed.
+- ``dipy.fixes`` package has been removed.
+- ``dipy.segment.quickbundes`` module has been removed.
+- ``dipy.reconst.peaks`` module has been removed.
+- Compatibility with Python 2.7 has been removed.
 
 DIPY 0.16 Changes
 -----------------

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -13,7 +13,6 @@ The core development team consists of the following individuals:
 - **Marc-Alexandre Côté**,  Microsoft Research, Montreal, QC, CA
 - **Serge Koudoro**, Indiana University, IN, USA
 - **Gabriel Girard**, Swiss Federal Institute of Technology (EPFL), Lausanne, CH
-- **Mauro Zucchelli**, INRIA, Sophia-Antipolis, France
 - **Rafael Neto Henriques**, Cambridge University, UK
 - **Matthieu Dumont**, Imeka, Sherbrooke, QC, CA
 - **Ranveer Aggarwal**, Microsoft, Hyderabad, Telangana, India
@@ -23,9 +22,10 @@ And here is the rest of the wonderful contributors:
 - **Ian Nimmo-Smith**, retired, formerly at MRC Cognition and Brain Sciences Unit, Cambridge, UK
 - **Maxime Descoteaux**, University of Sherbrooke, QC, CA
 - **Stefan Van der Walt**, University of California, Berkeley, CA, USA
+- **Jean-Christophe Houde**, University of Sherbrooke, QC, CA and Imeka, Sherbrooke, QC, CA
+- **Francois Rhéault**, University of Sherbrooke, QC, CA
 - **Samuel St-Jean**, University Medical Center (UMC) Utrecht, Utrecht, NL
 - **Michael Paquette**, Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, DE
-- **Jean-Christophe Houde**, University of Sherbrooke, QC, CA and Imeka, Sherbrooke, QC, CA
 - **Christopher Nguyen**,  Massachusetts General Hospital, MA, USA
 - **Emanuele Olivetti**, NeuroInformatics Laboratory (NILab), Trento, IT
 - **Yaroslav Halchenco**, PBS Department, Dartmouth, NH, USA
@@ -35,6 +35,7 @@ And here is the rest of the wonderful contributors:
 - **Kimberly Chan**, Stanford University, CA, USA
 - **Chantal Tax**, Cardiff University, Cardiff, UK
 - **Demian Wassermann**, INRIA, Sophia Antipolis, FR
+- **Mauro Zucchelli**, INRIA, Sophia-Antipolis, France
 - **Rutger Fick**, INRIA, Sophia Antipolis, FR
 - **Gregory R. Lee**, Cincinnati Children's Hospital Medical Center, Cincinnati, OH, USA
 - **Endolith**, New-York, NY, USA
@@ -44,6 +45,7 @@ And here is the rest of the wonderful contributors:
 - **Maria Luisa Mandelli**, University of California, San Francisco, CA, USA
 - **Adam Rybinski**, Jagiellonian University, Krakow, PL
 - **Qiyuan Tian**, Stanford University, Stanford, CA, USA
+- **Jon Haitz Legarreta Gorroño**, University of Sherbrooke, QC, CA
 - **Rafael Neto Henriques**, Champalimaud Neuroscience Programme, Champalimaud Centre for the Unknown, Lisbon, PT
 - **Stephan Meesters**, Eindhoven University of Technology, NL
 - **Himanshu Mishra**, Indian Institute of Technology, Karaghpur, IN
@@ -56,6 +58,9 @@ And here is the rest of the wonderful contributors:
 - **Vatsala Swaroop**, Mombai, IN
 - **Shahnawaz Ahmed**, Birla Institute of Technology and Science, Pilani, Goa, IN
 - **Nil Goyette**, Imeka, Sherbrooke, QC, CA
+- **Scott Trinkle**, University of Chicago
+- **Kevin R. Sitek**, MIT McGovern Institute for Brain Research
+- **Derek Pisner**, University of Texas at Austin
 
 
 

--- a/doc/examples/bundle_extraction.py
+++ b/doc/examples/bundle_extraction.py
@@ -116,6 +116,7 @@ model_af_l_file, model_cst_l_file = get_two_hcp842_bundles()
 """
 Extracting bundles using recobundles [Garyfallidis17]_
 """
+
 sft_af_l = load_trk(model_af_l_file, "same", bbox_valid_check=False)
 model_af_l = sft_af_l.streamlines
 
@@ -162,6 +163,7 @@ in the space of the atlas, we save the streamlines that are in the original
 space of the subject anatomy.
 
 """
+
 reco_af_l = StatefulTractogram(target[af_l_labels], target_header,
                                Space.RASMM)
 save_trk(reco_af_l, "AF_L.trk", bbox_valid_check=False)
@@ -210,6 +212,7 @@ if interactive:
 Save the bundle as a trk file:
 
 """
+
 reco_cst_l = StatefulTractogram(target[cst_l_labels], target_header,
                                 Space.RASMM)
 save_trk(reco_cst_l, "CST_L.trk", bbox_valid_check=False)

--- a/doc/examples/denoise_ascm.py
+++ b/doc/examples/denoise_ascm.py
@@ -106,7 +106,7 @@ axial_middle = data.shape[2] // 2
 
 original = data[:, :, axial_middle].T
 final_output = den_final[:, :, axial_middle].T
-difference = np.abs(final_output.astype('f8') - original.astype('f8'))
+difference = np.abs(final_output.astype(np.float64) - original.astype(np.float64))
 difference[~mask[:, :, axial_middle].T] = 0
 
 fig, ax = plt.subplots(1, 3)

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -23,7 +23,8 @@ module of dipy:
 
 from dipy.denoise.gibbs import gibbs_removal
 
-""" We first apply this algorithm to T1-weighted dataset which can be fetched
+"""
+We first apply this algorithm to T1-weighted dataset which can be fetched
 using the following code:
 """
 
@@ -35,7 +36,9 @@ t1_img = read_tissue_data(contrast='T1 denoised')
 
 t1 = t1_img.get_data()
 
-""" Let's plot a slice of this dataset. """
+"""
+Let's plot a slice of this dataset.
+"""
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -51,6 +54,7 @@ t1_slice = np.rot90(t1_slice)
 plt.subplot(1, 2, 1)
 plt.imshow(t1_slice, cmap='gray', vmin=100, vmax=400)
 plt.colorbar()
+fig.savefig('structural.png')
 
 """
 .. figure:: structural.png
@@ -61,7 +65,8 @@ plt.colorbar()
 Due to the high quality of the data, Gibbs artefacts are not visually
 evident in this dataset. Therefore, to analyse the benefits of the Gibbs
 suppression algorithm, Gibbs artefacts are artificially introduced by
-removing high frequencies of the image's Fourier transform."""
+removing high frequencies of the image's Fourier transform.
+"""
 
 c = np.fft.fft2(t1_slice)
 c = np.fft.fftshift(c)
@@ -70,12 +75,16 @@ c_crop = c[64: 192, 64: 192]
 N = c_crop.shape[0]
 t1_gibbs = abs(np.fft.ifft2(c_crop)/4)
 
-""" Gibbs oscillation suppression of this single data slice can be performed by
-running the following command:"""
+"""
+Gibbs oscillation suppression of this single data slice can be performed by
+running the following command:
+"""
 
 t1_unring = gibbs_removal(t1_gibbs)
 
-""" Let’s plot the results: """
+"""
+Let’s plot the results:
+"""
 
 fig1, ax = plt.subplots(1, 3, figsize=(12, 6),
                         subplot_kw={'xticks': [], 'yticks': []})
@@ -149,23 +158,27 @@ img, gtab = read_cenir_multib(bvals)
 
 data = img.get_data()
 
-""" For illustration proposes, we select two slices of this dataset """
+"""
+For illustration proposes, we select two slices of this dataset
+"""
 
 data_slices = data[:, :, 40:42, :]
 
-
-""" Gibbs oscillation suppression of all multi-shell data and all slices
+"""
+Gibbs oscillation suppression of all multi-shell data and all slices
 can be performed in the following way:
 """
 
 data_corrected = gibbs_removal(data_slices, slice_axis=2)
 
-""" Due to the high dimensionality of diffusion-weighted data, we recommend
+"""
+Due to the high dimensionality of diffusion-weighted data, we recommend
 that you specify which is the axis of data matrix that corresponds to different
 slices in the above step. This is done by using the optional parameter
 'slice_axis'.
 
-Below we plot the results for an image acquired with b-value=0: """
+Below we plot the results for an image acquired with b-value=0:
+"""
 
 fig2, ax = plt.subplots(1, 3, figsize=(12, 6),
                         subplot_kw={'xticks': [], 'yticks': []})
@@ -203,7 +216,7 @@ compute a brain mask.
 # Create a brain mask
 from dipy.segment.mask import median_otsu
 
-maskdata, mask = median_otsu(data_slices, vol_idx=range(10, 50), 
+maskdata, mask = median_otsu(data_slices, vol_idx=range(10, 50),
                              median_radius=3, numpass=1, autocrop=False,
                              dilate=1)
 

--- a/doc/examples/denoise_mppca.py
+++ b/doc/examples/denoise_mppca.py
@@ -218,7 +218,9 @@ setting the optional input parameter ``return_sigma`` to True.
 
 denoised_arr, sigma = mppca(data, patch_radius=2, return_sigma=True)
 
-""" Let's plot the noise standard deviation estimate """
+"""
+Let's plot the noise standard deviation estimate:
+"""
 
 fig3 = plt.figure('PCA Noise standard deviation estimation')
 plt.imshow(sigma[..., sli].T, cmap='gray', origin='lower')

--- a/doc/examples/denoise_nlmeans.py
+++ b/doc/examples/denoise_nlmeans.py
@@ -61,7 +61,7 @@ axial_middle = data.shape[2] // 2
 before = data[:, :, axial_middle].T
 after = den[:, :, axial_middle].T
 
-difference = np.abs(after.astype('f8') - before.astype('f8'))
+difference = np.abs(after.astype(np.float64) - before.astype(np.float64))
 
 difference[~mask[:, :, axial_middle].T] = 0
 

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -7,7 +7,7 @@ DKI can also be used to derive concrete biophysical parameters by applying
 microstructural models to DT and KT estimated from DKI. For instance,
 Fieremans et al. [Fierem2011]_ showed that DKI can be used to
 estimate the contribution of hindered and restricted diffusion for well-aligned
-fibers  - model that was later referred to as the white matter tract integrity
+fibers - a model that was later referred to as the white matter tract integrity
 WMTI technique [Fierem2013]_. The two tensors of WMTI can be also
 interpreted as the influences of intra- and extra-cellular compartments and can
 be used to estimate the axonal volume fraction and diffusion extra-cellular
@@ -15,7 +15,7 @@ tortuosity. According to previous studies [Fierem2012]_ [Fierem2013]_,
 these latter measures can be used to distinguish processes of axonal loss from
 processes of myelin degeneration.
 
-In this example, we show how to process a diffusion weighting dataset using
+In this example, we show how to process a dMRI dataset using
 the WMTI model.
 
 First, we import all relevant modules:
@@ -32,9 +32,9 @@ from scipy.ndimage.filters import gaussian_filter
 
 """
 As the standard DKI, WMTI requires multi-shell data, i.e. data acquired from
-more than one non-zero b-value. Here, we use fetch to download a multi-shell
-dataset which was kindly provided by Hansen and Jespersen (more details about
-the data are provided in their paper [Hansen2016]_).
+more than one non-zero b-value. Here, we use a fetcher to download a
+multi-shell dataset which was kindly provided by Hansen and Jespersen
+(more details about the data are provided in their paper [Hansen2016]_).
 """
 
 fetch_cfin_multib()
@@ -46,7 +46,7 @@ data = img.get_data()
 affine = img.affine
 
 """
-For comparison, this dataset is pre-processing using the same steps used in the
+For comparison, this dataset is pre-processed using the same steps used in the
 example for reconstructing DKI (see :ref:`example_reconst_dki`).
 """
 

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -32,9 +32,8 @@ the free water diffusion (normally set to $3.0 \times 10^{-3} mm^{2}s^{-1}$).
 In this example, we show how to process a diffusion weighting dataset using
 an adapted version of the free water elimination proposed by [Hoy2014]_.
 
-The full details of Dipy's free water DTI implementation was published on
-the ReScience C initiative [Henriques2017]_. Please cite this work if you use
-this algorithm.
+The full details of Dipy's free water DTI implementation was published in
+[Henriques2017]_. Please cite this work if you use this algorithm.
 
 Let's start by importing the relevant modules:
 """

--- a/doc/examples/reconst_msdki.py
+++ b/doc/examples/reconst_msdki.py
@@ -96,7 +96,8 @@ bvecs = np.vstack((np.zeros((2, 3)), directions, directions))
 gtab = gradient_table(bvals, bvecs)
 
 
-""" Simulations are looped for different intra- and extra-cellular water
+"""
+Simulations are looped for different intra- and extra-cellular water
 volume fractions and different intersection angles of the two-fiber
 populations.
 """
@@ -123,7 +124,8 @@ for f_i in range(f.size):
                                       fractions=fractions, snr=None)
         dwi[f_i, a_i, :] = signal
 
-""" Now that all synthetic signals were produced, we can go forward with
+"""
+Now that all synthetic signals were produced, we can go forward with
 MSDKI fitting. As other Dipy's reconstruction techniques, the MSDKI model has
 to be first defined for the specific GradientTable object of the synthetic
 data. For MSDKI, this is done by instantiating the MeanDiffusionKurtosisModel
@@ -157,7 +159,8 @@ dki_fit = dki_model.fit(dwi)
 MD = dki_fit.md
 MK = dki_fit.mk(0, 3)
 
-""" Now we plot the results as a function of the ground truth intersection
+"""
+Now we plot the results as a function of the ground truth intersection
 angle and for different volume fractions of intra-cellular water.
 """
 

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -38,7 +38,7 @@ print('data.shape (%d, %d, %d, %d)' % data.shape)
 object (gradient information e.g. b-values). For example, to show the b-values
 it is possible to write::
 
-    ``print(gtab.bvals)``
+    print(gtab.bvals)
 
 Instantiate the SHORE Model.
 

--- a/doc/examples/tracking_bootstrap_peaks.py
+++ b/doc/examples/tracking_bootstrap_peaks.py
@@ -43,6 +43,7 @@ seeds = utils.seeds_from_mask(seed_mask, affine, density=1)
 """
 Next, we fit the CSD model.
 """
+
 response, ratio = auto_response(gtab, data, roi_radius=10, fa_thr=0.7)
 csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
 csd_fit = csd_model.fit(data, mask=white_matter)

--- a/doc/examples/tracking_sfm.py
+++ b/doc/examples/tracking_sfm.py
@@ -23,6 +23,7 @@ from dipy.reconst import sfm
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.streamline import (select_random_set_of_streamlines,
+                                      transform_streamlines,
                                       Streamlines)
 from dipy.tracking.stopping_criterion import ThresholdStoppingCriterion
 from dipy.viz import window, actor, colormap, has_fury
@@ -160,6 +161,7 @@ if has_fury:
 Finally, we can save these streamlines to a 'trk' file, for use in other
 software, or for further analysis.
 """
+
 sft = StatefulTractogram(streamlines, hardi_img, Space.RASMM)
 save_trk(sft, "tractogram_sfm_detr.trk")
 

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -52,7 +52,6 @@ We will use 3 bundles, FA and the affine transformation that brings the voxel
 coordinates to world coordinates (RAS 1mm).
 """
 
-# import ipdb; ipdb.set_trace()
 streamlines = Streamlines(res['af.left'])
 streamlines.extend(res['cst.right'])
 streamlines.extend(res['cc_1'])

--- a/doc/examples/viz_advanced.py
+++ b/doc/examples/viz_advanced.py
@@ -34,7 +34,7 @@ a ``LineSlider2D`` widget.
 
 First we need to fetch and load some datasets.
 """
-
+from dipy.tracking.streamline import Streamlines
 from dipy.data.fetcher import fetch_bundles_2_subjects, read_bundles_2_subjects
 
 fetch_bundles_2_subjects()
@@ -52,7 +52,11 @@ We will use 3 bundles, FA and the affine transformation that brings the voxel
 coordinates to world coordinates (RAS 1mm).
 """
 
-streamlines = res['af.left'] + res['cst.right'] + res['cc_1']
+# import ipdb; ipdb.set_trace()
+streamlines = Streamlines(res['af.left'])
+streamlines.extend(res['cst.right'])
+streamlines.extend(res['cc_1'])
+
 data = res['fa']
 shape = data.shape
 affine = res['affine']
@@ -196,6 +200,7 @@ line_slider_z.on_change = change_slice_z
 line_slider_x.on_change = change_slice_x
 line_slider_y.on_change = change_slice_y
 opacity_slider.on_change = change_opacity
+
 """
 We'll also create text labels to identify the sliders.
 """

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -18,7 +18,7 @@ Quick Start
 -----------
 
 - :ref:`example_quick_start`
-- :ref:`example_introduction_eudx`
+- :ref:`example_tracking_introduction_eudx`
 
 -------------
 Preprocessing

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,7 @@ visualization, and statistical analysis of MRI data.
 Highlights
 **********
 
-**DIPY 0.16.0** is now available. New features include:
+**DIPY 1.0.0** is now available. New features include:
 
 - Horizon, medical visualization interface powered by QuickBundlesX.
 - New Tractometry tools: Bundle Analysis / Bundle Profiles.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,7 @@ Highlights
 - Large refactoring of tracking API.
 - New pre-processing algorithms: MP-PCA, Gibbs Ringing.
 - New interpolation module: ``dipy.core.interpolation``.
-- New reconstruction model: MTMS-CSD.
+- New reconstruction model: MTMS-CSD, Mean Signal DKI.
 - Increase affine consistency by updating API.
 - New object to manage safely tractography data: StatefulTractogram
 - New command line interface for downloading datasets: FetchFlow

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,15 +15,21 @@ Highlights
 
 **DIPY 1.0.0** is now available. New features include:
 
-- Horizon, medical visualization interface powered by QuickBundlesX.
-- New Tractometry tools: Bundle Analysis / Bundle Profiles.
-- New reconstruction model: IVIM MIX (Variable Projection).
-- New command line interface: Affine and Diffeomorphic Registration.
-- New command line interface: Probabilistic, Deterministic and PFT Tracking.
-- Integration of Cython Guidelines for developers.
-- Replacement of Nose by Pytest.
-- Documentation update.
-- Closed 103 issues and merged 41 pull requests.
+- Critical :doc:`API changes <api_changes>`
+- Large refactoring of tracking API.
+- New pre-processing algorithms: MP-PCA, Gibbs Ringing.
+- New interpolation module: ``dipy.core.interpolation``.
+- New reconstruction model: MTMS-CSD.
+- Increase affine consistency by updating API.
+- New object to manage safely tractography data: StatefulTractogram
+- New command line interface for downloading datasets: FetchFlow
+- Horizon updated, medical visualization interface powered by QuickBundlesX.
+- Removed all deprecated functions and parameters.
+- Removed compatibility with Python 2.7.
+- Updated minimum dependencies version (Numpy, Scipy).
+-  3 New tutorials added and all updated to API changes.
+- Large documentation update.
+- Closed 289 issues and merged 97 pull requests.
 
 See :ref:`Older Highlights <old_highlights>`.
 
@@ -40,10 +46,9 @@ Announcements
   </div>
 
 
-- :doc:`DIPY 0.16 <release_notes/release0.16>` released March 10, 2019.
+- :doc:`DIPY 1.0 <release_notes/release1.0>` released August 5, 2019.
 - :doc:`DIPY 0.15 <release_notes/release0.15>` released December 12, 2018.
 - :doc:`DIPY 0.14 <release_notes/release0.14>` released May 1, 2018.
-- :doc:`DIPY 0.13 <release_notes/release0.13>` released October 24, 2017.
 
 
 See some of our :ref:`Past Announcements <old_news>`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,19 +17,20 @@ Highlights
 
 - Critical :doc:`API changes <api_changes>`
 - Large refactoring of tracking API.
-- New pre-processing algorithms: MP-PCA, Gibbs Ringing.
+- New denoising algorithm: MP-PCA.
+- New Gibbs ringing removal.
 - New interpolation module: ``dipy.core.interpolation``.
-- New reconstruction model: MTMS-CSD, Mean Signal DKI.
-- Increase affine consistency by updating API.
+- New reconstruction models: MTMS-CSD, Mean Signal DKI.
+- Increased coordinate systems consistency.
 - New object to manage safely tractography data: StatefulTractogram
 - New command line interface for downloading datasets: FetchFlow
 - Horizon updated, medical visualization interface powered by QuickBundlesX.
 - Removed all deprecated functions and parameters.
 - Removed compatibility with Python 2.7.
 - Updated minimum dependencies version (Numpy, Scipy).
--  3 New tutorials added and all updated to API changes.
+- All tutorials updated to API changes and 3 new added.
 - Large documentation update.
-- Closed 289 issues and merged 97 pull requests.
+- Closed 289 issues and merged 98 pull requests.
 
 See :ref:`Older Highlights <old_highlights>`.
 
@@ -47,8 +48,8 @@ Announcements
 
 
 - :doc:`DIPY 1.0 <release_notes/release1.0>` released August 5, 2019.
+- :doc:`DIPY 0.16 <release_notes/release0.16>` released March 10, 2019.
 - :doc:`DIPY 0.15 <release_notes/release0.15>` released December 12, 2018.
-- :doc:`DIPY 0.14 <release_notes/release0.14>` released May 1, 2018.
 
 
 See some of our :ref:`Past Announcements <old_news>`

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -18,7 +18,7 @@ e-mail list neuroimaging@python.org with subject starting with ``[DIPY]``.
 
    This is a depiction of tractography created with DIPY.
 
-   If you want to learn more how you can create these with your datasets 
+   If you want to learn more how you can create these with your datasets
    read the examples in our :ref:`documentation` .
 
 .. include:: links_names.inc

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -18,7 +18,7 @@ e-mail list neuroimaging@python.org with subject starting with ``[DIPY]``.
 
    This is a depiction of tractography created with DIPY.
 
-   If you want to learn more how you can create these with your datasets
+   If you want to learn how you can create these with your datasets,
    read the examples in our :ref:`documentation` .
 
 .. include:: links_names.inc

--- a/doc/old_highlights.rst
+++ b/doc/old_highlights.rst
@@ -4,6 +4,19 @@
 Older Highlights
 ****************
 
+**DIPY 0.16.0** is now available. New features include:
+
+- Horizon, medical visualization interface powered by QuickBundlesX.
+- New Tractometry tools: Bundle Analysis / Bundle Profiles.
+- New reconstruction model: IVIM MIX (Variable Projection).
+- New command line interface: Affine and Diffeomorphic Registration.
+- New command line interface: Probabilistic, Deterministic and PFT Tracking.
+- Integration of Cython Guidelines for developers.
+- Replacement of Nose by Pytest.
+- Documentation update.
+- Closed 103 issues and merged 41 pull requests.
+
+
 **DIPY 0.15.0** is now available. New features include:
 
 - Updated RecoBundles for automatic anatomical bundle segmentation.
@@ -15,7 +28,7 @@ Older Highlights
 - Many tutorials added or updated (5 New).
 - Large documentation update.
 - Moved visualization module to a new library: FURY.
-- Closed 287 issues and merged 93 pull requests. 
+- Closed 287 issues and merged 93 pull requests.
 
 **DIPY 0.14** is now available. New features include:
 

--- a/doc/old_news.rst
+++ b/doc/old_news.rst
@@ -5,6 +5,7 @@
 Past Announcements
 **********************
 
+- :doc:`DIPY 0.14 <release_notes/release0.14>` released May 1, 2018.
 - :doc:`DIPY 0.13 <release_notes/release0.13>` released October 24, 2017.
 - :doc:`DIPY 0.12 <release_notes/release0.12>` released June 26, 2017.
 - :doc:`DIPY 0.11 <release_notes/release0.11>` released February 21, 2016.

--- a/doc/release_notes/release1.0.rst
+++ b/doc/release_notes/release1.0.rst
@@ -1,0 +1,329 @@
+.. _release1.0:
+
+====================================
+ Release notes for DIPY version 1.0
+====================================
+
+GitHub stats for 2019/03/11 - 2019/08/05 (tag: 0.16.0)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+The following 17 authors contributed 707 commits.
+
+* Adam Richie-Halford
+* Antoine Theberge
+* Ariel Rokem
+* Clint Greene
+* Eleftherios Garyfallidis
+* Francois Rheault
+* Gabriel Girard
+* Jean-Christophe Houde
+* Jon Haitz Legarreta Gorroño
+* Kevin Sitek
+* Marc-Alexandre Côté
+* Matt Cieslak
+* Rafael Neto Henriques
+* Samuel St-Jean
+* Scott Trinkle
+* Serge Koudoro
+* Shreyas Fadnavis
+
+
+We closed a total of 289 issues, 97 pull requests and 192 regular issues;
+this is the full list (generated with the script
+:file:`tools/github_stats.py`):
+
+Pull Requests (97):
+
+* :ghpull:`1924`: Some updates in Horizon fixing some issues for upcoming release
+* :ghpull:`1946`: Fix empty tractogram loading saving
+* :ghpull:`1947`: DOC: fixing examples links
+* :ghpull:`1942`: Remove dipy.io.trackvis
+* :ghpull:`1917`: A functional implementation of Random matrix local pca.
+* :ghpull:`1940`: Increase affine consistency in dipy.tracking.streamlines
+* :ghpull:`1909`: [WIP] - MTMS-CSD Tutorial
+* :ghpull:`1931`: [BF] IVIM fixes
+* :ghpull:`1944`: Update DKI, WMTI, fwDTI examples and give more evidence to WMTI and fwDTI models
+* :ghpull:`1939`: Increase affine consistency in dipy.tracking.utils
+* :ghpull:`1943`: Increase affine consistency in dipy.tracking.life and dipy.stats.analysis
+* :ghpull:`1941`: Remove some viz tutorial
+* :ghpull:`1926`: RF - dipy.tracking.local
+* :ghpull:`1935`: Remove dipy.external and dipy.fixes packages
+* :ghpull:`1903`: Skip some tests on big endian architecture (like s390x)
+* :ghpull:`1892`: Use the correct (row) order of the tensor components
+* :ghpull:`1804`: BF: added check to avoid infinite loop on consecutive coordinates.
+* :ghpull:`1937`: Add a warning about future changes that will happen in dipy.stats.
+* :ghpull:`1928`: Update streamlines formats example
+* :ghpull:`1925`: FIX: Stateful tractogram examples
+* :ghpull:`1927`: BF - move import to top level
+* :ghpull:`1923`: [Fix] removing minmax_norm parameter from peak_direction
+* :ghpull:`1894`: Default sphere: From symmetric724 to repulsion724
+* :ghpull:`1812`: ENH: Statefull tractogram, robust spatial handling and IO
+* :ghpull:`1922`: Remove deprecated functions from imaffine
+* :ghpull:`1885`: BF - remove single pts streamline
+* :ghpull:`1913`: RF - EuDX legacy code/test
+* :ghpull:`1915`: Doc generation under Windows
+* :ghpull:`1630`: [Fix] remove Userwarning message
+* :ghpull:`1896`: New module: dipy.core.interpolation
+* :ghpull:`1912`: Remove deprecated parameter voxel_size
+* :ghpull:`1916`: Spherical deconvolution model CANNOT be constructed without specifying a response
+* :ghpull:`1918`: ENH: Remove unused `warning` package import
+* :ghpull:`1881`: DOC - RF tracking examples
+* :ghpull:`1911`: Add python_requires
+* :ghpull:`1914`: [Fix] vol_idx missing in snr_in_cc Tutorial
+* :ghpull:`1907`: DOC: Fix examples documentation generation warnings
+* :ghpull:`1908`: DOC: Fix typos
+* :ghpull:`1887`: DOC - updated streamline_tools example with the LocalTracking Framework
+* :ghpull:`1905`: ENH: Remove deprecated SH bases
+* :ghpull:`1849`: Adds control for number of iterations in CSD recon
+* :ghpull:`1902`: Warn users if they don't have FURY installed
+* :ghpull:`1904`: DOC: Improve documentation
+* :ghpull:`1771`: Gibbs removal
+* :ghpull:`1899`: Fix: Byte ordering error on Python 3.5
+* :ghpull:`1898`: Replace SingleTensor by single_tensor
+* :ghpull:`1897`: DOC: Fix typos
+* :ghpull:`1893`: Remove scratch folder
+* :ghpull:`1891`: Move the tests from test_refine_rb to test_bundles.
+* :ghpull:`1888`: BF - fix eudx tracking for npeaks=1
+* :ghpull:`1879`: DOC - explicitly run the streamline generators before saving the trk
+* :ghpull:`1884`: Clean up: Remove streamlines memory patch
+* :ghpull:`1875`: ENH: Add binary tissue classifier option for tracking workflow
+* :ghpull:`1882`: DOC - clarified the state of the tracking process once stopped
+* :ghpull:`1880`: DOC: Fix typos and improve documentation
+* :ghpull:`1878`: Clean up: Remove NUMPY_LESS_0.8.x
+* :ghpull:`1877`: Clean up: Remove all SCIPY_LESS_0.x.x
+* :ghpull:`1876`: DOC: Fix typos
+* :ghpull:`1874`: DOC: Fix documentation oversights.
+* :ghpull:`1858`: NF: MSMT - CSD
+* :ghpull:`1843`: [NF] new workflow: FetchFlow
+* :ghpull:`1866`: MAINT: Drop support for Python 3.4
+* :ghpull:`1850`: NF: Add is_hemispherical test
+* :ghpull:`1855`: Pin scipy version for bots that need statsmodels.
+* :ghpull:`1835`: [Fix]  Workflow mask documentation
+* :ghpull:`1836`: Corrected median_otsu function declaration that was breaking tutorials
+* :ghpull:`1792`: [NF]: Add seeds to TRK
+* :ghpull:`1851`: DOC: Add single-module test/coverage instructions
+* :ghpull:`1842`: [Fix] Remove tput from fetcher
+* :ghpull:`1800`: Update command line documentation generation
+* :ghpull:`1830`: Delete six module
+* :ghpull:`1821`: Fixes 238, by requiring vol_idx input with 4D images.
+* :ghpull:`1775`: Remove Python 2 dependency.
+* :ghpull:`1816`: Remove Deprecated function  dipy.data.get_data
+* :ghpull:`1818`: [DOC] fix rank order typo
+* :ghpull:`1827`: Remove deprecated module dipy.segment.quickbundes
+* :ghpull:`1824`: Remove deprecated module dipy.reconst.peaks
+* :ghpull:`1819`: [Fix] Diffeormorphic + CCMetric on small image
+* :ghpull:`1823`: Remove accent colormap
+* :ghpull:`1814`: [Fix]  add a basic check on dipy_horizon
+* :ghpull:`1815`: [FIX] median_otsu deprecated parameter
+* :ghpull:`1813`: [Fix] Add Readme for doc generation
+* :ghpull:`1766`: NF - add tracking workflow parameters
+* :ghpull:`1772`: BF: changes min_signal defaults from 1 to 1e-5
+* :ghpull:`1810`: [Bug FIx]  dipy_fit_csa and dipy_fit_csd workflow
+* :ghpull:`1806`: Plot both IVIM fits on the same axis
+* :ghpull:`1789`: VarPro Fit Example IVIM
+* :ghpull:`1770`: Parallel reconst workflows
+* :ghpull:`1796`: [Fix] stripping in workflow documentation
+* :ghpull:`1795`: [Fix] workflows description
+* :ghpull:`1768`: Add afq to stats
+* :ghpull:`1788`: Add test for different dtypes
+* :ghpull:`1769`: Change "is" check for 'GCV'
+* :ghpull:`1767`: BF: self.self
+* :ghpull:`1759`: Add one more acknowledgement
+* :ghpull:`1230`: Mean Signal DKI
+* :ghpull:`1760`: Implements the inverse of decfa
+
+Issues (192):
+
+* :ghissue:`1798`: ploting denoised img
+* :ghissue:`1924`: Some updates in Horizon fixing some issues for upcoming release
+* :ghissue:`1946`: Fix empty tractogram loading saving
+* :ghissue:`1947`: DOC: fixing examples links
+* :ghissue:`1942`: Remove dipy.io.trackvis
+* :ghissue:`1917`: A functional implementation of Random matrix local pca.
+* :ghissue:`1940`: Increase affine consistency in dipy.tracking.streamlines
+* :ghissue:`1909`: [WIP] - MTMS-CSD Tutorial
+* :ghissue:`1931`: [BF] IVIM fixes
+* :ghissue:`1817`: Unusual behavior in Dipy IVIM implementation/example
+* :ghissue:`1774`: Split up DKI example
+* :ghissue:`1944`: Update DKI, WMTI, fwDTI examples and give more evidence to WMTI and fwDTI models
+* :ghissue:`1939`: Increase affine consistency in dipy.tracking.utils
+* :ghissue:`1943`: Increase affine consistency in dipy.tracking.life and dipy.stats.analysis
+* :ghissue:`1941`: Remove some viz tutorial
+* :ghissue:`1926`: RF - dipy.tracking.local
+* :ghissue:`1935`: Remove dipy.external and dipy.fixes packages
+* :ghissue:`1903`: Skip some tests on big endian architecture (like s390x)
+* :ghissue:`1587`: Could tests for functionality not supported on big endians just skip?
+* :ghissue:`1890`: Tensor I/O in dipy_fit_dti
+* :ghissue:`1892`: Use the correct (row) order of the tensor components
+* :ghissue:`1804`: BF: added check to avoid infinite loop on consecutive coordinates.
+* :ghissue:`1937`: Add a warning about future changes that will happen in dipy.stats.
+* :ghissue:`1933`: Remove deprecated voxel_size from seed_from_mask
+* :ghissue:`1928`: Update streamlines formats example
+* :ghissue:`985`: Getting started example should be commented at each step
+* :ghissue:`1558`: Example of creating Trackvis compatible streamlines is needed
+* :ghissue:`1925`: FIX: Stateful tractogram examples
+* :ghissue:`1910`: BF: IVIM fixes
+* :ghissue:`1927`: BF - move import to top level
+* :ghissue:`1923`: [Fix] removing minmax_norm parameter from peak_direction
+* :ghissue:`389`: minmax_norm in peaks_directions does nothing
+* :ghissue:`1894`: Default sphere: From symmetric724 to repulsion724
+* :ghissue:`590`: Change default sphere
+* :ghissue:`1722`: Error when using TCK files written by dipy
+* :ghissue:`1832`: Tracking workflow header affine issue & fix
+* :ghissue:`1812`: ENH: Statefull tractogram, robust spatial handling and IO
+* :ghissue:`1922`: Remove deprecated functions from imaffine
+* :ghissue:`1885`: BF - remove single pts streamline
+* :ghissue:`1913`: RF - EuDX legacy code/test
+* :ghissue:`283`: Spherical deconvolution model can be constructed without specifying a response
+* :ghissue:`1915`: Doc generation under Windows
+* :ghissue:`1630`: [Fix] remove Userwarning message
+* :ghissue:`1896`: New module: dipy.core.interpolation
+* :ghissue:`728`: Many interpolation functions in different places can they all go to same module?
+* :ghissue:`1912`: Remove deprecated parameter voxel_size
+* :ghissue:`1920`: How can I get streamlines using fiber orientation by bedpostx of MRtrix3?
+* :ghissue:`1432`: DOC/RF - update/standardize tracking examples
+* :ghissue:`1779`: Probabilistic Direction Getter gallery example
+* :ghissue:`1916`: Spherical deconvolution model CANNOT be constructed without specifying a response
+* :ghissue:`1918`: ENH: Remove unused `warning` package import
+* :ghissue:`1881`: DOC - RF tracking examples
+* :ghissue:`1906`: Add python_requires=">=3.5"
+* :ghissue:`1911`: Add python_requires
+* :ghissue:`1901`: window.record() function shows the coronal view
+* :ghissue:`1914`: [Fix] vol_idx missing in snr_in_cc Tutorial
+* :ghissue:`1718`: cannot import name window
+* :ghissue:`1747`: CI error that sometimes shows up (Python 2.7)
+* :ghissue:`1907`: DOC: Fix examples documentation generation warnings
+* :ghissue:`1908`: DOC: Fix typos
+* :ghissue:`1887`: DOC - updated streamline_tools example with the LocalTracking Framework
+* :ghissue:`1839`: [WIP] IVIM fixes
+* :ghissue:`1905`: ENH: Remove deprecated SH bases
+* :ghissue:`583`: Make a cython style guide
+* :ghissue:`1849`: Adds control for number of iterations in CSD recon
+* :ghissue:`1902`: Warn users if they don't have FURY installed
+* :ghissue:`1904`: DOC: Improve documentation
+* :ghissue:`1694`: Intermittent test failures in `test_streamline`
+* :ghissue:`1724`: Failure on Windows/Python 3.5
+* :ghissue:`1771`: Gibbs removal
+* :ghissue:`1899`: Fix: Byte ordering error on Python 3.5
+* :ghissue:`1898`: Replace SingleTensor by single_tensor
+* :ghissue:`844`: Refactor behavior of dipy.sims.voxel.single_tensor vs SingleTensor
+* :ghissue:`1752`: Intermittent failure on Python 3.4
+* :ghissue:`1856`: Figure out how to get a "used by" button
+* :ghissue:`1897`: DOC: Fix typos
+* :ghissue:`1807`: tracking fails when npeaks=1 for peaks_from_model with tensor model
+* :ghissue:`1889`: `segment.bundles` package not being tested
+* :ghissue:`1893`: Remove scratch folder
+* :ghissue:`1713`: Clean up "scratch"
+* :ghissue:`1891`: Move the tests from test_refine_rb to test_bundles.
+* :ghissue:`1888`: BF - fix eudx tracking for npeaks=1
+* :ghissue:`668`: Add transformation matrix output and input
+* :ghissue:`592`: Shouldn't TRACKPOINT be renamed to NODIRECTION?
+* :ghissue:`1879`: DOC - explicitly run the streamline generators before saving the trk
+* :ghissue:`1884`: Clean up: Remove streamlines memory patch
+* :ghissue:`1875`: ENH: Add binary tissue classifier option for tracking workflow
+* :ghissue:`1811`: Add binary tissue classifier option for the tracking workflow
+* :ghissue:`1846`: streamlines to array
+* :ghissue:`1831`: bvec file dimension  prob
+* :ghissue:`1882`: DOC - clarified the state of the tracking process once stopped
+* :ghissue:`1880`: DOC: Fix typos and improve documentation
+* :ghissue:`1857`: point outside data error
+* :ghissue:`1878`: Clean up: Remove NUMPY_LESS_0.8.x
+* :ghissue:`1877`: Clean up: Remove all SCIPY_LESS_0.x.x
+* :ghissue:`1863`: Clean up core.optimize
+* :ghissue:`1876`: DOC: Fix typos
+* :ghissue:`1874`: DOC: Fix documentation oversights.
+* :ghissue:`1781`: [WIP] Random lpca
+* :ghissue:`1858`: NF: MSMT - CSD
+* :ghissue:`1843`: [NF] new workflow: FetchFlow
+* :ghissue:`1869`: get rotation and translation parameters of a rigid transformation
+* :ghissue:`1844`: Statsmodels import error
+* :ghissue:`1866`: MAINT: Drop support for Python 3.4
+* :ghissue:`1865`: Drop Python 3.4?
+* :ghissue:`1850`: NF: Add is_hemispherical test
+* :ghissue:`1860`: Dependency Graph: Dependents?
+* :ghissue:`1855`: Pin scipy version for bots that need statsmodels.
+* :ghissue:`1168`: Nf mtms csd model
+* :ghissue:`1854`: Testing the CI. DO NOT MERGE
+* :ghissue:`1835`: [Fix]  Workflow mask documentation
+* :ghissue:`1764`: DTI metrics workflow: mask is optional, but crashes when no mask provided
+* :ghissue:`1836`: Corrected median_otsu function declaration that was breaking tutorials
+* :ghissue:`1792`: [NF]: Add seeds to TRK
+* :ghissue:`1731`: Plan for dropping Python 2 support.
+* :ghissue:`1851`: DOC: Add single-module test/coverage instructions
+* :ghissue:`1845`: Signal to noise
+* :ghissue:`1842`: [Fix] Remove tput from fetcher
+* :ghissue:`1829`: When fetching ... 'tput' is not reco...
+* :ghissue:`1606`: Cleaned PR for Visualization Modules to Assess the quality of Registration Qualitatively.
+* :ghissue:`1837`: labels
+* :ghissue:`1786`: Upcoming DIPY lab meetings
+* :ghissue:`1828`: IVIM VarPro implementation throws infeasible 'x0'
+* :ghissue:`1833`: Affine registration of similar images
+* :ghissue:`1834`: Which file to convert  from dicom to nifti?!
+* :ghissue:`1800`: Update command line documentation generation
+* :ghissue:`1830`: Delete six module
+* :ghissue:`1721`: using code style
+* :ghissue:`238`: Median_otsu b0slices too implicit?
+* :ghissue:`1821`: Fixes 238, by requiring vol_idx input with 4D images.
+* :ghissue:`1775`: Remove Python 2 dependency.
+* :ghissue:`1816`: Remove Deprecated function  dipy.data.get_data
+* :ghissue:`1818`: [DOC] fix rank order typo
+* :ghissue:`1499`: Possible mistake about B matrix in documentation "DIY Stuff about b and q"
+* :ghissue:`1827`: Remove deprecated module dipy.segment.quickbundes
+* :ghissue:`1822`: .trk file
+* :ghissue:`1824`: Remove deprecated module dipy.reconst.peaks
+* :ghissue:`1825`: Fury visualizing bug - plane only visible for XY-slice of FODs
+* :ghissue:`1819`: [Fix] Diffeormorphic + CCMetric on small image
+* :ghissue:`1048`: divide by zero error in DiffeomorphicRegistration of small image volumes
+* :ghissue:`1823`: Remove accent colormap
+* :ghissue:`1797`: function parameters
+* :ghissue:`1802`: crossing fibers & fractional anisotropy
+* :ghissue:`1787`: RF - change default tracking algorithm for dipy_track_local to EuDX
+* :ghissue:`1763`: Threshold default in QballBaseModel
+* :ghissue:`1814`: [Fix]  add a basic check on dipy_horizon
+* :ghissue:`1756`: Error using dipy_horizon
+* :ghissue:`1815`: [FIX] median_otsu deprecated parameter
+* :ghissue:`1761`: Deprecation warning when running median_otsu
+* :ghissue:`795`: dipy.tracking: Converting an array with ndim > 0 to an index will result in an error
+* :ghissue:`620`: Extend the AUTHOR list with more information
+* :ghissue:`1813`: [Fix] Add Readme for doc generation
+* :ghissue:`436`: Doc won't build without cvxopt
+* :ghissue:`1758`: additional parameters for dipy_track_local workflow
+* :ghissue:`1766`: NF - add tracking workflow parameters
+* :ghissue:`1772`: BF: changes min_signal defaults from 1 to 1e-5
+* :ghissue:`1810`: [Bug FIx]  dipy_fit_csa and dipy_fit_csd workflow
+* :ghissue:`1808`: `dipy_fit_csd` CLI is broken?
+* :ghissue:`1806`: Plot both IVIM fits on the same axis
+* :ghissue:`1794`: Removed/renamed DetTrackPAMFlow?
+* :ghissue:`1801`: segmentation
+* :ghissue:`1803`: tools
+* :ghissue:`1809`: datasets
+* :ghissue:`1799`: steps from nifiti file to tracts
+* :ghissue:`1712`: dipy.reconst.peak_direction_getter.PeaksAndMetricsDirectionGetter.initial_direction (dipy/reconst/peak_direction_getter.c:3075) IndexError: point outside data
+* :ghissue:`1789`: VarPro Fit Example IVIM
+* :ghissue:`1770`: Parallel reconst workflows
+* :ghissue:`1796`: [Fix] stripping in workflow documentation
+* :ghissue:`1795`: [Fix] workflows description
+* :ghissue:`1768`: Add afq to stats
+* :ghissue:`1783`: Make trilinear_interpolate4d work with more dtypes.
+* :ghissue:`1784`: Generalize trilinear_interpolate4d to other dtypes.
+* :ghissue:`1788`: Add test for different dtypes
+* :ghissue:`1790`: ValueError: operands could not be broadcast together with remapped shapes [original->remapped]: (13,13)->(13,13) (10000,10)->(10000,newaxis,10)
+* :ghissue:`1782`: Conversion from MRTrix SH basis to dipy
+* :ghissue:`1769`: Change "is" check for 'GCV'
+* :ghissue:`1320`: WIP: Bias correction
+* :ghissue:`1245`: non_local_means : patch size argument for local mean and variance
+* :ghissue:`1240`: WIP: Improve the axonal water fraction estimation.
+* :ghissue:`1237`: DOC: Flesh out front page example.
+* :ghissue:`1192`: Error handling in SDT
+* :ghissue:`1096`: Robust Brain Extraction
+* :ghissue:`832`: trilinear_interpolate4d only works on float64
+* :ghissue:`578`: WIP: try out Stefan Behnel's cython coverage
+* :ghissue:`1780`: [WIP]: Randommatrix localpca
+* :ghissue:`1022`: Fixes #720 : Auto generate ipython notebooks
+* :ghissue:`1126`: Publishing in JOSS : Added paper summary for IVIM
+* :ghissue:`1603`: [WIP] - Free water elimination algorithm for single-shell DTI
+* :ghissue:`1767`: BF: self.self
+* :ghissue:`1759`: Add one more acknowledgement
+* :ghissue:`1230`: Mean Signal DKI
+* :ghissue:`1760`: Implements the inverse of decfa

--- a/doc/release_notes/release1.0.rst
+++ b/doc/release_notes/release1.0.rst
@@ -23,7 +23,6 @@ The following 17 authors contributed 707 commits.
 * Marc-Alexandre Côté
 * Matt Cieslak
 * Rafael Neto Henriques
-* Samuel St-Jean
 * Scott Trinkle
 * Serge Koudoro
 * Shreyas Fadnavis

--- a/doc/stateoftheart.rst
+++ b/doc/stateoftheart.rst
@@ -28,6 +28,7 @@ For a full list of the features implemented in the most recent release cycle, ch
 .. toctree::
    :maxdepth: 1
 
+   release_notes/release1.0
    release_notes/release0.16
    release_notes/release0.15
    release_notes/release0.14


### PR DESCRIPTION
# Summary

Preparation for 1.0.0 release, targeting Wednesday, July 31.  The new 1.X.X series !!! Python 3 only !!!

Just a note that any PR can block the release. If they are not in, it will be for the next release in
October.

# Release checklist
- [x] add release_notes 1.0.0
- [x] Update changelog an api_changes
- [x] Update .mailmap
- [x] Set release number in info.py and doc/conf.py
- [x] Check the copyright years in doc/conf.py and LICENSE
- [x] Check documentation
- [x] Check Tutorial
- [x] Update index.rst
- [x] Update Highligth.rst, old_news.rst, stateofheart.rst
- [x] Update developers.rst list
- [ ] Update website
- [x] Update deprecation cycle : `DeprecationWarning` -> `PendingDeprecationWarning` -> delete 
- [x] Finish up small fixes suggested by @arokem in https://github.com/nipy/dipy/pull/1944