### PR TITLE
SFT constructor from another SFT

### DIFF
--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -396,7 +396,7 @@ class StatefulTractogram(object):
             is_valid = False
 
         self.to_space(old_space)
-        self.change_origin(old_shift)
+        self.change_origin(old_origin)
 
         return is_valid
 
@@ -445,7 +445,7 @@ class StatefulTractogram(object):
                                       affine_to_rasmm=np.eye(4))
 
         self.to_space(old_space)
-        self.change_origin(old_shift)
+        self.change_origin(old_origin)
 
         return indices_to_remove, indices_to_keep
 

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -10,6 +10,7 @@ from nibabel.streamlines.tractogram import (Tractogram,
                                             PerArrayDict)
 import numpy as np
 
+import dipy
 from dipy.io.dpy import Streamlines
 from dipy.io.utils import get_reference_info
 
@@ -96,6 +97,12 @@ class StatefulTractogram(object):
                                       data_per_point=data_per_point,
                                       data_per_streamline=data_per_streamline)
 
+        if isinstance(reference, dipy.io.stateful_tractogram.StatefulTractogram):
+            logging.warning('Using a StatefulTractogram as reference, this will' +
+                            ' copy only the space_attributes, not the state.' +
+                            ' Variables space shifted_origin must be specified' +
+                            ' separately.')
+
         space_attributes = get_reference_info(reference)
         if space_attributes is None:
             raise TypeError('Reference MUST be one of the following:\n' +
@@ -114,6 +121,36 @@ class StatefulTractogram(object):
             raise TypeError('origin_at_corner MUST be a boolean')
         self._origin_at_corner = origin_at_corner
         logger.debug(self)
+
+
+    @staticmethod
+    def from_sft(streamlines, sft,
+                 data_per_point=None,
+                 data_per_streamline=None):
+        """ Re-create a strict, state-aware, robust tractogram from another
+
+        Parameters
+        ----------
+        streamlines : list or ArraySequence
+            Streamlines of the tractogram
+        sft : StatefulTractgram,
+            The other StatefulTractgram to copy the space_attribute AND
+            state from.
+        data_per_point : dict
+            Dictionary in which each key has X items, each items has Y_i items
+            X being the number of streamlines
+            Y_i being the number of points on streamlines #i
+        data_per_streamline : dict
+            Dictionary in which each key has X items
+            X being the number of streamlines
+        -----
+        """
+        new_sft = StatefulTractogram(streamlines, sft.space_attributes, sft.space,
+                                     shifted_origin=sft.shifted_origin,
+                                     data_per_point=data_per_point,
+                                     data_per_streamline=data_per_streamline)
+        return new_sft
+
 
     def __str__(self):
         """ Generate the string for printing """

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -36,6 +36,11 @@ class Space(enum.Enum):
     VOXMM = 'voxmm'
     RASMM = 'rasmm'
 
+class Origin(enum.Enum):
+    """ Enum to simplify future change to convention """
+    NIFTI = False
+    TRACKVIS = True
+
 
 class StatefulTractogram(object):
     """ Class for stateful representation of collections of streamlines
@@ -317,6 +322,18 @@ class StatefulTractogram(object):
             logger.error('Unsupported target space, please use Enum in '
                          'dipy.io.stateful_tractogram')
 
+    def change_origin(self, target_origin):
+        """ Safe function to change streamlines to a particular origin standard 
+        False means NIFTI (center) and True means TrackVis (corner) """
+        print(Origin.NIFTI)
+        if target_origin == Origin.NIFTI.value:
+            self.to_center()
+        elif target_origin == Origin.TRACKVIS.value:
+            self.to_corner()
+        else:
+            logger.error('Unsupported origin standard, please use Enum in '
+                         'dipy.io.stateful_tractogram')
+
     def to_center(self):
         """ Safe function to shift streamlines so the center of voxel is
         the origin """
@@ -378,13 +395,8 @@ class StatefulTractogram(object):
             logger.debug(bbox_corners)
             is_valid = False
 
-        if old_space == Space.RASMM:
-            self.to_rasmm()
-        elif old_space == Space.VOXMM:
-            self.to_voxmm()
-
-        if not old_origin:
-            self.to_center()
+        self.to_space(old_space)
+        self.change_origin(old_shift)
 
         return is_valid
 
@@ -432,13 +444,8 @@ class StatefulTractogram(object):
                                       data_per_streamline=tmp_data_per_streamline,
                                       affine_to_rasmm=np.eye(4))
 
-        if old_space == Space.RASMM:
-            self.to_rasmm()
-        elif old_space == Space.VOXMM:
-            self.to_voxmm()
-
-        if not old_origin:
-            self.to_center()
+        self.to_space(old_space)
+        self.change_origin(old_shift)
 
         return indices_to_remove, indices_to_keep
 

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -10,7 +10,6 @@ from nibabel.streamlines.tractogram import (Tractogram,
                                             PerArrayDict)
 import numpy as np
 
-import dipy
 from dipy.io.dpy import Streamlines
 from dipy.io.utils import get_reference_info, is_reference_info_valid
 
@@ -103,7 +102,7 @@ class StatefulTractogram(object):
                                       data_per_point=data_per_point,
                                       data_per_streamline=data_per_streamline)
 
-        if isinstance(reference, dipy.io.stateful_tractogram.StatefulTractogram):
+        if isinstance(reference, type(self)):
             logging.warning('Using a StatefulTractogram as reference, this '
                             'will copy only the space_attributes, not '
                             'the state. The variables space and origin_at_corner '

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -68,15 +68,15 @@ class StatefulTractogram(object):
             Current space in which the streamlines are (vox, voxmm or rasmm)
             Typically after tracking the space is VOX, after nibabel loading
             the space is RASMM
-        origin_at_corner : bool
+        origin_at_corner : bool, optional
             Information on the position of the origin,
             False is NIFTI standard, default (center of the voxel)
             True is TrackVis standard (corner of the voxel)
-        data_per_point : dict
+        data_per_point : dict, optional
             Dictionary in which each key has X items, each items has Y_i items
             X being the number of streamlines
             Y_i being the number of points on streamlines #i
-        data_per_streamline : dict
+        data_per_streamline : dict, optional
             Dictionary in which each key has X items
             X being the number of streamlines
 
@@ -157,7 +157,7 @@ class StatefulTractogram(object):
             Dictionary in which each key has X items, each items has Y_i items
             X being the number of streamlines
             Y_i being the number of points on streamlines #i
-        data_per_streamline : dict
+        data_per_streamline : dict, optional
             Dictionary in which each key has X items
             X being the number of streamlines
         -----

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -153,7 +153,7 @@ class StatefulTractogram(object):
         sft : StatefulTractgram,
             The other StatefulTractgram to copy the space_attribute AND
             state from.
-        data_per_point : dict
+        data_per_point : dict, optional
             Dictionary in which each key has X items, each items has Y_i items
             X being the number of streamlines
             Y_i being the number of points on streamlines #i

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -104,23 +104,23 @@ class StatefulTractogram(object):
                                       data_per_streamline=data_per_streamline)
 
         if isinstance(reference, dipy.io.stateful_tractogram.StatefulTractogram):
-            logging.warning('Using a StatefulTractogram as reference, this ' +
-                            'will copy only the space_attributes, not ' +
-                            'the state. The variables space and origin_at_corner ' +
+            logging.warning('Using a StatefulTractogram as reference, this '
+                            'will copy only the space_attributes, not '
+                            'the state. The variables space and origin_at_corner '
                             'must be specified separately.')
 
         if isinstance(reference, tuple) and len(reference) == 4:
             if is_reference_info_valid(*reference):
                 space_attributes = reference
             else:
-                raise TypeError('The provided space attributes are not ' +
-                                'considered valid, please correct before ' +
+                raise TypeError('The provided space attributes are not '
+                                'considered valid, please correct before '
                                 'using them with StatefulTractogram.')
         else:
             space_attributes = get_reference_info(reference)
             if space_attributes is None:
-                raise TypeError('Reference MUST be one of the following:\n' +
-                                'Nifti or Trk filename, Nifti1Image or ' +
+                raise TypeError('Reference MUST be one of the following:\n'
+                                'Nifti or Trk filename, Nifti1Image or '
                                 'TrkFile, Nifti1Header or trk.header (dict).')
 
         (self._affine, self._dimensions,
@@ -131,8 +131,12 @@ class StatefulTractogram(object):
             raise ValueError('Space MUST be from Space enum, e.g Space.VOX')
         self._space = space
 
+        if origin_at_corner in Origin:
+            origin_at_corner = origin_at_corner.value
+
         if not isinstance(origin_at_corner, bool):
-            raise TypeError('origin_at_corner MUST be a boolean')
+            raise TypeError('origin_at_corner MUST be a boolean or from '
+                            'Origin enum, e.g Origin.NIFTI')
         self._origin_at_corner = origin_at_corner
         logger.debug(self)
 

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -144,7 +144,7 @@ class StatefulTractogram(object):
     def from_sft(streamlines, sft,
                  data_per_point=None,
                  data_per_streamline=None):
-        """ Re-create a strict, state-aware, robust tractogram from another
+        """ Create an instance of `StatefulTractogram` from another instance of `StatefulTractogram`.
 
         Parameters
         ----------

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -106,7 +106,7 @@ class StatefulTractogram(object):
         if isinstance(reference, dipy.io.stateful_tractogram.StatefulTractogram):
             logging.warning('Using a StatefulTractogram as reference, this ' +
                             'will copy only the space_attributes, not ' +
-                            'the state. Variables space origin_at_corner ' +
+                            'the state. The variables space and origin_at_corner ' +
                             'must be specified separately.')
 
         if isinstance(reference, tuple) and len(reference) == 4:

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('StatefulTractogram')
 
 def set_sft_logger_level(log_level):
     """ Change the logger of the StatefulTractogram
-    to one on the following: DEBUG, INFO, WARNING, ERROR
+    to one on the following: DEBUG, INFO, WARNING, CRITICAL, ERROR
 
     Parameters
     ----------
@@ -106,6 +106,9 @@ class StatefulTractogram(object):
                             'will copy only the space_attributes, not '
                             'the state. The variables space and origin '
                             'must be specified separately.')
