### PR TITLE
Deprecate Reconst*Flow

### DIFF
--- a/bin/dipy_fit_csa
+++ b/bin/dipy_fit_csa
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.reconst import ReconstCSAFlow
+from dipy.workflows.reconst import FitCSAFlow
 
 if __name__ == "__main__":
-    run_flow(ReconstCSAFlow())
+    run_flow(FitCSAFlow())

--- a/bin/dipy_fit_csd
+++ b/bin/dipy_fit_csd
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.reconst import ReconstCSDFlow
+from dipy.workflows.reconst import FitCSDFlow
 
 if __name__ == "__main__":
-    run_flow(ReconstCSDFlow())
+    run_flow(FitCSDFlow())

--- a/bin/dipy_fit_dki
+++ b/bin/dipy_fit_dki
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.reconst import ReconstDkiFlow
+from dipy.workflows.reconst import FitDkiFlow
 
 if __name__ == "__main__":
-    run_flow(ReconstDkiFlow())
+    run_flow(FitDkiFlow())

--- a/bin/dipy_fit_dti
+++ b/bin/dipy_fit_dti
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.reconst import ReconstDtiFlow
+from dipy.workflows.reconst import FitDtiFlow
 
 if __name__ == "__main__":
-    run_flow(ReconstDtiFlow())
+    run_flow(FitDtiFlow())

--- a/bin/dipy_fit_ivim
+++ b/bin/dipy_fit_ivim
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.reconst import ReconstIvimFlow
+from dipy.workflows.reconst import FitIvimFlow
 
 if __name__ == "__main__":
-    run_flow(ReconstIvimFlow())
+    run_flow(FitIvimFlow())

--- a/bin/dipy_fit_mapmri
+++ b/bin/dipy_fit_mapmri
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from dipy.workflows.flow_runner import run_flow
-from dipy.workflows.reconst import ReconstMAPMRIFlow
+from dipy.workflows.reconst import FitMAPMRIFlow
 
 if __name__ == "__main__":
-    run_flow(ReconstMAPMRIFlow())
+    run_flow(FitMAPMRIFlow())

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import logging
 import numpy as np
 import os.path
@@ -44,8 +42,9 @@ class FitMAPMRIFlow(Workflow):
             out_rtpp='rtpp.nii.gz', out_ng='ng.nii.gz',
             out_perng='perng.nii.gz',
             out_parng='parng.nii.gz'):
-        """ Workflow for fitting the MAPMRI model (with optional Laplacian
-        regularization). Generates rtop, lapnorm, msd, qiv, rtap, rtpp,
+        """Workflow for fitting the MAPMRI model.
+
+        Generates rtop, lapnorm, msd, qiv, rtap, rtpp,
         non-gaussian (ng), parallel ng, perpendicular ng saved in a nifti
         format in input files provided by `data_files` and saves the nifti
         files to an output directory specified by `out_dir`.
@@ -112,6 +111,7 @@ class FitMAPMRIFlow(Workflow):
             Name of the Non-Gaussianity perpendicular to be saved
         out_parng : string, optional
             Name of the Non-Gaussianity parallel to be saved
+
         """
         io_it = self.get_io_iterator()
         for (dwi, bval, bvec, out_rtop, out_lapnorm, out_msd, out_qiv,
@@ -223,8 +223,10 @@ class FitDtiFlow(Workflow):
             out_dir='', out_tensor='tensors.nii.gz', out_fa='fa.nii.gz',
             out_ga='ga.nii.gz', out_rgb='rgb.nii.gz', out_md='md.nii.gz',
             out_ad='ad.nii.gz', out_rd='rd.nii.gz', out_mode='mode.nii.gz',
-            out_evec='evecs.nii.gz', out_eval='evals.nii.gz', nifti_tensor=True):
-        """ Workflow for tensor reconstruction and for computing DTI metrics.
+            out_evec='evecs.nii.gz', out_eval='evals.nii.gz',
+            nifti_tensor=True):
+        """Workflow for tensor reconstruction and for computing DTI metrics.
+
         using Weighted Least-Squares.
         Performs a tensor reconstruction on the files by 'globing'
         ``input_files`` and saves the DTI metrics in a directory specified by
@@ -419,7 +421,7 @@ class FitCSDFlow(Workflow):
             out_peaks_dir='peaks_dirs.nii.gz',
             out_peaks_values='peaks_values.nii.gz',
             out_peaks_indices='peaks_indices.nii.gz', out_gfa='gfa.nii.gz'):
-        """ Constrained spherical deconvolution
+        """Constrained spherical deconvolution.
 
         Parameters
         ----------
@@ -490,6 +492,7 @@ class FitCSDFlow(Workflow):
         .. [1] Tournier, J.D., et al. NeuroImage 2007. Robust determination of
            the fibre orientation distribution in diffusion MRI: Non-negativity
            constrained super-resolved spherical deconvolution.
+
         """
         io_it = self.get_io_iterator()
 
