### PR TITLE
[FIX] Avoid copy of  Streamlines data

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -277,9 +277,9 @@ class StatefulTractogram(object):
         output : ndarray
             8 corners of the XYZ aligned box, all zeros if no streamlines
         """
-        if self._tractogram.streamlines.data.size > 0:
-            bbox_min = np.min(self._tractogram.streamlines.data, axis=0)
-            bbox_max = np.max(self._tractogram.streamlines.data, axis=0)
+        if self._tractogram.streamlines._data.size > 0:
+            bbox_min = np.min(self._tractogram.streamlines._data, axis=0)
+            bbox_max = np.max(self._tractogram.streamlines._data, axis=0)
             return np.asarray(list(product(*zip(bbox_min, bbox_max))))
 
         return np.zeros((8, 3))
@@ -347,9 +347,9 @@ class StatefulTractogram(object):
         self.to_vox()
         self.to_corner()
 
-        min_condition = np.min(self._tractogram.streamlines.data,
+        min_condition = np.min(self._tractogram.streamlines._data,
                                axis=1) < 0.0
-        max_condition = np.any(self._tractogram.streamlines.data >
+        max_condition = np.any(self._tractogram.streamlines._data >
                                self._dimensions, axis=1)
         ic_offsets_indices = np.where(np.logical_or(min_condition,
                                                     max_condition))[0]
@@ -393,7 +393,7 @@ class StatefulTractogram(object):
     def _vox_to_voxmm(self):
         """ Unsafe function to transform streamlines """
         if self._space == Space.VOX:
-            if self._tractogram.streamlines.data.size > 0:
+            if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
@@ -405,7 +405,7 @@ class StatefulTractogram(object):
     def _voxmm_to_vox(self):
         """ Unsafe function to transform streamlines """
         if self._space == Space.VOXMM:
-            if self._tractogram.streamlines.data.size > 0:
+            if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.streamlines._data /= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOX
@@ -417,7 +417,7 @@ class StatefulTractogram(object):
     def _vox_to_rasmm(self):
         """ Unsafe function to transform streamlines """
         if self._space == Space.VOX:
-            if self._tractogram.streamlines.data.size > 0:
+            if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
                 logging.info('Moved streamlines from vox to rasmm')
@@ -428,7 +428,7 @@ class StatefulTractogram(object):
     def _rasmm_to_vox(self):
         """ Unsafe function to transform streamlines """
         if self._space == Space.RASMM:
-            if self._tractogram.streamlines.data.size > 0:
+            if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.apply_affine(self._inv_affine)
                 self._space = Space.VOX
                 logging.info('Moved streamlines from rasmm to vox')
@@ -439,7 +439,7 @@ class StatefulTractogram(object):
     def _voxmm_to_rasmm(self):
         """ Unsafe function to transform streamlines """
         if self._space == Space.VOXMM:
-            if self._tractogram.streamlines.data.size > 0:
+            if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.streamlines._data /= np.asarray(
                     self._voxel_sizes)
                 self._tractogram.apply_affine(self._affine)
@@ -452,7 +452,7 @@ class StatefulTractogram(object):
     def _rasmm_to_voxmm(self):
         """ Unsafe function to transform streamlines """
         if self._space == Space.RASMM:
-            if self._tractogram.streamlines.data.size > 0:
+            if self._tractogram.streamlines._data.size > 0:
                 self._tractogram.apply_affine(self._inv_affine)
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -32,7 +32,7 @@ def trk_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def tck_equal_in_vox_space():
@@ -40,7 +40,7 @@ def tck_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -51,7 +51,7 @@ def fib_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def dpy_equal_in_vox_space():
@@ -59,7 +59,7 @@ def dpy_equal_in_vox_space():
                           to_space=Space.VOX)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_vox_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def trk_equal_in_rasmm_space():
@@ -67,7 +67,7 @@ def trk_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def tck_equal_in_rasmm_space():
@@ -75,7 +75,7 @@ def tck_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -86,7 +86,7 @@ def fib_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def dpy_equal_in_rasmm_space():
@@ -94,7 +94,7 @@ def dpy_equal_in_rasmm_space():
                           to_space=Space.RASMM)
     tmp_points_rasmm = np.loadtxt(filepath_dix['gs_rasmm_space.txt'])
     assert_allclose(tmp_points_rasmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def trk_equal_in_voxmm_space():
@@ -102,7 +102,7 @@ def trk_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def tck_equal_in_voxmm_space():
@@ -110,7 +110,7 @@ def tck_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 @pytest.mark.skipif(not have_fury, reason="Requires FURY")
@@ -121,7 +121,7 @@ def fib_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def dpy_equal_in_voxmm_space():
@@ -129,7 +129,7 @@ def dpy_equal_in_voxmm_space():
                           to_space=Space.VOXMM)
     tmp_points_voxmm = np.loadtxt(filepath_dix['gs_voxmm_space.txt'])
     assert_allclose(tmp_points_voxmm,
-                    sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def switch_voxel_sizes_from_rasmm():
@@ -143,11 +143,11 @@ def switch_voxel_sizes_from_rasmm():
 
     sft_switch.to_rasmm()
     assert_allclose(tmp_points_rasmm,
-                    sft_switch.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
 
     sft_switch.to_voxmm()
     assert_allclose(tmp_points_voxmm,
-                    sft_switch.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def switch_voxel_sizes_from_voxmm():
@@ -161,11 +161,11 @@ def switch_voxel_sizes_from_voxmm():
 
     sft_switch.to_rasmm()
     assert_allclose(tmp_points_rasmm,
-                    sft_switch.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
 
     sft_switch.to_voxmm()
     assert_allclose(tmp_points_voxmm,
-                    sft_switch.streamlines.data, atol=1e-3, rtol=1e-6)
+                    sft_switch.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def to_rasmm_equivalence():
@@ -176,8 +176,8 @@ def to_rasmm_equivalence():
 
     sft_1.to_rasmm()
     sft_2.to_space(Space.RASMM)
-    assert_allclose(sft_1.streamlines.data,
-                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines._data,
+                    sft_2.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def to_voxmm_equivalence():
@@ -188,8 +188,8 @@ def to_voxmm_equivalence():
 
     sft_1.to_voxmm()
     sft_2.to_space(Space.VOXMM)
-    assert_allclose(sft_1.streamlines.data,
-                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines._data,
+                    sft_2.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def to_vox_equivalence():
@@ -200,8 +200,8 @@ def to_vox_equivalence():
 
     sft_1.to_vox()
     sft_2.to_space(Space.VOX)
-    assert_allclose(sft_1.streamlines.data,
-                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+    assert_allclose(sft_1.streamlines._data,
+                    sft_2.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def trk_iterative_saving_loading():
@@ -215,7 +215,7 @@ def trk_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.trk', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines.data,
+                            sft_iter.streamlines._data,
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.trk')
 
@@ -231,7 +231,7 @@ def tck_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.tck', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines.data,
+                            sft_iter.streamlines._data,
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.tck')
 
@@ -250,7 +250,7 @@ def fib_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.fib', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines.data,
+                            sft_iter.streamlines._data,
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.fib')
 
@@ -266,7 +266,7 @@ def dpy_iterative_saving_loading():
             sft_iter = load_tractogram('gs_iter.dpy', filepath_dix['gs.nii'],
                                        to_space=Space.RASMM)
             assert_allclose(tmp_points_rasmm,
-                            sft_iter.streamlines.data,
+                            sft_iter.streamlines._data,
                             atol=1e-3, rtol=1e-6)
             save_tractogram(sft_iter, 'gs_iter.dpy')
 
@@ -279,7 +279,7 @@ def iterative_to_vox_transformation():
         sft.to_vox()
         sft.to_rasmm()
         assert_allclose(tmp_points_rasmm,
-                        sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                        sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def iterative_to_voxmm_transformation():
@@ -290,7 +290,7 @@ def iterative_to_voxmm_transformation():
         sft.to_voxmm()
         sft.to_rasmm()
         assert_allclose(tmp_points_rasmm,
-                        sft.streamlines.data, atol=1e-3, rtol=1e-6)
+                        sft.streamlines._data, atol=1e-3, rtol=1e-6)
 
 
 def empty_space_change():
@@ -298,20 +298,20 @@ def empty_space_change():
     sft.to_vox()
     sft.to_voxmm()
     sft.to_rasmm()
-    assert_array_equal([], sft.streamlines.data)
+    assert_array_equal([], sft.streamlines._data)
 
 
 def empty_shift_change():
     sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
     sft.to_corner()
     sft.to_center()
-    assert_array_equal([], sft.streamlines.data)
+    assert_array_equal([], sft.streamlines._data)
 
 
 def empty_remove_invalid():
     sft = StatefulTractogram([], filepath_dix['gs.nii'], Space.VOX)
     sft.remove_invalid_streamlines()
-    assert_array_equal([], sft.streamlines.data)
+    assert_array_equal([], sft.streamlines._data)
 
 
 def shift_corner_from_rasmm():

--- a/dipy/stats/analysis.py
+++ b/dipy/stats/analysis.py
@@ -235,15 +235,15 @@ def bundle_analysis(model_bundle_folder, bundle_folder, orig_bundle_folder,
         clusters = qb.cluster(mbundle_streamlines)
         centroids = Streamlines(clusters.centroids)
 
-        print('Number of centroids ', len(centroids.data))
+        print('Number of centroids ', len(centroids._data))
         print('Model bundle ', mb[io])
         print('Number of streamlines in bundle in common space ',
               len(bundles))
         print('Number of streamlines in bundle in original space ',
               len(orig_bundles))
 
-        _, indx = cKDTree(centroids.data, 1,
-                          copy_data=True).query(bundles.data, k=1)
+        _, indx = cKDTree(centroids._data, 1,
+                          copy_data=True).query(bundles._data, k=1)
 
         metric_files_names = os.listdir(metric_folder)
         _, affine = load_nifti(os.path.join(metric_folder, "fa.nii.gz"))
@@ -313,7 +313,7 @@ def gaussian_weights(bundle, n_points=100, return_mahalnobis=False,
         # This should come back as a 3D covariance matrix with the spatial
         # variance covariance of this node across the different streamlines
         # This is a 3-by-3 array:
-        node_coords = bundle.data[node::n_points]
+        node_coords = bundle._data[node::n_points]
         c = np.cov(node_coords.T, ddof=0)
         # Reorganize as an upper diagonal matrix for expected Mahalanobis
         # input:

--- a/dipy/tracking/streamlinespeed.pyx
+++ b/dipy/tracking/streamlinespeed.pyx
@@ -101,15 +101,15 @@ def length(streamlines):
 
         arclengths = np.zeros(len(streamlines), dtype=np.float64)
 
-        if streamlines.data.dtype == np.float32:
+        if streamlines._data.dtype == np.float32:
             c_arclengths_from_arraysequence[float2d](
-                                    streamlines.data,
+                                    streamlines._data,
                                     streamlines._offsets.astype(np.intp),
                                     streamlines._lengths.astype(np.intp),
                                     arclengths)
         else:
             c_arclengths_from_arraysequence[double2d](
-                                      streamlines.data,
+                                      streamlines._data,
                                       streamlines._offsets.astype(np.intp),
                                       streamlines._lengths.astype(np.intp),
                                       arclengths)

--- a/dipy/tracking/tests/test_tracking.py
+++ b/dipy/tracking/tests/test_tracking.py
@@ -314,10 +314,10 @@ def test_probabilistic_odf_weighted_tracker():
     # Test reproducibility
     tracking_1 = Streamlines(LocalTracking(dg, sc, seeds, np.eye(4),
                                            0.5,
-                                           random_seed=0)).data
+                                           random_seed=0))._data
     tracking_2 = Streamlines(LocalTracking(dg, sc, seeds, np.eye(4),
                                            0.5,
-                                           random_seed=0)).data
+                                           random_seed=0))._data
     npt.assert_equal(tracking_1, tracking_2)
 
 
@@ -457,10 +457,10 @@ def test_particle_filtering_tractography():
     # Test reproducibility
     tracking1 = Streamlines(ParticleFilteringTracking(dg, sc, seeds, np.eye(4),
                                                       step_size,
-                                                      random_seed=0)).data
+                                                      random_seed=0))._data
     tracking2 = Streamlines(ParticleFilteringTracking(dg, sc, seeds, np.eye(4),
                                                       step_size,
-                                                      random_seed=0)).data
+                                                      random_seed=0))._data
     npt.assert_equal(tracking1, tracking2)
 
 


### PR DESCRIPTION
As you can see on this PR (https://github.com/nipy/nibabel/pull/811), `ArraySequence.data` will now return a copy of the data. This way, altering the data of the sliced/indexed tractogram will not affect the original data.

So, the goal of this PR is to prevent this copy since the future release of Nibabel is quite soon.