+            logging.warning('To copy the state from another StatefulTractogram'
+                            'you may want to use the function from_sft'
+                            '(static function of the StatefulTractogram)')
 
         if isinstance(reference, tuple) and len(reference) == 4:
             if is_reference_info_valid(*reference):
@@ -130,7 +133,8 @@ class StatefulTractogram(object):
         self._space = space
 
         if origin not in Origin:
-            raise ValueError('Origin MUST be from Origin enum, e.g Origin.NIFTI')
+            raise ValueError('Origin MUST be from Origin enum, '
+                             'e.g Origin.NIFTI')
         self._origin = origin
         logger.debug(self)
 
@@ -463,7 +467,7 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
-                logger.info('Moved streamlines from vox to voxmm')
+                logger.debug('Moved streamlines from vox to voxmm')
         else:
             logger.warning('Wrong initial space for this function')
             return
@@ -475,7 +479,7 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data /= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOX
-                logger.info('Moved streamlines from voxmm to vox')
+                logger.debug('Moved streamlines from voxmm to vox')
         else:
             logger.warning('Wrong initial space for this function')
             return
@@ -486,7 +490,7 @@ class StatefulTractogram(object):
             if self._tractogram.streamlines.data.size > 0:
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
-                logger.info('Moved streamlines from vox to rasmm')
+                logger.debug('Moved streamlines from vox to rasmm')
         else:
             logger.warning('Wrong initial space for this function')
             return
@@ -497,7 +501,7 @@ class StatefulTractogram(object):
             if self._tractogram.streamlines.data.size > 0:
                 self._tractogram.apply_affine(self._inv_affine)
                 self._space = Space.VOX
-                logger.info('Moved streamlines from rasmm to vox')
+                logger.debug('Moved streamlines from rasmm to vox')
         else:
             logger.warning('Wrong initial space for this function')
             return
