### PR TITLE
Update DKI, WMTI, fwDTI examples and give more evidence to WMTI and fwDTI models

### DIFF
--- a/dipy/reconst/fwdti.py
+++ b/dipy/reconst/fwdti.py
@@ -58,10 +58,10 @@ def fwdti_prediction(params, gtab, S0=1, Diso=3.0e-3):
 
     References
     ----------
-    .. [1] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
-           Optimization of a free water elimination two-compartmental model
-           for diffusion tensor imaging. NeuroImage 103, 323-333.
-           doi: 10.1016/j.neuroimage.2014.09.053
+    .. [1] Henriques, R.N., Rokem, A., Garyfallidis, E., St-Jean, S.,
+           Peterson E.T., Correia, M.M., 2017. [Re] Optimization of a free
+           water elimination two-compartment model for diffusion tensor
+           imaging. ReScience volume 3, issue 1, article number 2
     """
     evals = params[..., :3]
     evecs = params[..., 3:-1].reshape(params.shape[:-1] + (3, 3))
@@ -108,10 +108,10 @@ class FreeWaterTensorModel(ReconstModel):
 
         References
         ----------
-        .. [1] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
-               Optimization of a free water elimination two-compartmental model
-               for diffusion tensor imaging. NeuroImage 103, 323-333.
-               doi: 10.1016/j.neuroimage.2014.09.053
+        .. [1] Henriques, R.N., Rokem, A., Garyfallidis, E., St-Jean, S.,
+               Peterson E.T., Correia, M.M., 2017. [Re] Optimization of a free
+               water elimination two-compartment model for diffusion tensor
+               imaging. ReScience volume 3, issue 1, article number 2
         """
         ReconstModel.__init__(self, gtab)
 
@@ -192,6 +192,13 @@ class FreeWaterTensorFit(TensorFit):
                 2) Three lines of the eigenvector matrix each containing the
                    first, second and third coordinates of the eigenvector
                 3) The volume fraction of the free water compartment
+
+        References
+        ----------
+        .. [1] Henriques, R.N., Rokem, A., Garyfallidis, E., St-Jean, S.,
+               Peterson E.T., Correia, M.M., 2017. [Re] Optimization of a free
+               water elimination two-compartment model for diffusion tensor
+               imaging. ReScience volume 3, issue 1, article number 2
         """
         TensorFit.__init__(self, model, model_params)
 
@@ -367,10 +374,10 @@ def wls_fit_tensor(gtab, data, Diso=3e-3, mask=None, min_signal=1.0e-6,
 
     References
     ----------
-    .. [1] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
-           Optimization of a free water elimination two-compartmental model
-           for diffusion tensor imaging. NeuroImage 103, 323-333.
-           doi: 10.1016/j.neuroimage.2014.09.053
+    .. [1] Henriques, R.N., Rokem, A., Garyfallidis, E., St-Jean, S.,
+           Peterson E.T., Correia, M.M., 2017. [Re] Optimization of a free
+           water elimination two-compartment model for diffusion tensor
+           imaging. ReScience volume 3, issue 1, article number 2
     """
     fw_params = np.zeros(data.shape[:-1] + (13,))
     W = design_matrix(gtab)

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -12,7 +12,7 @@ biological tissues is non-Gaussian using the kurtosis tensor (KT)
 Measurements of non-Gaussian diffusion from the diffusion kurtosis model are of
 interest because they can be used to charaterize tissue microstructural
 heterogeneity [Jensen2010]_. Moreover, DKI can be used to: 1) derive concrete
-biophysical parameters, such as the density of axonal fibres and diffusion
+biophysical parameters, such as the density of axonal fibers and diffusion
 tortuosity [Fierem2011]_ (see :ref:`example_reconst_dki_micro`); and 2)
 resolve crossing fibers in tractography and to obtain invariant rotational
 measures not limited to well-aligned fiber populations [NetoHe2015]_.

--- a/doc/examples/reconst_dki.py
+++ b/doc/examples/reconst_dki.py
@@ -11,11 +11,11 @@ biological tissues is non-Gaussian using the kurtosis tensor (KT)
 
 Measurements of non-Gaussian diffusion from the diffusion kurtosis model are of
 interest because they can be used to charaterize tissue microstructural
