### PR TITLE
Fix empty tractogram loading saving

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -302,6 +302,9 @@ class StatefulTractogram(object):
         output : tuple
             Tuple of two list, indices_to_remove, indices_to_keep
         """
+        if not self.streamlines:
+            return
+
         old_space = deepcopy(self.space)
         old_shift = deepcopy(self.shifted_origin)
 
@@ -435,6 +438,9 @@ class StatefulTractogram(object):
     def _shift_voxel_origin(self):
         """ Unsafe function to switch the origin from center to corner
         and vice versa """
+        if not self.streamlines:
+            return
+
         shift = np.asarray([0.5, 0.5, 0.5])
         if self._space == Space.VOXMM:
             shift = shift * self._voxel_sizes
@@ -455,8 +461,8 @@ class StatefulTractogram(object):
 
 
 def _is_data_per_point_valid(streamlines, data):
-    """ Verify that the number of item in data is X and that each of these items
-        has Y_i items.
+    """ Verify that the number of item in data is X and that each of these
+        items has Y_i items.
 
         X being the number of streamlines
         Y_i being the number of points on streamlines #i

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -258,6 +258,9 @@ class StatefulTractogram(object):
         output : bool
             Are the streamlines within the volume of the associated reference
         """
+        if not self.streamlines:
+            return True
+
         old_space = deepcopy(self.space)
         old_shift = deepcopy(self.shifted_origin)
 

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -256,7 +256,6 @@ def empty_space_change():
     assert_array_equal([], sft.streamlines.data)
 
 
-
 def empty_shift_change():
     sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
     sft.to_corner()

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -248,6 +248,39 @@ def iterative_to_voxmm_transformation():
                         sft.streamlines.data, atol=1e-3, rtol=1e-6)
 
 
+def empty_space_change():
+    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+
+    try:
+        sft.to_vox()
+        sft.to_voxmm()
+        sft.to_rasmm()
+        return False
+    except:
+        return True
+
+
+def empty_shift_change():
+    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+
+    try:
+        sft.to_corner()
+        sft.to_center()
+        return False
+    except:
+        return True
+
+
+def empty_remove_invalid():
+    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+
+    try:
+        sft.remove_invalid_streamlines()
+        return False
+    except:
+        return True
+
+
 def shift_corner_from_rasmm():
     sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
                             to_space=Space.VOX)
@@ -470,6 +503,16 @@ def test_equal_in_voxmm_space():
 def test_switch_reference():
     switch_voxel_sizes_from_rasmm()
     switch_voxel_sizes_from_voxmm()
+
+
+def test_empty_sft():
+    # First two is expected to fail
+    if empty_space_change():
+        raise AssertionError()
+    if empty_shift_change():
+        raise AssertionError()
+    if empty_remove_invalid():
+        raise AssertionError()
 
 
 def test_shifting_corner():

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -249,9 +249,8 @@ def iterative_to_voxmm_transformation():
 
 
 def empty_space_change():
-    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
-
     try:
+        sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
         sft.to_vox()
         sft.to_voxmm()
         sft.to_rasmm()
@@ -261,9 +260,8 @@ def empty_space_change():
 
 
 def empty_shift_change():
-    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
-
     try:
+        sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
         sft.to_corner()
         sft.to_center()
         return False
@@ -272,9 +270,8 @@ def empty_shift_change():
 
 
 def empty_remove_invalid():
-    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
-
     try:
+        sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
         sft.remove_invalid_streamlines()
         return False
     except:

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -4,7 +4,7 @@ import os
 from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from dipy.data import fetch_gold_standard_io
 from dipy.io.stateful_tractogram import Space, StatefulTractogram
@@ -249,33 +249,25 @@ def iterative_to_voxmm_transformation():
 
 
 def empty_space_change():
-    try:
-        sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
-        sft.to_vox()
-        sft.to_voxmm()
-        sft.to_rasmm()
-        return False
-    except:
-        return True
+    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+    sft.to_vox()
+    sft.to_voxmm()
+    sft.to_rasmm()
+    assert_array_equal([], sft.streamlines.data)
+
 
 
 def empty_shift_change():
-    try:
-        sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
-        sft.to_corner()
-        sft.to_center()
-        return False
-    except:
-        return True
+    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+    sft.to_corner()
+    sft.to_center()
+    assert_array_equal([], sft.streamlines.data)
 
 
 def empty_remove_invalid():
-    try:
-        sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
-        sft.remove_invalid_streamlines()
-        return False
-    except:
-        return True
+    sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
+    sft.remove_invalid_streamlines()
+    assert_array_equal([], sft.streamlines.data)
 
 
 def shift_corner_from_rasmm():
@@ -503,13 +495,9 @@ def test_switch_reference():
 
 
 def test_empty_sft():
-    # First two is expected to fail
-    if empty_space_change():
-        raise AssertionError()
-    if empty_shift_change():
-        raise AssertionError()
-    if empty_remove_invalid():
-        raise AssertionError()
+    empty_space_change()
+    empty_shift_change()
+    empty_remove_invalid()
 
 
 def test_shifting_corner():


### PR DESCRIPTION
As of right now loading and saving empty tractogram is crashing because of the bbox in voxel space being checked.

Addition of a simple condition in the verification.