@@ -510,7 +514,7 @@ class StatefulTractogram(object):
                     self._voxel_sizes)
                 self._tractogram.apply_affine(self._affine)
                 self._space = Space.RASMM
-                logger.info('Moved streamlines from voxmm to rasmm')
+                logger.debug('Moved streamlines from voxmm to rasmm')
         else:
             logger.warning('Wrong initial space for this function')
             return
@@ -523,7 +527,7 @@ class StatefulTractogram(object):
                 self._tractogram.streamlines._data *= np.asarray(
                     self._voxel_sizes)
                 self._space = Space.VOXMM
-                logger.info('Moved streamlines from rasmm to voxmm')
+                logger.debug('Moved streamlines from rasmm to voxmm')
         else:
             logger.warning('Wrong initial space for this function')
             return
@@ -546,10 +550,10 @@ class StatefulTractogram(object):
 
         self._tractogram.streamlines._data += shift
         if self._origin == Origin.NIFTI:
-            logger.info('Origin moved to the corner of voxel')
+            logger.debug('Origin moved to the corner of voxel')
             self._origin = Origin.TRACKVIS
         else:
-            logger.info('Origin moved to the center of voxel')
+            logger.debug('Origin moved to the center of voxel')
             self._origin = Origin.NIFTI
 
 
@@ -586,14 +590,16 @@ def _is_data_per_point_valid(streamlines, data):
     for key in data.keys():
         total_point_entries = 0
         if not len(data[key]) == total_streamline:
-            logger.error('Missing entry for streamlines points data (1)')
+            logger.error('Missing entry for streamlines points data, '
+                         'incoherent number of streamlines.')
             return False
 
         for values in data[key]:
             total_point_entries += len(values)
 
         if total_point_entries != total_point:
-            logger.error('Missing entry for streamlines points data (2)')
+            logger.error('Missing entry for streamlines points data, '
+                         'incoherent number of points per streamlines.')
             return False
 
     return True
@@ -627,7 +633,8 @@ def _is_data_per_streamline_valid(streamlines, data):
 
     for key in data.keys():
         if not len(data[key]) == total_streamline:
-            logger.error('Missing entry for streamlines data (3)')
+            logger.error('Missing entry for streamlines points data, '
+                         'incoherent number of streamlines.')
             return False
 
     return True

--- a/dipy/io/stateful_tractogram.py
+++ b/dipy/io/stateful_tractogram.py
@@ -36,6 +36,7 @@ class Space(enum.Enum):
     VOXMM = 'voxmm'
     RASMM = 'rasmm'
 
+
 class Origin(enum.Enum):
     """ Enum to simplify future change to convention """
     NIFTI = False
@@ -323,12 +324,13 @@ class StatefulTractogram(object):
                          'dipy.io.stateful_tractogram')
 
     def change_origin(self, target_origin):
-        """ Safe function to change streamlines to a particular origin standard 
+        """ Safe function to change streamlines to a particular origin standard
         False means NIFTI (center) and True means TrackVis (corner) """
-        print(Origin.NIFTI)
-        if target_origin == Origin.NIFTI.value:
+        if target_origin == Origin.NIFTI or \
+                target_origin == Origin.NIFTI.value:
             self.to_center()
-        elif target_origin == Origin.TRACKVIS.value:
+        elif target_origin == Origin.TRACKVIS or \
+                target_origin == Origin.TRACKVIS.value:
             self.to_corner()
         else:
             logger.error('Unsupported origin standard, please use Enum in '

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -78,7 +78,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
 
     sft.to_space(old_space)
     sft.change_origin(old_origin)
-    
+
     return True
 
 
@@ -194,7 +194,7 @@ def load_generator(ttype):
               trk_header_check=True):
         _, extension = os.path.splitext(filename)
         if not extension == ttype:
-            raise ValueError('This function can only load {} files, for a more'
+            raise ValueError('This function can only load {} files, for a more
                              ' general purpose, use load_tractogram instead.'.format(ttype))
 
         sft = load_tractogram(filename, reference,

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -39,10 +39,10 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
         raise TypeError('Output filename is not one of the supported format')
 
     if bbox_valid_check and not sft.is_bbox_in_vox_valid():
-        raise ValueError('Bounding box is not valid in voxel space, cannot ' +
-                         'load a valid file if some coordinates are ' +
-                         'invalid. Please use the function ' +
-                         'remove_invalid_streamlines to discard invalid ' +
+        raise ValueError('Bounding box is not valid in voxel space, cannot '
+                         'load a valid file if some coordinates are '
+                         'invalid. Please use the function '
+                         'remove_invalid_streamlines to discard invalid '
                          'streamlines or set bbox_valid_check to False')
 
     old_space = deepcopy(sft.space)
@@ -127,13 +127,13 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         if extension == '.trk':
             reference = filename
         else:
-            logging.error('Reference must be provided, "same" is only ' +
+            logging.error('Reference must be provided, "same" is only '
                           'available for Trk file.')
             return False
 
     if trk_header_check and extension == '.trk':
         if not is_header_compatible(filename, reference):
-            logging.error('Trk file header does not match the provided ' +
+            logging.error('Trk file header does not match the provided '
                           'reference')
             return False
 
@@ -167,10 +167,10 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         sft.to_voxmm()
 
     if bbox_valid_check and not sft.is_bbox_in_vox_valid():
-        raise ValueError('Bounding box is not valid in voxel space, cannot ' +
-                         'load a valid file if some coordinates are invalid.' +
-                         'Please set bbox_valid_check to False and then use' +
-                         'the function remove_invalid_streamlines to discard' +
+        raise ValueError('Bounding box is not valid in voxel space, cannot '
+                         'load a valid file if some coordinates are invalid.'
+                         'Please set bbox_valid_check to False and then use'
+                         'the function remove_invalid_streamlines to discard'
                          'invalid streamlines.')
 
     return sft
@@ -194,7 +194,7 @@ def load_generator(ttype):
               trk_header_check=True):
         _, extension = os.path.splitext(filename)
         if not extension == ttype:
-            raise ValueError('This function can only load {} files, for a more
+            raise ValueError('This function can only load {} files, for a more'
                              ' general purpose, use load_tractogram instead.'.format(ttype))
 
         sft = load_tractogram(filename, reference,

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -77,8 +77,8 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
                   filename, len(sft), round(time.time() - timer, 3))
 
     sft.to_space(old_space)
-    sft.change_origin(old_shift)
-
+    sft.change_origin(old_origin)
+    
     return True
 
 

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -76,13 +76,8 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
     logging.debug('Save %s with %s streamlines in %s seconds',
                   filename, len(sft), round(time.time() - timer, 3))
 
-    if old_space == Space.VOX:
-        sft.to_vox()
-    elif old_space == Space.VOXMM:
-        sft.to_voxmm()
-
-    if old_origin:
-        sft.to_corner()
+    sft.to_space(old_space)
+    sft.change_origin(old_shift)
 
     return True
 

--- a/dipy/io/streamline.py
+++ b/dipy/io/streamline.py
@@ -8,7 +8,7 @@ from nibabel.streamlines import detect_format
 from nibabel.streamlines.tractogram import Tractogram
 import numpy as np
 
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.stateful_tractogram import Origin, Space, StatefulTractogram
 from dipy.io.vtk import save_vtk_streamlines, load_vtk_streamlines
 from dipy.io.dpy import Dpy
 from dipy.io.utils import (create_tractogram_header,
@@ -46,7 +46,7 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
                          'streamlines or set bbox_valid_check to False')
 
     old_space = deepcopy(sft.space)
-    old_origin = deepcopy(sft.origin_at_corner)
+    old_origin = deepcopy(sft.origin)
 
     sft.to_rasmm()
     sft.to_center()
@@ -77,13 +77,13 @@ def save_tractogram(sft, filename, bbox_valid_check=True):
                   filename, len(sft), round(time.time() - timer, 3))
 
     sft.to_space(old_space)
-    sft.change_origin(old_origin)
+    sft.to_origin(old_origin)
 
     return True
 
 
 def load_tractogram(filename, reference, to_space=Space.RASMM,
-                    origin_at_corner=False, bbox_valid_check=True,
+                    to_origin=Origin.NIFTI, bbox_valid_check=True,
                     trk_header_check=True):
     """ Load the stateful tractogram from any format (trk, tck, vtk, fib, dpy)
 
