### PR TITLE
Add ability to analyze entire streamline in connectivity_matrix

### DIFF
--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -143,8 +143,8 @@ def test_connectivity_matrix():
     expected[4, 3] = 1
     expected[3, 5] = 1
     expected[5, 4] = 1
-    expected[0,3:5] = 1
-    expected[3:5,0] = 1
+    expected[0, 3:5] = 1
+    expected[3:5, 0] = 1
 
     matrix = connectivity_matrix(streamlines, np.eye(4), label_volume,
                                  symmetric=False, inclusive=True)
@@ -152,7 +152,7 @@ def test_connectivity_matrix():
 
     # Test mapping
     matrix, mapping = connectivity_matrix(streamlines, np.eye(4), label_volume,
-                                          inclusive=True,symmetric=False,
+                                          inclusive=True, symmetric=False,
                                           return_mapping=True)
     npt.assert_array_equal(matrix, expected)
     npt.assert_equal(mapping[3, 4], [0, 1])
@@ -162,8 +162,9 @@ def test_connectivity_matrix():
     npt.assert_equal(mapping.get((0, 0)), None)
 
     # Test mapping and symmetric
-    matrix, mapping = connectivity_matrix(streamlines, np.eye(4), label_volume, inclusive=True,
-                                          symmetric=True, return_mapping=True)
+    matrix, mapping = connectivity_matrix(streamlines, np.eye(4), label_volume,
+                                          inclusive=True, symmetric=True,
+                                          return_mapping=True)
     npt.assert_equal(mapping[3, 4], [0, 1, 2])
     npt.assert_equal(mapping[0, 3], [1, 2])
     npt.assert_equal(mapping[0, 4], [1, 2])

--- a/dipy/tracking/tests/test_utils.py
+++ b/dipy/tracking/tests/test_utils.py
@@ -138,6 +138,9 @@ def test_connectivity_matrix():
 
     # Test Inclusive streamline analysis
     # Check basic Case (inclusive)
+    expected = np.zeros((6, 6), 'int')
+    expected[3, 4] = 2
+    expected[4, 3] = 1
     expected[3, 5] = 1
     expected[5, 4] = 1
     expected[0,3:5] = 1

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -170,29 +170,29 @@ def connectivity_matrix(streamlines, affine, label_volume, inclusive=False,
         #Create ndarray to store streamline connections
         edges = np.ndarray(shape=(3,0),dtype=int)
         lin_T, offset = _mapping_to_voxel(affine)
-        for s in range(len(streamlines)):
+        for sl in range(len(streamlines)):
             # Convert streamline to voxel coordinates
-            entire = _to_voxel_coordinates(streamlines[s], lin_T, offset)
+            entire = _to_voxel_coordinates(streamlines[sl], lin_T, offset)
             i, j, k = entire.T
             
             if symmetric:
                 # Create list of all labels streamline passes through
                 entirelabels = list(OrderedDict.fromkeys(label_volume[i,j,k]))
                 # Append all connection combinations along with streamline number
-                for e in combinations(entirelabels,2):
-                    edges=np.append(edges,[[e[0]],[e[1]],[s]], axis=1)
+                for comb in combinations(entirelabels,2):
+                    edges=np.append(edges,[[comb[0]],[comb[1]],[sl]], axis=1)
             else:
                 # Create list of all labels streamline passes through, preserving order
                 # and whether a label was entered multiple times
                 entirelabels = list(groupby(label_volume[i,j,k]))
                 # Append all connection combinations along with streamline number, removing
                 # duplicates and connections from a label to itself
-                comb = set(combinations([z[0] for z in entirelabels],2))
-                for e in comb:
-                    if e[0] == e[1]:
+                combs = set(combinations([z[0] for z in entirelabels],2))
+                for comb in combs:
+                    if comb[0] == comb[1]:
                         pass
                     else:
-                        edges=np.append(edges,[[e[0]],[e[1]],[s]], axis=1)
+                        edges=np.append(edges,[[comb[0]],[comb[1]],[sl]], axis=1)
         if symmetric:
             edges[0:2].sort(0)
         mx = label_volume.max() + 1

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -180,7 +180,8 @@ def connectivity_matrix(streamlines, affine, label_volume, inclusive=False,
                 entirelabels = list(OrderedDict.fromkeys(label_volume[i, j, k]))
                 # Append all connection combinations with streamline number
                 for comb in combinations(entirelabels, 2):
-                    edges = np.append(edges,[[comb[0]], [comb[1]], [sl]], axis=1)
+                    edges = np.append(edges, [[comb[0]], [comb[1]], [sl]],
+                                      axis=1)
             else:
                 # Create list of all labels streamline passes through, keeping
                 # order and whether a label was entered multiple times

--- a/dipy/tracking/utils.py
+++ b/dipy/tracking/utils.py
@@ -162,7 +162,7 @@ def connectivity_matrix(streamlines, affine, label_volume, inclusive=False,
         raise ValueError("label_volume must be a 3d integer array with"
                          "non-negative label values")
 
-    # If streamlines is an iterators
+    # If streamlines is an iterator
     if return_mapping and mapping_as_streamlines:
         streamlines = list(streamlines)
 
@@ -170,7 +170,7 @@ def connectivity_matrix(streamlines, affine, label_volume, inclusive=False,
         # Create ndarray to store streamline connections
         edges = np.ndarray(shape=(3, 0), dtype=int)
         lin_T, offset = _mapping_to_voxel(affine)
-        for sl in range(len(streamlines)):
+        for sl, _ in enumerate(streamlines):
             # Convert streamline to voxel coordinates
             entire = _to_voxel_coordinates(streamlines[sl], lin_T, offset)
             i, j, k = entire.T
@@ -212,8 +212,8 @@ def connectivity_matrix(streamlines, affine, label_volume, inclusive=False,
                     mapping[key] = [streamlines[i] for i in mapping[key]]
 
             return matrix, mapping
-        else:
-            return matrix
+        
+        return matrix
     else:
         # take the first and last point of each streamline
         endpoints = [sl[0::len(sl)-1] for sl in streamlines]
@@ -244,8 +244,8 @@ def connectivity_matrix(streamlines, affine, label_volume, inclusive=False,
 
             # Return the mapping matrix and the mapping
             return matrix, mapping
-        else:
-            return matrix
+        
+        return matrix
 
 
 def ndbincount(x, weights=None, shape=None):


### PR DESCRIPTION
Hi, this is Ross Lawrence (a research assistant in Jovo's lab). This is my first dipy PR, so forgive any formatting issues. In this PR I added the option for connectivity_matrix to use the entire streamline in its analysis (instead of just the start and end points). This method is essentially what is used for our [ndmg ](https://github.com/neurodata/ndmg/tree/staging) connectome pipeline. This allows for connectivity matrices to use label volumes of white matter structures and record the connections between them.

- Works by looking at all the rois the streamline goes through and recording the connection between each roi. For example, if the streamlines path is through rois 3->2->4->5, then a connection will be recorded for (3,2), (3,4), (3,5), (2,4), (2,5), and (4,5).
- This is added functionality and works with the existing arguments (symmetric, return_mapping, etc.)
- Maintains directionality of streamlines unless symmetric=true

