### PR TITLE
ENH: Use language level 3

### DIFF
--- a/cythexts.py
+++ b/cythexts.py
@@ -151,7 +151,7 @@ def build_stamp(pyxes, include_dirs=()):
         base, ext = splitext(source)
         pyx_hash = sha1((open(source, 'rt').read().encode())).hexdigest()
         c_filename = base + '.c'
-        options, sources = parse_command_line(includes + [source])
+        options, sources = parse_command_line(['-3'] + includes + [source])
         result = compile(sources, options)
         if result.num_errors > 0:
             raise RuntimeError('Cython failed to compile ' + source)

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -191,6 +191,9 @@ def add_flag_checking(build_ext_class, flag_defines, top_package_dir=''):
                     ext.extra_link_args += good_link_flags
                     if def_vars:
                         ext.include_dirs.append(config_dir)
+            self.cython_directives = {
+                'language_level': '3',
+            }
             build_ext_class.build_extensions(self)
 
     return Checker


### PR DESCRIPTION
Gets rid of a couple dozen warnings of the form:
```
.../Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/larsoner/python/dipy/dipy/denoise/enhancement_kernel.pyx
```
It's probably safer to use `-2` (it should be what's currently being used) but I put in `-3` to at least see if it works. And if you know you don't use `str` in your Cython code and you've been careful with `/` vs `//` then `-3` might actually be the right change.

From the source code it looked like there were probably two places this was needed, though for my particular use case (`pip install -e .`) I only needed the one in `setup_helpers.py`.

There might be a better way to do this, but it was difficult to get to any solution for this one, so this is about as much as I can look at it.