### PR TITLE
Fix origin nomenclature sft (center/corner)

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -160,7 +160,7 @@ class StatefulTractogram(object):
 
     @property
     def origin_at_corner(self):
-        """ Getter for shift """
+        """ Getter for origin standard """
         return self._origin_at_corner
 
     @property
@@ -300,7 +300,7 @@ class StatefulTractogram(object):
             return True
 
         old_space = deepcopy(self.space)
-        old_shift = deepcopy(self.origin_at_corner)
+        old_origin = deepcopy(self.origin_at_corner)
 
         # Do to rotation, equivalent of a OBB must be done
         self.to_vox()
@@ -325,7 +325,7 @@ class StatefulTractogram(object):
         elif old_space == Space.VOXMM:
             self.to_voxmm()
 
-        if not old_shift:
+        if not old_origin:
             self.to_center()
 
         return is_valid
@@ -344,7 +344,7 @@ class StatefulTractogram(object):
             return
 
         old_space = deepcopy(self.space)
-        old_shift = deepcopy(self.origin_at_corner)
+        old_origin = deepcopy(self.origin_at_corner)
 
         self.to_vox()
         self.to_corner()
@@ -379,7 +379,7 @@ class StatefulTractogram(object):
         elif old_space == Space.VOXMM:
             self.to_voxmm()
 
-        if not old_shift:
+        if not old_origin:
             self.to_center()
 
         return indices_to_remove, indices_to_keep

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -14,6 +14,8 @@ from dipy.io.dpy import Streamlines
 from dipy.io.utils import get_reference_info
 
 
+logger = logging.getLogger('StatefulTractogram')
+
 class Space(enum.Enum):
     """ Enum to simplify future change to convention """
     VOX = 'vox'
@@ -98,7 +100,7 @@ class StatefulTractogram(object):
         if not isinstance(origin_at_corner, bool):
             raise TypeError('origin_at_corner MUST be a boolean')
         self._origin_at_corner = origin_at_corner
-        logging.debug(self)
+        logger.debug(self)
 
     def __str__(self):
         """ Generate the string for printing """
@@ -184,7 +186,7 @@ class StatefulTractogram(object):
         self._tractogram._streamlines = Streamlines(streamlines)
         self.data_per_point = self.data_per_point
         self.data_per_streamline = self.data_per_streamline
-        logging.warning('Streamlines has been modified')
+        logger.warning('Streamlines has been modified')
 
     @property
     def data_per_point(self):
@@ -203,7 +205,7 @@ class StatefulTractogram(object):
             Y_i being the number of points on streamlines #i
         """
         self._tractogram.data_per_point = data
-        logging.warning('Data_per_point has been modified')
+        logger.warning('Data_per_point has been modified')
 
     @property
     def data_per_streamline(self):
@@ -221,7 +223,7 @@ class StatefulTractogram(object):
             X being the number of streamlines
         """
         self._tractogram.data_per_streamline = data
-        logging.warning('Data_per_streamline has been modified')
+        logger.warning('Data_per_streamline has been modified')
 
     def to_vox(self):
         """ Safe function to transform streamlines and update state """
@@ -254,7 +256,7 @@ class StatefulTractogram(object):
         elif target_space == Space.RASMM:
             self.to_rasmm()
         else:
