### PR TITLE
Adding Missing References in SHORE docs

### DIFF
--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -4,8 +4,9 @@ Continuous and analytical diffusion signal modelling with 3D-SHORE
 ==================================================================
 
 We show how to model the diffusion signal as a linear combination
-of continuous functions from the SHORE basis [Merlet2013]_.
-We also compute the analytical Orientation Distribution Function (ODF).
+of continuous functions from the SHORE basis [Merlet2013]_, [Özarslan2008]_, 
+[Özarslan2009]_. We also compute the analytical Orientation Distribution 
+Function (ODF).
 
 First import the necessary modules:
 """
@@ -102,6 +103,13 @@ if interactive:
 
 References
 ----------
+.. [Özarslan2008] Özarslan E. et al., "Simple harmonic oscillator based 
+   estimation and reconstruction for one-dimensional q-space MR,” in Proc Intl 
+   Soc Mag Reson Med, 16, Toronto, Canada, 2008
+
+.. [Özarslan2009] Özarslan E. et al., "Simple harmonic oscillator based 
+   reconstruction and estimation for three-dimensional q-space MRI," in Proc 
+   Intl Soc Mag Reson Med, 17, Honolulu, HI, 2009
 
 .. [Merlet2013] Merlet S. et al., "Continuous diffusion signal, EAP and ODF
    estimation via Compressive Sensing in diffusion MRI", Medical Image

--- a/doc/examples/reconst_shore.py
+++ b/doc/examples/reconst_shore.py
@@ -4,8 +4,8 @@ Continuous and analytical diffusion signal modelling with 3D-SHORE
 ==================================================================
 
 We show how to model the diffusion signal as a linear combination
-of continuous functions from the SHORE basis [Merlet2013]_, [Özarslan2008]_, 
-[Özarslan2009]_. We also compute the analytical Orientation Distribution 
+of continuous functions from the SHORE basis [Merlet2013]_, [Özarslan2008]_,
+[Özarslan2009]_. We also compute the analytical Orientation Distribution
 Function (ODF).
 
 First import the necessary modules:
@@ -103,12 +103,12 @@ if interactive:
 
 References
 ----------
-.. [Özarslan2008] Özarslan E. et al., "Simple harmonic oscillator based 
-   estimation and reconstruction for one-dimensional q-space MR,” in Proc Intl 
+.. [Özarslan2008] Özarslan E. et al., "Simple harmonic oscillator based
+   estimation and reconstruction for one-dimensional q-space MR,” in Proc Intl
    Soc Mag Reson Med, 16, Toronto, Canada, 2008
 
-.. [Özarslan2009] Özarslan E. et al., "Simple harmonic oscillator based 
-   reconstruction and estimation for three-dimensional q-space MRI," in Proc 
+.. [Özarslan2009] Özarslan E. et al., "Simple harmonic oscillator based
+   reconstruction and estimation for three-dimensional q-space MRI," in Proc
    Intl Soc Mag Reson Med, 17, Honolulu, HI, 2009
 
 .. [Merlet2013] Merlet S. et al., "Continuous diffusion signal, EAP and ODF


### PR DESCRIPTION
Following references were missing:

- E. Özarslan, C. G. Koay, and P. J. Basser, "Simple harmonic oscillator based estimation and reconstruction for one-dimensional q-space MR,” in Proc Intl Soc Mag Reson Med, 16, Toronto, Canada, 2008, p. 35.

- E. Özarslan, C. G. Koay, T. M. Shepherd, S. J. Blackband, and P. J. Basser, "Simple harmonic oscillator based reconstruction and estimation for three-dimensional q-space MRI," in Proc Intl Soc Mag Reson Med, 17, Honolulu, HI, 2009, p. 1396.