@@ -97,11 +97,11 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
         Typically a nifti-related object from the native diffusion used for
         streamlines generation
     to_space : Enum (dipy.io.stateful_tractogram.Space)
-        Space to which the streamlines will be transformed after loading.
-    origin_at_corner : bool
-        Information on the position of the origin,
-        False is NIFTI standard, default (center of the voxel)
-        True is TrackVis standard (corner of the voxel)
+        Space to which the streamlines will be transformed after loading
+    to_origin : Enum (dipy.io.stateful_tractogram.Origin)
+        Origin to which the streamlines will be transformed after loading
+            NIFTI standard, default (center of the voxel)
+            TRACKVIS standard (corner of the voxel)
     bbox_valid_check : bool
         Verification for negative voxel coordinates or values above the
         volume dimensions. Default is True, to enforce valid file.
@@ -157,14 +157,12 @@ def load_tractogram(filename, reference, to_space=Space.RASMM,
                   filename, len(streamlines), round(time.time() - timer, 3))
 
     sft = StatefulTractogram(streamlines, reference, Space.RASMM,
-                             origin_at_corner=origin_at_corner,
+                             origin=Origin.NIFTI,
                              data_per_point=data_per_point,
                              data_per_streamline=data_per_streamline)
 
-    if to_space == Space.VOX:
-        sft.to_vox()
-    elif to_space == Space.VOXMM:
-        sft.to_voxmm()
+    sft.to_space(to_space)
+    sft.to_origin(to_origin)
 
     if bbox_valid_check and not sft.is_bbox_in_vox_valid():
         raise ValueError('Bounding box is not valid in voxel space, cannot '
@@ -190,7 +188,7 @@ def load_generator(ttype):
         Function (load_tractogram) that handle only one file format
     """
     def f_gen(filename, reference, to_space=Space.RASMM,
-              origin_at_corner=False, bbox_valid_check=True,
+              to_origin=Origin.NIFTI, bbox_valid_check=True,
               trk_header_check=True):
         _, extension = os.path.splitext(filename)
         if not extension == ttype:
@@ -199,7 +197,7 @@ def load_generator(ttype):
 
         sft = load_tractogram(filename, reference,
                               to_space=Space.RASMM,
-                              origin_at_corner=origin_at_corner,
+                              to_origin=to_origin,
                               bbox_valid_check=bbox_valid_check,
                               trk_header_check=trk_header_check)
         return sft

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -211,7 +211,7 @@ def to_corner_equivalence():
                             to_space=Space.VOX)
 
     sft_1.to_corner()
-    sft_2.change_origin(Origin.TRACKVIS)
+    sft_2.to_origin(Origin.TRACKVIS)
     assert_allclose(sft_1.streamlines.data,
                     sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
 
@@ -223,7 +223,7 @@ def to_center_equivalence():
                             to_space=Space.VOX)
 
     sft_1.to_center()
-    sft_2.change_origin(Origin.NIFTI)
+    sft_2.to_origin(Origin.NIFTI)
     assert_allclose(sft_1.streamlines.data,
                     sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
 
@@ -431,9 +431,9 @@ def reassign_both_data_sep():
     return True
 
 
-def bounding_bbox_valid(shift):
+def bounding_bbox_valid(standard):
     sft = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
-                          origin_at_corner=shift, bbox_valid_check=False)
+                          to_origin=standard, bbox_valid_check=False)
 
     return sft.is_bbox_in_vox_valid()
 
@@ -579,7 +579,7 @@ def test_to_space():
     to_vox_equivalence()
 
 
-def test_change_origin():
+def test_to_origin():
     to_center_equivalence()
     to_corner_equivalence()
 
@@ -610,9 +610,9 @@ def test_replace_streamlines():
 
 def test_bounding_box():
     # First is expected to fail
-    if not bounding_bbox_valid(False):
+    if not bounding_bbox_valid(Origin.NIFTI):
         raise AssertionError()
-    if bounding_bbox_valid(True):
+    if not bounding_bbox_valid(Origin.TRACKVIS):
         raise AssertionError()
     # Last two are expected to fail
     if out_of_grid(100):
@@ -647,7 +647,7 @@ def test_create_from_sft():
     if not (np.array_equal(sft_1.streamlines, sft_2.streamlines)
             and sft_1.space_attributes == sft_2.space_attributes
             and sft_1.space == sft_2.space
-            and sft_1.origin_at_corner == sft_2.origin_at_corner
+            and sft_1.origin == sft_2.origin
             and sft_1.data_per_point == sft_2.data_per_point
             and sft_1.data_per_streamline == sft_2.data_per_streamline):
         raise AssertionError()

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
 from dipy.data import fetch_gold_standard_io
-from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.stateful_tractogram import Origin, Space, StatefulTractogram
 from dipy.io.streamline import load_tractogram, save_tractogram
 
 from dipy.utils.optpkg import optional_package
@@ -200,6 +200,30 @@ def to_vox_equivalence():
 
     sft_1.to_vox()
     sft_2.to_space(Space.VOX)
+    assert_allclose(sft_1.streamlines.data,
+                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+
+
+def to_corner_equivalence():
+    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+                            to_space=Space.VOX)
+    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+                            to_space=Space.VOX)
+
+    sft_1.to_corner()
+    sft_2.change_origin(Origin.TRACKVIS)
+    assert_allclose(sft_1.streamlines.data,
+                    sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
+
+
+def to_center_equivalence():
+    sft_1 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+                            to_space=Space.VOX)
+    sft_2 = load_tractogram(filepath_dix['gs.trk'], filepath_dix['gs.nii'],
+                            to_space=Space.VOX)
+
+    sft_1.to_center()
+    sft_2.change_origin(Origin.NIFTI)
     assert_allclose(sft_1.streamlines.data,
                     sft_2.streamlines.data, atol=1e-3, rtol=1e-6)
 
@@ -553,6 +577,11 @@ def test_to_space():
     to_rasmm_equivalence()
     to_voxmm_equivalence()
     to_vox_equivalence()
+
+
+def test_change_origin():
+    to_center_equivalence()
+    to_corner_equivalence()
 
 
 def test_empty_sft():

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -4,7 +4,7 @@ import os
 from nibabel.tmpdirs import InTemporaryDirectory
 import numpy as np
 import numpy.testing as npt
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal, assert_
 import pytest
 
 from dipy.data import fetch_gold_standard_io
@@ -598,43 +598,41 @@ def test_shifting_corner():
 
 def test_replace_streamlines():
     # First two is expected to fail
-    if not subsample_streamlines():
-        raise AssertionError()
-    if not replace_streamlines():
-        raise AssertionError()
-    if not reassign_both_data_sep():
-        raise AssertionError()
-    if not reassign_both_data_sep_to_empty():
-        raise AssertionError()
+    assert_(subsample_streamlines(),
+            msg='Subsampling streamlines should not fail')
+    assert_(replace_streamlines(),
+            msg='Replacing streamlines should not fail')
+    assert_(reassign_both_data_sep(),
+            msg='Reassigning streamline/point data should not fail')
+    assert_(reassign_both_data_sep_to_empty(),
+            msg='Emptying streamline/point data should not fail')
 
 
 def test_bounding_box():
-    # First is expected to fail
-    if not bounding_bbox_valid(Origin.NIFTI):
-        raise AssertionError()
-    if not bounding_bbox_valid(Origin.TRACKVIS):
-        raise AssertionError()
-    # Last two are expected to fail
-    if out_of_grid(100):
-        raise AssertionError()
-    if out_of_grid(-100):
-        raise AssertionError()
+    assert_(bounding_bbox_valid(Origin.NIFTI),
+            msg='Bounding box should be valid with proper declaration')
+    assert_(bounding_bbox_valid(Origin.TRACKVIS),
+            msg='Bounding box should be valid with proper declaration')
+    assert_(not out_of_grid(100),
+            msg='Positive translation should make the bbox check fail')
+    assert_(not out_of_grid(-100),
+            msg='Negative translation should make the bbox check fail')
 
 
 def test_invalid_streamlines():
-    if not remove_invalid_streamlines(True) == 5:
-        raise AssertionError()
-    if not remove_invalid_streamlines(False) == 13:
-        raise AssertionError()
+    assert_(remove_invalid_streamlines(True) == 5,
+            msg='A shifted gold standard should have 8 invalid streamlines')
+    assert_(remove_invalid_streamlines(False) == 13,
+            msg='A unshifted gold standard should have 0 invalid streamlines')
 
 
 def test_trk_coloring():
-    if not random_streamline_color():
-        raise AssertionError()
-    if not random_point_gray():
-        raise AssertionError()
-    if not random_point_color():
-        raise AssertionError()
+    assert_(random_streamline_color(),
+            msg='Streamlines color assignement failed')
+    assert_(random_point_gray(),
+            msg='Streamlines points gray assignement failed')
+    assert_(random_point_color(),
+            msg='Streamlines points color assignement failed')
 
 
 def test_create_from_sft():

--- a/dipy/io/tests/test_stateful_tractogram.py
+++ b/dipy/io/tests/test_stateful_tractogram.py
@@ -499,6 +499,17 @@ def out_of_grid(value):
     except (TypeError, ValueError):
         return True
 
+    sft = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft.to_vox()
+    tmp_streamlines = list(sft.get_streamlines_copy())
+    tmp_streamlines[0] += value
+
+    try:
+        sft.streamlines = tmp_streamlines
+        return sft.is_bbox_in_vox_valid()
+    except (TypeError, ValueError):
+        return True
+
 
 def test_iterative_transformation():
     iterative_to_vox_transformation()
@@ -594,6 +605,26 @@ def test_trk_coloring():
     if not random_point_gray():
         raise AssertionError()
     if not random_point_color():
+        raise AssertionError()
+
+
+def test_create_from_sft():
+    sft_1 = load_tractogram(filepath_dix['gs.tck'], filepath_dix['gs.nii'])
+    sft_2 = StatefulTractogram.from_sft(
+        sft_1.streamlines, sft_1,
+        data_per_point=sft_1.data_per_point,
+        data_per_streamline=sft_1.data_per_streamline)
+
+    if not (np.array_equal(sft_1.streamlines, sft_2.streamlines)
+            and sft_1.space_attributes == sft_2.space_attributes
+            and sft_1.space == sft_2.space
+            and sft_1.origin_at_corner == sft_2.origin_at_corner
+            and sft_1.data_per_point == sft_2.data_per_point
+            and sft_1.data_per_streamline == sft_2.data_per_streamline):
+        raise AssertionError()
+
+    sft_1.streamlines = np.arange(6000).reshape((100, 20, 3))
+    if np.array_equal(sft_1.streamlines, sft_2.streamlines):
         raise AssertionError()
 
 

--- a/dipy/io/tests/test_streamline.py
+++ b/dipy/io/tests/test_streamline.py
@@ -232,29 +232,29 @@ def trk_saver(filename):
 
 
 def test_io_trk_load():
-    if not trk_loader(filepath_dix['gs.trk']):
-        raise AssertionError()
-    if trk_loader('fake_file.TRK'):
-        raise AssertionError()
-    if trk_loader(filepath_dix['gs.tck']):
-        raise AssertionError()
-    if trk_loader(filepath_dix['gs.fib']):
-        raise AssertionError()
-    if trk_loader(filepath_dix['gs.dpy']):
-        raise AssertionError()
+    npt.assert_(trk_loader(filepath_dix['gs.trk']),
+                msg='trk_loader should be able to load a trk')
+    npt.assert_(not trk_loader('fake_file.TRK'),
+                msg='trk_loader should not be able to load a TRK')
+    npt.assert_(not trk_loader(filepath_dix['gs.tck']),
+                msg='trk_loader should not be able to load a tck')
+    npt.assert_(not trk_loader(filepath_dix['gs.fib']),
+                msg='trk_loader should not be able to load a fib')
+    npt.assert_(not trk_loader(filepath_dix['gs.dpy']),
+                msg='trk_loader should not be able to load a dpy')
 
 
 def test_io_trk_save():
-    if not trk_saver(filepath_dix['gs.trk']):
-        raise AssertionError()
-    if trk_saver('fake_file.TRK'):
-        raise AssertionError()
-    if trk_saver(filepath_dix['gs.tck']):
-        raise AssertionError()
-    if trk_saver(filepath_dix['gs.fib']):
-        raise AssertionError()
-    if trk_saver(filepath_dix['gs.dpy']):
-        raise AssertionError()
+    npt.assert_(trk_saver(filepath_dix['gs.trk']),
+                msg='trk_saver should be able to save a trk')
+    npt.assert_(not trk_saver('fake_file.TRK'),
+                msg='trk_saver should not be able to save a TRK')
+    npt.assert_(not trk_saver(filepath_dix['gs.tck']),
+                msg='trk_saver should not be able to save a tck')
+    npt.assert_(not trk_saver(filepath_dix['gs.fib']),
+                msg='trk_saver should not be able to save a fib')
+    npt.assert_(not trk_saver(filepath_dix['gs.dpy']),
+                msg='trk_saver should not be able to save a dpy')
 
 
 if __name__ == '__main__':

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -1,9 +1,10 @@
 import os
 
 from dipy.data import fetch_gold_standard_io
-from dipy.io.utils import (decfa, decfa_to_float,
+from dipy.io.utils import (create_nifti_header,
+                           decfa, decfa_to_float,
                            get_reference_info,
-                           create_nifti_header)
+                           is_reference_info_valid)
 from nibabel import Nifti1Image
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -51,6 +52,73 @@ def test_decfa():
     assert np.all(data_rt[0, 0, 0] == np.array([25, 0, 0]))
 
 
+def is_affine_valid(affine):
+    return is_reference_info_valid(affine, [1, 1, 1], [1.0, 1.0, 1.0],
+                                   'RAS')
+
+
+def is_dimensions_valid(dimensions):
+    return is_reference_info_valid(np.eye(4), dimensions, [1.0, 1.0, 1.0],
+                                   'RAS')
+
+
+def is_voxel_sizes_valid(voxel_sizes):
+    return is_reference_info_valid(np.eye(4), [1, 1, 1], voxel_sizes,
+                                   'RAS')
+
+
+def is_voxel_order_valid(voxel_order):
+    return is_reference_info_valid(np.eye(4), [1, 1, 1], [1.0, 1.0, 1.0],
+                                   voxel_order)
+
+
+def test_reference_info_validity():
+    if is_affine_valid(np.eye(3)):
+        raise AssertionError()
+    if is_affine_valid(np.zeros((4, 4))):
+        raise AssertionError()
+    if not is_affine_valid(np.eye(4)):
+        raise AssertionError()
+
+    if is_dimensions_valid([0, 0]):
+        raise AssertionError()
+    if is_dimensions_valid([1, 1.0, 1]):
+        raise AssertionError()
+    if is_dimensions_valid([1, -1.0, 1]):
+        raise AssertionError()
+    if not is_dimensions_valid([1, 1, 1]):
+        raise AssertionError()
+
+    if is_voxel_sizes_valid([0, 0]):
+        raise AssertionError()
+    if is_voxel_sizes_valid([1, -1.0, 1]):
+        raise AssertionError()
+    if not is_voxel_sizes_valid([1.0, 1.0, 1.0]):
+        raise AssertionError()
+
+    if is_voxel_order_valid('RA'):
+        raise AssertionError()
+    if is_voxel_order_valid(['RAS']):
+        raise AssertionError()
+    if is_voxel_order_valid(['R', 'A', 'Z']):
+        raise AssertionError()
+    if is_voxel_order_valid('RAZ'):
+        raise AssertionError()
+    if not is_voxel_order_valid('RAS'):
+        raise AssertionError()
+    if not is_voxel_order_valid(['R', 'A', 'S']):
+        raise AssertionError()
+
+
+def reference_info_zero_affine():
+    header = create_nifti_header(np.zeros((4, 4)), [10, 10, 10], [1, 1, 1])
+    try:
+        get_reference_info(header)
+        return True
+    except ValueError:
+        return False
+
+
 def test_reference_info_identical():
     tuple_1 = get_reference_info(filepath_dix['gs.trk'])
     tuple_2 = get_reference_info(filepath_dix['gs.nii'])
@@ -66,12 +134,3 @@ def test_reference_info_identical():
 def test_all_zeros_affine():
     if reference_info_zero_affine():
         raise AssertionError()
-
-
-def reference_info_zero_affine():
-    header = create_nifti_header(np.zeros((4, 4)), [10, 10, 10], [1, 1, 1])
-    try:
-        get_reference_info(header)
-        return True
-    except ValueError:
-        return False

--- a/dipy/io/tests/test_utils.py
+++ b/dipy/io/tests/test_utils.py
@@ -7,7 +7,7 @@ from dipy.io.utils import (create_nifti_header,
                            is_reference_info_valid)
 from nibabel import Nifti1Image
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal, assert_
 
 filepath_dix = {}
 files, folder = fetch_gold_standard_io()
@@ -73,41 +73,41 @@ def is_voxel_order_valid(voxel_order):
 
 
 def test_reference_info_validity():
-    if is_affine_valid(np.eye(3)):
-        raise AssertionError()
-    if is_affine_valid(np.zeros((4, 4))):
-        raise AssertionError()
-    if not is_affine_valid(np.eye(4)):
-        raise AssertionError()
+    assert_(not is_affine_valid(np.eye(3)),
+            msg='3x3 affine is invalid')
+    assert_(not is_affine_valid(np.zeros((4, 4))),
+            msg='All zeroes affine is invalid')
+    assert_(is_affine_valid(np.eye(4)),
+            msg='Identity should be valid')
 
-    if is_dimensions_valid([0, 0]):
-        raise AssertionError()
-    if is_dimensions_valid([1, 1.0, 1]):
-        raise AssertionError()
-    if is_dimensions_valid([1, -1.0, 1]):
-        raise AssertionError()
-    if not is_dimensions_valid([1, 1, 1]):
-        raise AssertionError()
+    assert_(not is_dimensions_valid([0, 0]),
+            msg='Dimensions of the wrong length')
+    assert_(not is_dimensions_valid([1, 1.0, 1]),
+            msg='Dimensions cannot be float')
+    assert_(not is_dimensions_valid([1, -1, 1]),
+            msg='Dimensions cannot be negative')
+    assert_(is_dimensions_valid([1, 1, 1]),
+            msg='Dimensions of [1,1,1] should be valid')
 
-    if is_voxel_sizes_valid([0, 0]):
-        raise AssertionError()
-    if is_voxel_sizes_valid([1, -1.0, 1]):
-        raise AssertionError()
-    if not is_voxel_sizes_valid([1.0, 1.0, 1.0]):
-        raise AssertionError()
+    assert_(not is_voxel_sizes_valid([0, 0]),
+            msg='Voxel sizes of the wrong length')
+    assert_(not is_voxel_sizes_valid([1, -1, 1]),
+            msg='Voxel sizes cannot be negative')
+    assert_(is_voxel_sizes_valid([1.0, 1.0, 1.0]),
+            msg='Voxel sizes of [1.0,1.0,1.0] should be valid')
 
-    if is_voxel_order_valid('RA'):
-        raise AssertionError()
-    if is_voxel_order_valid(['RAS']):
-        raise AssertionError()
-    if is_voxel_order_valid(['R', 'A', 'Z']):
-        raise AssertionError()
-    if is_voxel_order_valid('RAZ'):
-        raise AssertionError()
-    if not is_voxel_order_valid('RAS'):
-        raise AssertionError()
-    if not is_voxel_order_valid(['R', 'A', 'S']):
-        raise AssertionError()
+    assert_(not is_voxel_order_valid('RA'),
+            msg='Voxel order of the wrong length')
+    assert_(not is_voxel_order_valid(['RAS']),
+            msg='List of string is not a valid voxel order')
+    assert_(not is_voxel_order_valid(['R', 'A', 'Z']),
+            msg='Invalid value for voxel order (Z)')
+    assert_(not is_voxel_order_valid('RAZ'),
+            msg='Invalid value for voxel order (Z)')
+    assert_(is_voxel_order_valid('RAS'),
+            msg='RAS should be a valid voxel order')
+    assert_(is_voxel_order_valid(['R', 'A', 'S']),
+            msg='RAS should be a valid voxel order')
 
 
 def reference_info_zero_affine():
@@ -132,5 +132,5 @@ def test_reference_info_identical():
 
 
 def test_all_zeros_affine():
-    if reference_info_zero_affine():
-        raise AssertionError()
+    assert_(not reference_info_zero_affine(),
+            msg='An all zeros affine should not be valid')

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -139,10 +139,32 @@ def decfa_to_float(img_orig):
 
 
 def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
+    """ Will validate basic data type and value of spatial attribute.
+    Does not ensure that voxel_sizes and voxel_order are self-coherent with
+    affine.
+    The listed parameters are what is expected, provide something else and this
+    function should fail (cover common mistakes).
+
+    Parameters
+    ----------
+        affine: ndarray (4,4)
+            Tranformation of VOX to RASMM
+        dimensions: ndarray (3,), int16
+            Volume shape for each axis
+        voxel_sizes:  ndarray (3,), float32
+            Size of voxel for each axis
+        voxel_order: string
+            Typically 'RAS' or 'LPS'
+
+    Returns
+    -------
+    output : bool
+        Does the input represent a valid 'state' of spatial attribute
+    """
     all_valid = True
     only_3d_warning = False
 
-    if not affine.shape == (4,4):
+    if not affine.shape == (4, 4):
         all_valid = False
         logging.warning('Transformation matrix must be 4x4')
 
@@ -158,7 +180,9 @@ def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
         if not isinstance(i, numbers.Integral):
             all_valid = False
             logging.warning('Dimensions must be int.')
-            break
+        if i <= 0:
+            all_valid = False
+            logging.warning('Dimensions must be above 0.')
 
     if not len(voxel_sizes) >= 3:
         all_valid = False
@@ -167,7 +191,9 @@ def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
         if not isinstance(i, numbers.Number):
             all_valid = False
             logging.warning('Voxel size must be int/float.')
-            break
+        if i <= 0:
+            all_valid = False
+            logging.warning('Voxel size must be above 0.')
 
     if not len(voxel_order) >= 3:
         all_valid = False
@@ -176,7 +202,9 @@ def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
         if not isinstance(i, six.string_types):
             all_valid = False
             logging.warning('Voxel order must be string/char.')
-            break
+        if i not in ['R', 'A', 'S', 'L', 'P', 'I']:
+            all_valid = False
+            logging.warning('Voxel order does not follow convention.')
 
     if only_3d_warning:
         logging.warning('Only 3D (and above) reference are considered valid.')
@@ -197,8 +225,8 @@ def get_reference_info(reference):
     -------
     output : tuple
         - affine ndarray (4,4), np.float32, tranformation of VOX to RASMM
-        - dimensions list (3), int, volume shape for each axis
-        - voxel_sizes  list (3), float, size of voxel for each axis
+        - dimensions ndarray (3,), int16, volume shape for each axis
+        - voxel_sizes  ndarray (3,), float32, size of voxel for each axis
         - voxel_order, string, Typically 'RAS' or 'LPS'
     """
 

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -141,20 +141,26 @@ def decfa_to_float(img_orig):
 def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
     """ Will validate basic data type and value of spatial attribute.
     Does not ensure that voxel_sizes and voxel_order are self-coherent with
-    affine.
+    the affine.
+    Only verify
+    - affine is of the right type (float) and dimension (4,4)
+    - affine contain values in the rotation part
+    - dimensions is of right type (int) and length (3) 
+    - voxel_sizes is of right type (float) and length (3) 
+    - voxel_order is of right type (str) and length (3) 
     The listed parameters are what is expected, provide something else and this
     function should fail (cover common mistakes).
 
     Parameters
     ----------
-        affine: ndarray (4,4)
-            Tranformation of VOX to RASMM
-        dimensions: ndarray (3,), int16
-            Volume shape for each axis
-        voxel_sizes:  ndarray (3,), float32
-            Size of voxel for each axis
-        voxel_order: string
-            Typically 'RAS' or 'LPS'
+    affine: ndarray (4,4)
+        Tranformation of VOX to RASMM
+    dimensions: ndarray (3,), int16
+        Volume shape for each axis
+    voxel_sizes:  ndarray (3,), float32
+        Size of voxel for each axis
+    voxel_order: string
+        Typically 'RAS' or 'LPS'
 
     Returns
     -------

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -141,12 +141,12 @@ def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
     """ Will validate basic data type and value of spatial attribute.
     Does not ensure that voxel_sizes and voxel_order are self-coherent with
     the affine.
-    Only verify
-    - affine is of the right type (float) and dimension (4,4)
-    - affine contain values in the rotation part
-    - dimensions is of right type (int) and length (3)
-    - voxel_sizes is of right type (float) and length (3)
-    - voxel_order is of right type (str) and length (3)
+    Only verify the following:
+        - affine is of the right type (float) and dimension (4,4)
+        - affine contain values in the rotation part
+        - dimensions is of right type (int) and length (3)
+        - voxel_sizes is of right type (float) and length (3)
+        - voxel_order is of right type (str) and length (3)
     The listed parameters are what is expected, provide something else and this
     function should fail (cover common mistakes).
 

--- a/dipy/io/utils.py
+++ b/dipy/io/utils.py
@@ -2,7 +2,6 @@
 import logging
 import numbers
 import os
-import six
 
 import dipy
 import nibabel as nib
@@ -145,9 +144,9 @@ def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
     Only verify
     - affine is of the right type (float) and dimension (4,4)
     - affine contain values in the rotation part
-    - dimensions is of right type (int) and length (3) 
-    - voxel_sizes is of right type (float) and length (3) 
-    - voxel_order is of right type (str) and length (3) 
+    - dimensions is of right type (int) and length (3)
+    - voxel_sizes is of right type (float) and length (3)
+    - voxel_order is of right type (str) and length (3)
     The listed parameters are what is expected, provide something else and this
     function should fail (cover common mistakes).
 
@@ -205,7 +204,7 @@ def is_reference_info_valid(affine, dimensions, voxel_sizes, voxel_order):
         all_valid = False
         only_3d_warning = True
     for i in voxel_order:
-        if not isinstance(i, six.string_types):
+        if not isinstance(i, str):
             all_valid = False
             logging.warning('Voxel order must be string/char.')
         if i not in ['R', 'A', 'S', 'L', 'P', 'I']:


### PR DESCRIPTION
Instead of creating a `StatefulTractogram` from scratch providing the the reference, the space, the `voxel_at_origin` is cumbersome if the user wanted to have the exact same state as another SFT.
Colleagues were trying to do that and sometime forgot to pass along  `voxel_at_origin` messing up the new SFT state.

So to simplifying the operation (or at least provide a clear function for that), a constructor was added for that situation. Quite specific, but useful and clear functionality.

Added function to improve usability.
The reference for `StatefulTractogram` can now be (on top of the 6 other ways) a tuple similar to what `get_reference_info` was returning. The function `is_reference_info_valid` now check the basic type and value of the element to decrease chance of mistake.

This will have to be merged after #2008 , in time I will rebase and make sure the history is fine. Only the last 2 commits are truly for that PR (in case someone wanted to give comment, otherwise this can wait after the merge)

For focus `dipy.io.utils.is_reference_info_valid` and the static method `dipy.io.stateful_tractogram.from_sft` and `dipy.io.stateful_tractogram.change_origin` are the only one new. If anyone has suggestions for improvement.

_(Does not break anything, is not even a real new features, simple adjustment from observing colleagues and from our day to day usage.)_