@@ -599,7 +602,7 @@ class FitCSAFlow(Workflow):
             out_peaks_values='peaks_values.nii.gz',
             out_peaks_indices='peaks_indices.nii.gz',
             out_gfa='gfa.nii.gz'):
-        """ Constant Solid Angle.
+        """Constant Solid Angle.
 
         Parameters
         ----------
@@ -655,6 +658,7 @@ class FitCSAFlow(Workflow):
         ----------
         .. [1] Aganj, I., et al. 2009. ODF Reconstruction in Q-Ball Imaging
            with Solid Angle Consideration.
+
         """
         io_it = self.get_io_iterator()
 
@@ -724,8 +728,9 @@ class FitDkiFlow(Workflow):
             out_evec='evecs.nii.gz', out_eval='evals.nii.gz',
             out_dk_tensor="dki_tensors.nii.gz",
             out_mk="mk.nii.gz", out_ak="ak.nii.gz", out_rk="rk.nii.gz"):
-        """ Workflow for Diffusion Kurtosis reconstruction and for computing
-        DKI metrics. Performs a DKI reconstruction on the files by 'globing'
+        """Workflow for Diffusion Kurtosis reconstruction.
+
+        Performs a DKI reconstruction on the files by 'globing'
         ``input_files`` and saves the DKI metrics in a directory specified by
         ``out_dir``.
 
@@ -799,6 +804,7 @@ class FitDkiFlow(Workflow):
            and Kyle Kaczynski. 2005. Diffusional Kurtosis Imaging: The
            Quantification of Non-Gaussian Water Diffusion by Means of Magnetic
            Resonance Imaging. MRM 53 (6):1432-40.
+
         """
         io_it = self.get_io_iterator()
 
@@ -907,8 +913,9 @@ class FitIvimFlow(Workflow):
             out_dir='', out_S0_predicted='S0_predicted.nii.gz',
             out_perfusion_fraction='perfusion_fraction.nii.gz',
             out_D_star='D_star.nii.gz', out_D='D.nii.gz'):
-        """ Workflow for Intra-voxel Incoherent Motion reconstruction and for
-        computing IVIM metrics. Performs a IVIM reconstruction on the files
+        """Workflow for Intra-voxel Incoherent Motion reconstruction.
+
+        Performs a IVIM reconstruction on the files
         by 'globing' ``input_files`` and saves the IVIM metrics in a directory
         specified by ``out_dir``.
 
@@ -968,6 +975,7 @@ class FitIvimFlow(Workflow):
         .. [LeBihan84] Le Bihan, Denis, et al. "Separation of diffusion
                        and perfusion in intravoxel incoherent motion MR
                        imaging." Radiology 168.2 (1988): 497-505.