-            logging.error('Unsupported target space, please use Enum in '
+            logger.error('Unsupported target space, please use Enum in '
                           'dipy.io.stateful_tractogram')
 
     def to_center(self):
@@ -307,15 +309,15 @@ class StatefulTractogram(object):
 
         is_valid = True
         if np.any(bbox_corners < 0):
-            logging.error('Voxel space values lower than 0.0')
-            logging.debug(bbox_corners)
+            logger.error('Voxel space values lower than 0.0')
+            logger.debug(bbox_corners)
             is_valid = False
 
         if np.any(bbox_corners[:, 0] > self._dimensions[0]) or \
                 np.any(bbox_corners[:, 1] > self._dimensions[1]) or \
                 np.any(bbox_corners[:, 2] > self._dimensions[2]):
-            logging.error('Voxel space values higher than dimensions')
-            logging.debug(bbox_corners)
+            logger.error('Voxel space values higher than dimensions')
+            logger.debug(bbox_corners)
             is_valid = False
 
         if old_space == Space.RASMM:
@@ -397,9 +399,9 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
-                logging.info('Moved streamlines from vox to voxmm')
+                logger.info('Moved streamlines from vox to voxmm')
         else:
-            logging.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function')
             return
 
     def _voxmm_to_vox(self):
@@ -409,9 +411,9 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data /= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOX
-                logging.info('Moved streamlines from voxmm to vox')
+                logger.info('Moved streamlines from voxmm to vox')
         else:
-            logging.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function')
             return
 
     def _vox_to_rasmm(self):
@@ -420,9 +422,9 @@ class StatefulTractogram(object):
             if self._tractogram.streamlines.data.size > 0:
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
-                logging.info('Moved streamlines from vox to rasmm')
+                logger.info('Moved streamlines from vox to rasmm')
         else:
-            logging.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function')
             return
 
     def _rasmm_to_vox(self):
@@ -431,9 +433,9 @@ class StatefulTractogram(object):
             if self._tractogram.streamlines.data.size > 0:
                 self._tractogram.apply_affine(self._inv_affine)
                 self._space = Space.VOX
-                logging.info('Moved streamlines from rasmm to vox')
+                logger.info('Moved streamlines from rasmm to vox')
         else:
-            logging.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function')
             return
 
     def _voxmm_to_rasmm(self):
@@ -444,9 +446,9 @@ class StatefulTractogram(object):
                     self._voxel_sizes)
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
-                logging.info('Moved streamlines from voxmm to rasmm')
+                logger.info('Moved streamlines from voxmm to rasmm')
         else:
-            logging.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function')
             return
 
     def _rasmm_to_voxmm(self):
@@ -457,9 +459,9 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
-                logging.info('Moved streamlines from rasmm to voxmm')
+                logger.info('Moved streamlines from rasmm to voxmm')
         else:
-            logging.warning('Wrong initial space for this function')
+            logger.warning('Wrong initial space for this function')
             return
 
     def _shift_voxel_origin(self):
@@ -480,9 +482,9 @@ class StatefulTractogram(object):
 
         self._tractogram.streamlines._data += shift
         if not self._origin_at_corner:
-            logging.info('Origin moved to the corner of voxel')
+            logger.info('Origin moved to the corner of voxel')
         else:
-            logging.info('Origin moved to the center of voxel')
+            logger.info('Origin moved to the center of voxel')
 
         self._origin_at_corner = not self._origin_at_corner
 
@@ -506,7 +508,7 @@ def _is_data_per_point_valid(streamlines, data):
         Does all the streamlines and metadata attribute match
     """
     if not isinstance(data, (dict, PerArraySequenceDict)):
-        logging.error('data_per_point MUST be a dictionary')
+        logger.error('data_per_point MUST be a dictionary')
         return False
     elif data == {}:
         return True
@@ -520,14 +522,14 @@ def _is_data_per_point_valid(streamlines, data):
     for key in data.keys():
         total_point_entries = 0
         if not len(data[key]) == total_streamline:
-            logging.error('Missing entry for streamlines points data (1)')
+            logger.error('Missing entry for streamlines points data (1)')
             return False
 
         for values in data[key]:
             total_point_entries += len(values)
 
         if total_point_entries != total_point:
-            logging.error('Missing entry for streamlines points data (2)')
+            logger.error('Missing entry for streamlines points data (2)')
             return False
 
     return True
@@ -550,7 +552,7 @@ def _is_data_per_streamline_valid(streamlines, data):
         Does all the streamlines and metadata attribute match
     """
     if not isinstance(data, (dict, PerArrayDict)):
-        logging.error('data_per_point MUST be a dictionary')
+        logger.error('data_per_point MUST be a dictionary')
         return False
     elif data == {}:
         return True
@@ -561,7 +563,7 @@ def _is_data_per_streamline_valid(streamlines, data):
 
     for key in data.keys():
         if not len(data[key]) == total_streamline:
