### PR TITLE
ENH: Speed up Cython, remove warnings

### DIFF
--- a/dipy/core/interpolation.pyx
+++ b/dipy/core/interpolation.pyx
@@ -1,3 +1,5 @@
+# cython: boundscheck=False, wraparound=False, cdivision=True
+
 cimport cython
 cimport numpy as np
 cimport numpy as cnp


### PR DESCRIPTION
Gets rid of a slew of warnings of the form:
```
    warning: dipy/core/interpolation.pyx:749:25: Use boundscheck(False) for faster access
```
when building from source. Also should make things a tiny bit faster.

Alternatively this can be enabled using more fine-grained control via individual decorators like:
```
@cython.boundscheck(False)
```
From a quick look it seems like these are reasonable options for this file, but I did not look super closely. This is thus really more of a "suggestion PR" so feel free to close if it does not make sense.