+
         """
 
         io_it = self.get_io_iterator()

--- a/dipy/workflows/reconst.py
+++ b/dipy/workflows/reconst.py
@@ -29,7 +29,7 @@ from dipy.reconst.ivim import IvimModel
 from dipy.reconst import mapmri
 
 
-class ReconstMAPMRIFlow(Workflow):
+class FitMAPMRIFlow(Workflow):
     @classmethod
     def get_short_name(cls):
         return 'mapmri'
@@ -213,7 +213,7 @@ class ReconstMAPMRIFlow(Workflow):
                          format(os.path.dirname(out_dir)))
 
 
-class ReconstDtiFlow(Workflow):
+class FitDtiFlow(Workflow):
     @classmethod
     def get_short_name(cls):
         return 'dti'
@@ -405,7 +405,7 @@ class ReconstDtiFlow(Workflow):
         return tenfit, gtab
 
 
-class ReconstCSDFlow(Workflow):
+class FitCSDFlow(Workflow):
     @classmethod
     def get_short_name(cls):
         return 'csd'
@@ -585,7 +585,7 @@ class ReconstCSDFlow(Workflow):
             return io_it
 
 
-class ReconstCSAFlow(Workflow):
+class FitCSAFlow(Workflow):
     @classmethod
     def get_short_name(cls):
         return 'csa'
@@ -711,7 +711,7 @@ class ReconstCSAFlow(Workflow):
             return io_it
 
 
-class ReconstDkiFlow(Workflow):
+class FitDkiFlow(Workflow):
     @classmethod
     def get_short_name(cls):
         return 'dki'
@@ -897,7 +897,7 @@ class ReconstDkiFlow(Workflow):
         return dkfit, gtab
 
 
-class ReconstIvimFlow(Workflow):
+class FitIvimFlow(Workflow):
     @classmethod
     def get_short_name(cls):
         return 'ivim'
@@ -1019,3 +1019,49 @@ class ReconstIvimFlow(Workflow):
         ivimfit = ivimmodel.fit(data, mask)
 
         return ivimfit, gtab
+
+
+# Deprecated Workflow
+# Should be deleted on DIPY 1.3.x
+
+def print_deprecated_message(old_name, new_name):
+    msg = "'{0}' class name is deprecated.".format(old_name)
+    msg += " It will be removed on DIPY 1.3.x."
+    msg += " Please, use '{0}' instead".format(new_name)
+    warn(msg, category=PendingDeprecationWarning)
+
+
+class ReconstMAPMRIFlow(FitMAPMRIFlow):
+    def __init__(self, *args, **kwargs):
+        print_deprecated_message("ReconstMAPMRIFlow", "FitMAPMRIFlow")
+        super().__init__(*args, **kwargs)
+
+
+class ReconstDtiFlow(FitDtiFlow):
+    def __init__(self, *args, **kwargs):
+        print_deprecated_message("ReconstDtiFlow", "FitDtiFlow")
+        super().__init__(*args, **kwargs)
+
+
+class ReconstCSDFlow(FitCSDFlow):
+    def __init__(self, *args, **kwargs):
+        print_deprecated_message("ReconstCSDFlow", "FitCSDFlow")
+        super().__init__(*args, **kwargs)
+
+
+class ReconstCSAFlow(FitCSAFlow):
+    def __init__(self, *args, **kwargs):
+        print_deprecated_message("ReconstCSAFlow", "FitCSAFlow")
+        super().__init__(*args, **kwargs)
+
+
+class ReconstDkiFlow(FitDkiFlow):
+    def __init__(self, *args, **kwargs):
+        print_deprecated_message("ReconstDkiFlow", "FitDkiFlow")
+        super().__init__(*args, **kwargs)
+
+
+class ReconstIvimFlow(FitIvimFlow):
+    def __init__(self, *args, **kwargs):
+        print_deprecated_message("ReconstIvimFlow", "FitIvimFlow")
+        super().__init__(*args, **kwargs)

--- a/dipy/workflows/tests/test_reconst_csa_csd.py
+++ b/dipy/workflows/tests/test_reconst_csa_csd.py
@@ -11,17 +11,17 @@ from dipy.core.gradients import generate_bvecs
 from nibabel.tmpdirs import TemporaryDirectory
 
 from dipy.data import get_fnames
-from dipy.workflows.reconst import ReconstCSDFlow, ReconstCSAFlow
+from dipy.workflows.reconst import FitCSDFlow, FitCSAFlow
 from dipy.reconst.shm import sph_harm_ind_list
 logging.getLogger().setLevel(logging.INFO)
 
 
 def test_reconst_csa():
-    reconst_flow_core(ReconstCSAFlow)
+    reconst_flow_core(FitCSAFlow)
 
 
 def test_reconst_csd():
-    reconst_flow_core(ReconstCSDFlow)
+    reconst_flow_core(FitCSDFlow)
 
 
 def reconst_flow_core(flow):

--- a/dipy/workflows/tests/test_reconst_dki.py
+++ b/dipy/workflows/tests/test_reconst_dki.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_equal
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import generate_bvecs
-from dipy.workflows.reconst import ReconstDkiFlow
+from dipy.workflows.reconst import FitDkiFlow
 
 
 def test_reconst_dki():
@@ -24,7 +24,7 @@ def test_reconst_dki():
         mask_path = pjoin(out_dir, 'tmp_mask.nii.gz')
         nib.save(mask_img, mask_path)
 
-        dki_flow = ReconstDkiFlow()
+        dki_flow = FitDkiFlow()
 
         args = [data_path, bval_path, bvec_path, mask_path]
 

--- a/dipy/workflows/tests/test_reconst_dti.py
+++ b/dipy/workflows/tests/test_reconst_dti.py
@@ -7,19 +7,19 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from dipy.data import get_fnames
-from dipy.workflows.reconst import ReconstDtiFlow
+from dipy.workflows.reconst import FitDtiFlow
 
 
 def test_reconst_dti_wls():
-    reconst_flow_core(ReconstDtiFlow)
+    reconst_flow_core(FitDtiFlow)
 
 
 def test_reconst_dti_nlls():
-    reconst_flow_core(ReconstDtiFlow, extra_args=[], extra_kwargs={})
+    reconst_flow_core(FitDtiFlow, extra_args=[], extra_kwargs={})
 
 
 def test_reconst_dti_alt_tensor():
-    reconst_flow_core(ReconstDtiFlow, extra_args=[],
+    reconst_flow_core(FitDtiFlow, extra_args=[],
                       extra_kwargs={'nifti_tensor': False})
 
 

--- a/dipy/workflows/tests/test_reconst_ivim.py
+++ b/dipy/workflows/tests/test_reconst_ivim.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_equal
 
 from dipy.sims.voxel import multi_tensor
 from dipy.core.gradients import generate_bvecs, gradient_table
-from dipy.workflows.reconst import ReconstIvimFlow
+from dipy.workflows.reconst import FitIvimFlow
 
 
 def test_reconst_ivim():
@@ -49,7 +49,7 @@ def test_reconst_ivim():
         mask_path = pjoin(out_dir, 'tmp_mask.nii.gz')
         nib.save(mask_img, mask_path)
 
-        ivim_flow = ReconstIvimFlow()
+        ivim_flow = FitIvimFlow()
 
         args = [data_path, temp_bval_path, temp_bvec_path, mask_path]
 

--- a/dipy/workflows/tests/test_reconst_mapmri.py
+++ b/dipy/workflows/tests/test_reconst_mapmri.py
@@ -10,25 +10,25 @@ from dipy.reconst import mapmri
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.core.gradients import generate_bvecs
-from dipy.workflows.reconst import ReconstMAPMRIFlow
+from dipy.workflows.reconst import FitMAPMRIFlow
 
 
 def test_reconst_mmri_laplacian():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=True, pos=False)
+    reconst_mmri_core(FitMAPMRIFlow, lap=True, pos=False)
 
 
 def test_reconst_mmri_none():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=False, pos=False)
+    reconst_mmri_core(FitMAPMRIFlow, lap=False, pos=False)
 
 
 @np.testing.dec.skipif(not mapmri.have_cvxpy)
 def test_reconst_mmri_both():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=True, pos=True)
+    reconst_mmri_core(FitMAPMRIFlow, lap=True, pos=True)
 
 
 @np.testing.dec.skipif(not mapmri.have_cvxpy)
 def test_reconst_mmri_positivity():
-    reconst_mmri_core(ReconstMAPMRIFlow, lap=True, pos=False)
+    reconst_mmri_core(FitMAPMRIFlow, lap=True, pos=False)
 
 
 def reconst_mmri_core(flow, lap, pos):

--- a/dipy/workflows/tests/test_tracking.py
+++ b/dipy/workflows/tests/test_tracking.py
@@ -10,7 +10,7 @@ from dipy.data import get_fnames
 from dipy.io.image import save_nifti
 from dipy.io.streamline import load_tractogram
 from dipy.workflows.mask import MaskFlow
-from dipy.workflows.reconst import ReconstCSDFlow
+from dipy.workflows.reconst import FitCSDFlow
 from dipy.workflows.tracking import (LocalFiberTrackingPAMFlow,
                                      PFTrackingPAMFlow)
 
@@ -73,7 +73,7 @@ def test_particle_filtering_traking_workflows():
                      path)
 
         # CSD Reconstruction
-        reconst_csd_flow = ReconstCSDFlow()
+        reconst_csd_flow = FitCSDFlow()
         reconst_csd_flow.run(dwi_path, bval_path, bvec_path, mask_path,
                              out_dir=out_dir, extract_pam_values=True)
 
@@ -118,7 +118,7 @@ def test_local_fiber_tracking_workflow():
         mask_path = join(out_dir, 'tmp_mask.nii.gz')
         nib.save(mask_img, mask_path)
 
-        reconst_csd_flow = ReconstCSDFlow()
+        reconst_csd_flow = FitCSDFlow()
         reconst_csd_flow.run(data_path, bval_path, bvec_path, mask_path,
                              out_dir=out_dir, extract_pam_values=True)
 


### PR DESCRIPTION
This PR start a new deprecation cycle for `dipy.workflows.reconst`. All class `Reconst*Flow` has been renamed `Fit*Flow`.