-            logging.error('Missing entry for streamlines data (3)')
+            logger.error('Missing entry for streamlines data (3)')
             return False
 
     return True

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -16,6 +16,19 @@ from dipy.io.utils import get_reference_info
 
 logger = logging.getLogger('StatefulTractogram')
 
+
+def set_sft_logger_level(log_level):
+    """ Change the logger of the StatefulTractogram
+    to one on the following: DEBUG, INFO, WARNING, ERROR
+
+    Parameters
+    ----------
+    log_level : str
+        Log level for the StatefulTractogram only
+    """
+    logger.setLevel(level=log_level)
+
+
 class Space(enum.Enum):
     """ Enum to simplify future change to convention """
     VOX = 'vox'
@@ -257,7 +270,7 @@ class StatefulTractogram(object):
             self.to_rasmm()
         else:
             logger.error('Unsupported target space, please use Enum in '
-                          'dipy.io.stateful_tractogram')
+                         'dipy.io.stateful_tractogram')
 
     def to_center(self):
         """ Safe function to shift streamlines so the center of voxel is

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -323,8 +323,8 @@ class StatefulTractogram(object):
         elif old_space == Space.VOXMM:
             self.to_voxmm()
 
-        if old_shift:
-            self.to_corner()
+        if not old_shift:
+            self.to_center()
 
         return is_valid
 
@@ -377,8 +377,8 @@ class StatefulTractogram(object):
         elif old_space == Space.VOXMM:
             self.to_voxmm()
 
-        if old_shift:
-            self.to_corner()
+        if not old_shift:
+            self.to_center()
 
         return indices_to_remove, indices_to_keep
 

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -46,7 +46,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
                          'streamlines or set bbox_valid_check to False')
 
     old_space = deepcopy(sft.space)
-    old_shift = deepcopy(sft.shifted_origin)
+    old_shift = deepcopy(sft.origin_at_corner)
 
     sft.to_rasmm()
     sft.to_center()
@@ -88,7 +88,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
 
 
 def load_tractogram(filename, reference, to_space=Space.RASMM,
-                    shifted_origin=False, bbox_valid_check=True,
+                    origin_at_corner=False, bbox_valid_check=True,
                     trk_header_check=True):
     """ Load the stateful tractogram from any format (trk, tck, vtk, fib, dpy)
 
@@ -103,10 +103,10 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         streamlines generation
     to_space : Enum (dipy.io.stateful_tractogram.Space)
         Space to which the streamlines will be transformed after loading.
-    shifted_origin : bool
+    origin_at_corner : bool
         Information on the position of the origin,
-        False is Trackvis standard, default (center of the voxel)
-        True is NIFTI standard (corner of the voxel)
+        False is NIFTI standard, default (center of the voxel)
+        True is TrackVis standard (corner of the voxel)
     bbox_valid_check : bool
         Verification for negative voxel coordinates or values above the
         volume dimensions. Default is True, to enforce valid file.
@@ -162,7 +162,7 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
                   filename, len(streamlines), round(time.time() - timer, 3))
 
     sft = StatefulTractogram(streamlines, reference, Space.RASMM,
-                             shifted_origin=shifted_origin,
+                             origin_at_corner=origin_at_corner,
                              data_per_point=data_per_point,
                              data_per_streamline=data_per_streamline)
 
