### PR TITLE
fix broken link of devel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ conversation about the issue, by typing into the text box in the issue page.
 
 ## The development process
 
-Please refer to the [development section](http://dipy.org/devel/index.html)
+Please refer to the [development section](https://dipy.org/documentation/1.0.0./devel/)
 of the documentation for the procedures we use in developing the code.
 
 ## When writing code, please pay attention to the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ conversation about the issue, by typing into the text box in the issue page.
 
 ## The development process
 
-Please refer to the [development section](https://dipy.org/documentation/lastest/devel/)
+Please refer to the [development section](https://dipy.org/documentation/latest/devel/)
 of the documentation for the procedures we use in developing the code.
 
 ## When writing code, please pay attention to the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ conversation about the issue, by typing into the text box in the issue page.
 
 ## The development process
 
-Please refer to the [development section](https://dipy.org/documentation/1.0.0./devel/)
+Please refer to the [development section](https://dipy.org/documentation/lastest/devel/)
 of the documentation for the procedures we use in developing the code.
 
 ## When writing code, please pay attention to the following:


### PR DESCRIPTION
Fix the broken link under the subtitle "The development process" of the file "CONTRIBUTING.md".
It looks like after we released version 1.0.0, the route of the website change a little bit. This might cause other broken links. And also, there might be a better way to fix this. Discussion and advice are welcoming. 