### PR TITLE
DOC: Improve the `doc/examples/README` file contents

### DIFF
--- a/doc/examples/README.md
+++ b/doc/examples/README.md
@@ -1,9 +1,8 @@
-Examples
---------
+# Examples
 
-These are the dipy examples.  They are built as docs in the dipy
-``examples_built`` directory in the documentation.
+These are the DIPY examples. They are built as docs in the DIPY
+`examples_built` directory in the documentation.
 
 If you add an example (yes please!), please remember to add it to the
-``valid_examples.txt`` file located in this directory and to the
-``examples_index.rst`` file listing in the ``doc`` directory.
+`valid_examples.txt` file located in this directory and to the
+`examples_index.rst` file listing in the `doc` directory.


### PR DESCRIPTION
Improve the `doc/examples/README` file contents:
- Make the syntax be consistent with the one `README` file in the `doc`
  folder (headings style and literal text markup).
- Capitalize DIPY.