-heterogeneity [Jensen2010]_ and to derive concrete biophysical parameters, such
-as the density of axonal fibres and diffusion tortuosity [Fieremans2011]_.
-Moreover, DKI can be used to resolve crossing fibers in tractography and to
-obtain invariant rotational measures not limited to well-aligned fiber
-populations [NetoHe2015]_.
+heterogeneity [Jensen2010]_. Moreover, DKI can be used to: 1) derive concrete
+biophysical parameters, such as the density of axonal fibres and diffusion
+tortuosity [Fierem2011]_ (see :ref:`example_reconst_dki_micro`); and 2)
+resolve crossing fibers in tractography and to obtain invariant rotational
+measures not limited to well-aligned fiber populations [NetoHe2015]_.
 
 The diffusion kurtosis model expresses the diffusion-weighted signal as:
 
@@ -64,7 +64,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import dipy.reconst.dki as dki
 import dipy.reconst.dti as dti
-import dipy.reconst.dki_micro as dki_micro
 from dipy.data import fetch_cfin_multib
 from dipy.data import read_cfin_dwi
 from dipy.segment.mask import median_otsu
@@ -180,30 +179,30 @@ fig1, ax = plt.subplots(2, 4, figsize=(12, 6),
 
 fig1.subplots_adjust(hspace=0.3, wspace=0.05)
 
-ax.flat[0].imshow(FA[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=0.7,
-                  origin='lower')
+ax.flat[0].imshow(FA[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=0.7, origin='lower')
 ax.flat[0].set_title('FA (DKI)')
-ax.flat[1].imshow(MD[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=2.0e-3,
-                  origin='lower')
+ax.flat[1].imshow(MD[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=2.0e-3, origin='lower')
 ax.flat[1].set_title('MD (DKI)')
-ax.flat[2].imshow(AD[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=2.0e-3,
-                  origin='lower')
+ax.flat[2].imshow(AD[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=2.0e-3, origin='lower')
 ax.flat[2].set_title('AD (DKI)')
-ax.flat[3].imshow(RD[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=2.0e-3,
-                  origin='lower')
+ax.flat[3].imshow(RD[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=2.0e-3, origin='lower')
 ax.flat[3].set_title('RD (DKI)')
 
-ax.flat[4].imshow(dti_FA[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=0.7,
-                  origin='lower')
+ax.flat[4].imshow(dti_FA[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=0.7, origin='lower')
 ax.flat[4].set_title('FA (DTI)')
-ax.flat[5].imshow(dti_MD[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=2.0e-3,
-                  origin='lower')
+ax.flat[5].imshow(dti_MD[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=2.0e-3, origin='lower')
 ax.flat[5].set_title('MD (DTI)')
-ax.flat[6].imshow(dti_AD[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=2.0e-3,
-                  origin='lower')
+ax.flat[6].imshow(dti_AD[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=2.0e-3, origin='lower')
 ax.flat[6].set_title('AD (DTI)')
-ax.flat[7].imshow(dti_RD[:, :, axial_slice].T, cmap='gray', vmin=0, vmax=2.0e-3,
-                  origin='lower')
+ax.flat[7].imshow(dti_RD[:, :, axial_slice].T, cmap='gray',
+                  vmin=0, vmax=2.0e-3, origin='lower')
 ax.flat[7].set_title('RD (DTI)')
 
 plt.show()
@@ -264,105 +263,6 @@ Therefore, as the figure above shows, white matter kurtosis values are smaller
 along the axial direction of fibers (smaller amplitudes shown in the AK map)
 than for the radial directions (larger amplitudes shown in the RK map).
 
-As mentioned above, DKI can also be used to derive concrete biophysical
-parameters by applying microstructural models to DT and KT estimated from DKI.
-For instance,  Fieremans et al. [Fieremans2011]_ showed that DKI can be used to
-estimate the contribution of hindered and restricted diffusion for well-aligned
-fibers. These tensors can be also interpreted as the influences of intra- and
-extra-cellular compartments and can be used to estimate the axonal volume
-fraction and diffusion extra-cellular tortuosity. According to recent studies,
-these latter measures can be used to distinguish processes of axonal loss from
-processes of myelin degeneration [Fieremans2012]_.
-
-The model proposed by Fieremans and colleagues can be defined in DIPY by
-instantiating the 'KurtosisMicrostructureModel' object in the following way:
-"""
-
-dki_micro_model = dki_micro.KurtosisMicrostructureModel(gtab)
-
-"""
-Before fitting this microstructural model, it is useful to indicate the
-regions in which this model provides meaningful information (i.e. voxels of
-well-aligned fibers). Following Fieremans et al. [Fieremans2011]_, a simple way
-to select this region is to generate a well-aligned fiber mask based on the
-values of diffusion sphericity, planarity and linearity. Here we will follow
-these selection criteria for a better comparision of our figures with the
-original article published by Fieremans et al. [Fieremans2011]_. Nevertheless,
-it is important to note that voxels with well-aligned fibers can be selected
-based on other approaches such as using predefined regions of interest.
-"""
-
-well_aligned_mask = np.ones(data.shape[:-1], dtype='bool')
-
-# Diffusion coefficient of linearity (cl) has to be larger than 0.4, thus
-# we exclude voxels with cl < 0.4.
-cl = dkifit.linearity.copy()
-well_aligned_mask[cl < 0.4] = False
-
-# Diffusion coefficient of planarity (cp) has to be lower than 0.2, thus
-# we exclude voxels with cp > 0.2.
-cp = dkifit.planarity.copy()
-well_aligned_mask[cp > 0.2] = False
-
-# Diffusion coefficient of sphericity (cs) has to be lower than 0.35, thus
-# we exclude voxels with cs > 0.35.
-cs = dkifit.sphericity.copy()
-well_aligned_mask[cs > 0.35] = False
-
-# Removing nan associated with background voxels
-well_aligned_mask[np.isnan(cl)] = False
-well_aligned_mask[np.isnan(cp)] = False
-well_aligned_mask[np.isnan(cs)] = False
-
-"""
-Analogous to DKI, the data fit can be done by calling the ``fit`` function of
-the model's object as follows:
-"""
-
-dki_micro_fit = dki_micro_model.fit(data_smooth, mask=well_aligned_mask)
-
-"""
-The KurtosisMicrostructureFit object created by this ``fit`` function can then
-be used to extract model parameters such as the axonal water fraction and
-diffusion hindered tortuosity:
-"""
-
-AWF = dki_micro_fit.awf
-TORT = dki_micro_fit.tortuosity
-
-"""
-These parameters are plotted below on top of the mean kurtosis maps:
-"""
-
-fig3, ax = plt.subplots(1, 2, figsize=(9, 4),
-                        subplot_kw={'xticks': [], 'yticks': []})
-
-AWF[AWF == 0] = np.nan
-TORT[TORT == 0] = np.nan
-
-ax[0].imshow(MK[:, :, axial_slice].T, cmap=plt.cm.gray, interpolation='nearest',
-             origin='lower')
-im0 = ax[0].imshow(AWF[:, :, axial_slice].T, cmap=plt.cm.Reds, alpha=0.9,
-                   vmin=0.3, vmax=0.7, interpolation='nearest', origin='lower')
-fig3.colorbar(im0, ax=ax.flat[0])
-
-ax[1].imshow(MK[:, :, axial_slice].T, cmap=plt.cm.gray, interpolation='nearest',
-             origin='lower')
-im1 = ax[1].imshow(TORT[:, :, axial_slice].T, cmap=plt.cm.Blues, alpha=0.9,
-                   vmin=2, vmax=6, interpolation='nearest', origin='lower')
-fig3.colorbar(im1, ax=ax.flat[1])
-
-fig3.savefig('Kurtosis_Microstructural_measures.png')
-
-"""
-.. figure:: Kurtosis_Microstructural_measures.png
-   :align: center
-
-   Axonal water fraction (left panel) and tortuosity (right panel) values
-   of well-aligned fiber regions overlaid on a top of a mean kurtosis all-brain
-   image.
-
-
 References
 ----------
 
@@ -377,15 +277,9 @@ References
 .. [Jensen2010] Jensen JH, Helpern JA (2010). MRI quantification of
                 non-Gaussian water diffusion by kurtosis analysis. NMR in
                 Biomedicine 23(7): 698-710
-.. [Fieremans2011] Fieremans E, Jensen JH, Helpern JA (2011). White matter
+.. [Fierem2011] Fieremans E, Jensen JH, Helpern JA (2011). White matter
                 characterization with diffusion kurtosis imaging. NeuroImage
                 58: 177-188
-.. [Fieremans2012] Fieremans E, Jensen JH, Helpern JA, Kim S, Grossman RI,
-                Inglese M, Novikov DS. (2012). Diffusion distinguishes between
-                axonal loss and demyelination in brain white matter.
-                Proceedings of the 20th Annual Meeting of the International
-                Society for Magnetic Resonance Medicine; Melbourne, Australia.
-                May 5-11.
 .. [Hansen2016] Hansen, B, Jespersen, SN (2016). Data for evaluation of fast
                 kurtosis strategies, b-value optimization and exploration of
                 diffusion MRI contrast. Scientific Data 3: 160072

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -1,0 +1,188 @@
+"""
+=====================================================================
+Reconstruction of the diffusion signal with the WMTI model
+=====================================================================
+
+DKI can also be used to derive concrete biophysical parameters by applying
+microstructural models to DT and KT estimated from DKI. For instance,
+Fieremans et al. [Fierem2011]_ showed that DKI can be used to
+estimate the contribution of hindered and restricted diffusion for well-aligned
+fibers  - model that was later referred to as the white matter tract integrity
+WMTI technique [Fierem2013]_. The two tensors of WMTI can be also
+interpreted as the influences of intra- and extra-cellular compartments and can
+be used to estimate the axonal volume fraction and diffusion extra-cellular
+tortuosity. According to previous studies [Fierem2012]_ [Fierem2013]_,
+these latter measures can be used to distinguish processes of axonal loss from
+processes of myelin degeneration.
+
+In this example, we show how to process a diffusion weighting dataset using
+the WMTI model.
+
+First, we import all relevant modules:
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import dipy.reconst.dki as dki
+import dipy.reconst.dki_micro as dki_micro
+from dipy.data import fetch_cfin_multib
+from dipy.data import read_cfin_dwi
+from dipy.segment.mask import median_otsu
+from scipy.ndimage.filters import gaussian_filter
+
+"""
+As the standard DKI, WMTI requires multi-shell data, i.e. data acquired from
+more than one non-zero b-value. Here, we use fetch to download a multi-shell
+dataset which was kindly provided by Hansen and Jespersen (more details about
+the data are provided in their paper [Hansen2016]_).
+"""
+
+fetch_cfin_multib()
+
+img, gtab = read_cfin_dwi()
+
+data = img.get_data()
+
+affine = img.affine
+
+"""
+For comparison, this dataset is pre-processing using the same steps used in the
+example for reconstructing DKI (see :ref:`example_reconst_dki`).
+"""
+
+# data masking
+maskdata, mask = median_otsu(data, vol_idx=[0, 1], median_radius=4, numpass=2,
+                             autocrop=False, dilate=1)
+
+# Smoothing
+fwhm = 1.25
+gauss_std = fwhm / np.sqrt(8 * np.log(2))
+data_smooth = np.zeros(data.shape)
+for v in range(data.shape[-1]):
+    data_smooth[..., v] = gaussian_filter(data[..., v], sigma=gauss_std)
+
+
+"""
+The WMTI model can be defined in DIPY by instantiating the
+'KurtosisMicrostructureModel' object in the following way:
+"""
+
+dki_micro_model = dki_micro.KurtosisMicrostructureModel(gtab)
+
+"""
+Before fitting this microstructural model, it is useful to indicate the
+regions in which this model provides meaningful information (i.e. voxels of
+well-aligned fibers). Following Fieremans et al. [Fieremans2011]_, a simple way
+to select this region is to generate a well-aligned fiber mask based on the
+values of diffusion sphericity, planarity and linearity. Here we will follow
+these selection criteria for a better comparision of our figures with the
+original article published by Fieremans et al. [Fieremans2011]_. Nevertheless,
+it is important to note that voxels with well-aligned fibers can be selected
+based on other approaches such as using predefined regions of interest.
+"""
+
+# Diffusion Tensor is computed based on the standard DKI model
+dkimodel = dki.DiffusionKurtosisModel(gtab)
+dkifit = dkimodel.fit(data_smooth, mask=mask)
+
+# Initialize well aligned mask with ones
+well_aligned_mask = np.ones(data.shape[:-1], dtype='bool')
+
+# Diffusion coefficient of linearity (cl) has to be larger than 0.4, thus
+# we exclude voxels with cl < 0.4.
+cl = dkifit.linearity.copy()
+well_aligned_mask[cl < 0.4] = False
+
+# Diffusion coefficient of planarity (cp) has to be lower than 0.2, thus
+# we exclude voxels with cp > 0.2.
+cp = dkifit.planarity.copy()
+well_aligned_mask[cp > 0.2] = False
+
+# Diffusion coefficient of sphericity (cs) has to be lower than 0.35, thus
+# we exclude voxels with cs > 0.35.
+cs = dkifit.sphericity.copy()
+well_aligned_mask[cs > 0.35] = False
+
+# Removing nan associated with background voxels
+well_aligned_mask[np.isnan(cl)] = False
+well_aligned_mask[np.isnan(cp)] = False
+well_aligned_mask[np.isnan(cs)] = False
+
+"""
+Analogous to DKI, the data fit can be done by calling the ``fit`` function of
+the model's object as follows:
+"""
+
+dki_micro_fit = dki_micro_model.fit(data_smooth, mask=well_aligned_mask)
+
+"""
+The KurtosisMicrostructureFit object created by this ``fit`` function can then
+be used to extract model parameters such as the axonal water fraction and
+diffusion hindered tortuosity:
+"""
+
+AWF = dki_micro_fit.awf
+TORT = dki_micro_fit.tortuosity
+
+"""
+These parameters are plotted below on top of the mean kurtosis maps:
+"""
+
+MK = dkifit.mk(0, 3)
+
+axial_slice = 9
+
+fig1, ax = plt.subplots(1, 2, figsize=(9, 4),
+                        subplot_kw={'xticks': [], 'yticks': []})
+
+AWF[AWF == 0] = np.nan
+TORT[TORT == 0] = np.nan
+
+ax[0].imshow(MK[:, :, axial_slice].T, cmap=plt.cm.gray,
+             interpolation='nearest', origin='lower')
+im0 = ax[0].imshow(AWF[:, :, axial_slice].T, cmap=plt.cm.Reds, alpha=0.9,
+                   vmin=0.3, vmax=0.7, interpolation='nearest', origin='lower')
+fig1.colorbar(im0, ax=ax.flat[0])
+
+ax[1].imshow(MK[:, :, axial_slice].T, cmap=plt.cm.gray,
+             interpolation='nearest', origin='lower')
+im1 = ax[1].imshow(TORT[:, :, axial_slice].T, cmap=plt.cm.Blues, alpha=0.9,
+                   vmin=2, vmax=6, interpolation='nearest', origin='lower')
+fig1.colorbar(im1, ax=ax.flat[1])
+
+fig1.savefig('Kurtosis_Microstructural_measures.png')
+
+"""
+.. figure:: Kurtosis_Microstructural_measures.png
+   :align: center
+
+   Axonal water fraction (left panel) and tortuosity (right panel) values
+   of well-aligned fiber regions overlaid on a top of a mean kurtosis all-brain
+   image.
+
+
+References
+----------
+
+.. [Fierem2011] Fieremans E, Jensen JH, Helpern JA (2011). White matter
+                characterization with diffusion kurtosis imaging. NeuroImage
+                58: 177-188
+.. [Fierem2012] Fieremans E, Jensen JH, Helpern JA, Kim S, Grossman RI,
+                Inglese M, Novikov DS. (2012). Diffusion distinguishes between
+                axonal loss and demyelination in brain white matter.
+                Proceedings of the 20th Annual Meeting of the International
+                Society for Magnetic Resonance Medicine; Melbourne, Australia.
+                May 5-11.
+.. [Fierem2013] Fieremans, E., Benitez, A., Jensen, J.H., Falangola, M.F.,
+                Tabesh, A., Deardorff, R.L., Spampinato, M.V., Babb, J.S.,
+                Novikov, D.S., Ferris, S.H., Helpern, J.A., 2013. Novel
+                white matter tract integrity metrics sensitive to Alzheimer
+                disease progression. AJNR Am. J. Neuroradiol. 34(11),
+                2105-2112. doi: 10.3174/ajnr.A3553
+.. [Hansen2016] Hansen, B, Jespersen, SN (2016). Data for evaluation of fast
+                kurtosis strategies, b-value optimization and exploration of
+                diffusion MRI contrast. Scientific Data 3: 160072
+                doi:10.1038/sdata.2016.72
+
+.. include:: ../links_names.inc
+"""

--- a/doc/examples/reconst_dki_micro.py
+++ b/doc/examples/reconst_dki_micro.py
@@ -75,7 +75,7 @@ regions in which this model provides meaningful information (i.e. voxels of
 well-aligned fibers). Following Fieremans et al. [Fieremans2011]_, a simple way
 to select this region is to generate a well-aligned fiber mask based on the
 values of diffusion sphericity, planarity and linearity. Here we will follow
-these selection criteria for a better comparision of our figures with the
+these selection criteria for a better comparison of our figures with the
 original article published by Fieremans et al. [Fieremans2011]_. Nevertheless,
 it is important to note that voxels with well-aligned fibers can be selected
 based on other approaches such as using predefined regions of interest.

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -1,7 +1,7 @@
 """
-=========================================================================
-Using the free water elimination model to remove free water contamination
-=========================================================================
+=============================================================================
+Using the free water elimination model to remove DTI free water contamination
+=============================================================================
 
 As shown previously (see :ref:`example_reconst_dti`), the diffusion tensor
 model is a simple way to characterize diffusion anisotropy. However, in regions
@@ -14,7 +14,8 @@ atrophy that occurs in several brain pathologies and ageing).
 
 A way to remove this free water influences is to expand the DTI model to take
 into account an extra compartment representing the contributions of free water
-diffusion. The expression of the expanded DTI model is shown below:
+diffusion [Pasternak2009]_. The expression of the expanded DTI model is shown
+below:
 
 .. math::
 
@@ -28,8 +29,12 @@ no diffusion weighting, $\mathbf{D}$ is the diffusion tensor, $f$ the volume
 fraction of the free water component, and $D_{iso}$ is the isotropic value of
 the free water diffusion (normally set to $3.0 \times 10^{-3} mm^{2}s^{-1}$).
 
-In this example, we show how to process a diffusion weighting dataset using the
-free water elimination.
+In this example, we show how to process a diffusion weighting dataset using
+an adapted version of the free water elimination proposed by [Hoy2014]_.
+
+The full details of Dipy's free water DTI implementation was published on
+the ReScience C initiative [Henriques2017]_. Please cite this work if you use
+this algorithm.
 
 Let's start by importing the relevant modules:
 """
@@ -226,10 +231,16 @@ fig1.savefig('In_vivo_free_water_DTI_and_standard_DTI_corrected.png')
 
 References
 ----------
-
+.. [Pasternak2009] Pasternak, O., Sochen, N., Gur, Y., Intrator, N., Assaf, Y.,
+   2009. Free water elimination and mapping from diffusion MRI. Magn. Reson.
+   Med. 62(3): 717-30. doi: 10.1002/mrm.22055.
 .. [Hoy2014] Hoy, A.R., Koay, C.G., Kecskemeti, S.R., Alexander, A.L., 2014.
    Optimization of a free water elimination two-compartmental model for
    diffusion tensor imaging. NeuroImage 103, 323-333. doi:
    10.1016/j.neuroimage.2014.09.053
+.. [Henriques2017] Henriques, R.N., Rokem, A., Garyfallidis, E., St-Jean, S.,
+   Peterson E.T., Correia, M.M., 2017. [Re] Optimization of a free water
+   elimination two-compartment model for diffusion tensor imaging.
+   ReScience volume 3, issue 1, article number 2
 
 """

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -6,6 +6,7 @@
  reconst_csd.py
  reconst_forecast.py
  reconst_dki.py
+ reconst_dki_micro.py
  reconst_msdki.py
  reconst_dsi_metrics.py
  reconst_dsi.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -86,8 +86,11 @@ Diffusion Tensor Imaging
 
 - :ref:`example_reconst_dti`
 - :ref:`example_restore_dti`
-- :ref:`example_reconst_fwdti`
 
+Free-water Diffusion Tensor Imaging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :ref:`example_reconst_fwdti`
 
 Diffusion Kurtosis Imaging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,6 +98,9 @@ Diffusion Kurtosis Imaging
 - :ref:`example_reconst_dki`
 - :ref:`example_reconst_msdki`
 
+White Matter Tract Integrity Model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- :ref:`example_reconst_dki_micro`
 
 Q-Ball Constant Solid Angle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi! In this PR, I am submitting a documentation update of the following models fwDTI, DKI, and WMTI. 

Basically I've improved the following aspects.
- Add the Rescience paper that reports all the code adaptions done for fwDTI implementation in Dipy (we were still citing the previous implementation proposed by Hoy et al.)
- Splitting the DKI example - this to address issue #1774.
- Give more highlight to WMTI and fwDTI models in Dipy's gallery. Previously, these models were added as a subsection of DTI and DKI models, which might be decreasing WMTI and fwDTI visibility.

PS: This is my last PR for Dipy's release 1.0 