@@ -195,7 +195,7 @@ def load_generator(ttype):
         Function (load_tractogram) that handle only one file format
     """
     def f_gen(filename, reference, to_space=Space.RASMM,
-              shifted_origin=False, bbox_valid_check=True,
+              origin_at_corner=False, bbox_valid_check=True,
               trk_header_check=True):
         _, extension = os.path.splitext(filename)
         if not extension == ttype:
@@ -204,7 +204,7 @@ def load_generator(ttype):
 
         sft = load_tractogram(filename, reference,
                               to_space=Space.RASMM,
-                              shifted_origin=shifted_origin,
+                              origin_at_corner=origin_at_corner,
                               bbox_valid_check=bbox_valid_check,
                               trk_header_check=trk_header_check)
         return sft

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -46,7 +46,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
                          'streamlines or set bbox_valid_check to False')
 
     old_space = deepcopy(sft.space)
-    old_shift = deepcopy(sft.origin_at_corner)
+    old_origin = deepcopy(sft.origin_at_corner)
 
     sft.to_rasmm()
     sft.to_center()
@@ -81,7 +81,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
     elif old_space == Space.VOXMM:
         sft.to_voxmm()
 
-    if old_shift:
+    if old_origin:
         sft.to_corner()
 
     return True

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -409,7 +409,7 @@ def reassign_both_data_sep():
 
 def bounding_bbox_valid(shift):
     sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
-                          shifted_origin=shift, bbox_valid_check=False)
+                          origin_at_corner=shift, bbox_valid_check=False)
 
     return sft.is_bbox_in_vox_valid()
 

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -1,6 +1,17 @@
-from dipy.io.utils import decfa, decfa_to_float
+import os
+
+from dipy.data import fetch_gold_standard_io
+from dipy.io.utils import (decfa, decfa_to_float,
+                           get_reference_info,
+                           create_nifti_header)
 from nibabel import Nifti1Image
 import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+
+filepath_dix = {}
+files, folder = fetch_gold_standard_io()
+for filename in files:
+    filepath_dix[filename] = os.path.join(folder, filename)
 
 
 def test_decfa():
@@ -38,3 +49,29 @@ def test_decfa():
     data_rt = round_trip.get_data()
     assert data_rt.shape == (4, 4, 4, 3)
     assert np.all(data_rt[0, 0, 0] == np.array([25, 0, 0]))
+
+
+def test_reference_info_identical():
+    tuple_1 = get_reference_info(filepath_dix['gs.trk'])
+    tuple_2 = get_reference_info(filepath_dix['gs.nii'])
+    affine_1, dimensions_1, voxel_sizes_1, voxel_order_1 = tuple_1
+    affine_2, dimensions_2, voxel_sizes_2, voxel_order_2 = tuple_2
+
+    assert_allclose(affine_1, affine_2)
+    assert_array_equal(dimensions_1, dimensions_2)
+    assert_allclose(voxel_sizes_1, voxel_sizes_2)
+    assert voxel_order_1 == voxel_order_2
+
+
+def test_all_zeros_affine():
+    if reference_info_zero_affine():
+        raise AssertionError()
+
+
+def reference_info_zero_affine():
+    header = create_nifti_header(np.zeros((4, 4)), [10, 10, 10], [1, 1, 1])
+    try:
+        get_reference_info(header)
+        return True
+    except ValueError:
+        return False

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -193,9 +193,9 @@ def get_reference_info(reference):
         dimensions = header['dim'][1:4]
         voxel_sizes = header['pixdim'][1:4]
 
-        if not affine.any():
-            raise TypeError('Invalid affine, contains only zeros.'
-                            'Cannot determine voxel order from transformation')
+        if not affine[0:3, 0:3].any():
+            raise ValueError('Invalid affine, contains only zeros.'
+                             'Cannot determine voxel order from transformation')
         voxel_order = ''.join(nib.aff2axcodes(affine))
     elif is_trk:
         affine = header['voxel_to_rasmm']

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -195,7 +195,7 @@ def get_reference_info(reference):
 
         if not affine.any():
             raise TypeError('Invalid affine, contains only zeros.'
-                            'cannot determine voxel order from transformation')
+                            'Cannot determine voxel order from transformation')
         voxel_order = ''.join(nib.aff2axcodes(affine))
     elif is_trk:
         affine = header['voxel_to_rasmm']

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -192,6 +192,10 @@ def get_reference_info(reference):
         affine[2, 0:4] = header['srow_z']
         dimensions = header['dim'][1:4]
         voxel_sizes = header['pixdim'][1:4]
+
+        if not affine.any():
+            raise TypeError('Invalid affine, contains only zeros.'
+                            'cannot determine voxel order from transformation')
         voxel_order = ''.join(nib.aff2axcodes(affine))
     elif is_trk:
         affine = header['voxel_to_rasmm']


### PR DESCRIPTION
Fix the inversion in the documentation about the standard (trackvis vs nifti).
Replace the unclear variable name (`shifted_origin` -> `origin_at_corner`)
Added a small catch for all-zero affine that was crashing in `nib.aff2axcodes`