### PR TITLE
BUG: Fix workflows IO `FetchFlow` `all` dataset fetching

### DIFF
--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -118,7 +118,29 @@ class FetchFlow(Workflow):
     def get_short_name(cls):
         return 'fetch'
 
-    def load_module(self, module_path):
+    @staticmethod
+    def get_fetcher_datanames():
+        """Gets available dataset and function names.
+
+        Returns
+        -------
+        available_data: dict
+            Available dataset and function names.
+
+        """
+
+        fetcher_module = FetchFlow.load_module('dipy.data.fetcher')
+
+        available_data = dict([(name.replace('fetch_', ''), func)
+                               for name, func in getmembers(fetcher_module,
+                                                            isfunction)
+                               if name.lower().startswith("fetch_") and
+                               func is not fetcher_module.fetch_data])
+
+        return available_data
+
+    @staticmethod
+    def load_module(module_path):
         """Load / reload an external module.
 
         Parameters
@@ -153,13 +175,7 @@ class FetchFlow(Workflow):
             dipy_home = os.environ.get('DIPY_HOME', None)
             os.environ['DIPY_HOME'] = out_dir
 
-        fetcher_module = self.load_module('dipy.data.fetcher')
-
-        available_data = dict([(name.replace('fetch_', ''), func)
-                               for name, func in getmembers(fetcher_module,
-                                                            isfunction)
-                               if name.lower().startswith("fetch_") and
-                               func is not fetcher_module.fetch_data])
+        available_data = FetchFlow.get_fetcher_datanames()
 
         data_names = [name.lower() for name in data_names]
 

--- a/dipy/workflows/io.py
+++ b/dipy/workflows/io.py
@@ -158,7 +158,8 @@ class FetchFlow(Workflow):
         available_data = dict([(name.replace('fetch_', ''), func)
                                for name, func in getmembers(fetcher_module,
                                                             isfunction)
-                               if name.lower().startswith("fetch_")])
+                               if name.lower().startswith("fetch_") and
+                               func is not fetcher_module.fetch_data])
 
         data_names = [name.lower() for name in data_names]
 

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -7,6 +7,7 @@ from dipy.testing import assert_true
 from dipy.data.fetcher import dipy_home
 from dipy.workflows.io import IoInfoFlow, FetchFlow, SplitFlow
 from nibabel.tmpdirs import TemporaryDirectory
+from os.path import join as pjoin
 from tempfile import mkstemp
 fname_log = mkstemp()[1]
 
@@ -50,6 +51,11 @@ def test_io_fetch():
         npt.assert_equal(os.path.isdir(os.path.join(out_dir,
                                                     'bundle_fa_hcp')),
                          True)
+
+        fetch_flow.run(['all'])
+        npt.assert_equal(
+            len(list(filter(lambda x: os.path.isdir(pjoin(dipy_home, x)),
+                            os.listdir(dipy_home)))), 18)
 
 
 def test_split_flow():

--- a/dipy/workflows/tests/test_io.py
+++ b/dipy/workflows/tests/test_io.py
@@ -52,10 +52,23 @@ def test_io_fetch():
                                                     'bundle_fa_hcp')),
                          True)
 
-        fetch_flow.run(['all'])
-        npt.assert_equal(
-            len(list(filter(lambda x: os.path.isdir(pjoin(dipy_home, x)),
-                            os.listdir(dipy_home)))), 18)
+
+def test_io_fetch_fetcher_datanames():
+    available_data = FetchFlow.get_fetcher_datanames()
+
+    dataset_names = ['bundle_atlas_hcp842', 'bundle_fa_hcp',
+                     'bundles_2_subjects', 'cenir_multib', 'cfin_multib',
+                     'file_formats', 'gold_standard_io', 'isbi2013_2shell',
+                     'ivim', 'mni_template', 'qtdMRI_test_retest_2subjects',
+                     'scil_b0', 'sherbrooke_3shell', 'stanford_hardi',
+                     'stanford_labels', 'stanford_pve_maps', 'stanford_t1',
+                     'syn_data', 'taiwan_ntu_dsi', 'target_tractogram_hcp',
+                     'tissue_data']
+
+    num_expected_fetch_methods = len(dataset_names)
+    npt.assert_equal(len(available_data), num_expected_fetch_methods)
+    npt.assert_equal(all(dataset_name in available_data.keys()
+                         for dataset_name in dataset_names), True)
 
 
 def test_split_flow():
@@ -79,5 +92,6 @@ def test_split_flow():
 
 if __name__ == '__main__':
     test_io_fetch()
+    test_io_fetch_fetcher_datanames()
     test_io_info()
     test_split_flow()


### PR DESCRIPTION
Fix workflows IO `FetchFlow` `all` dataset fetching: the `fetch_data` is
contained in the `available_data` dictionary because as the actual data fetcher
function it starts with  `fetch_`. However, the `fetch_data` function is what
the actual fetchers call with the necessary arguments. Thus, the
`dipy.workflows.tests.test_io.test_io_fetch` test fails if we specify
`fetch_flow.run(['all'])` because the parameters of `fetch_data` are empty.

The fix is to avoid adding the `fetch_data` function when the dictionary is
created.

Fixes
```
  File
"/src/dipy/dipy/workflows/tests/test_io.py",
line 80, in <module>
    test_io_fetch()
  File
"src/dipy/dipy/workflows/tests/test_io.py",
line 54, in test_io_fetch
    fetch_flow.run(['all'])
  File
"/src/dipy/dipy/workflows/io.py",
line 172, in run
    fetcher_function()
TypeError: fetch_data() missing 2 required positional arguments: 'files' and
'folder'
```

Add a test for the `all` case and compare to the expected number of dataset
folders (18).