### PR TITLE
DOC: Fix parameter docstring in `dipy.io.streamline.load_tractogram`

### DIFF
--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -101,9 +101,8 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         Reference that provides the spatial attribute.
         Typically a nifti-related object from the native diffusion used for
         streamlines generation
-    space : string
-        Space in which the streamlines will be transformed after loading
-        (vox, voxmm or rasmm)
+    to_space : Enum (dipy.io.stateful_tractogram.Space)
+        Space to which the streamlines will be transformed after loading.
     shifted_origin : bool
         Information on the position of the origin,
         False is Trackvis standard, default (center of the voxel)


### PR DESCRIPTION
Fix parameter docstring in `dipy.io.streamline.load_tractogram`: fix
name and type.