### PR TITLE
Update pep8speaks configuration

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -19,6 +19,7 @@ pycodestyle:
     # ignore:  # Errors and warnings to ignore
     #    - W391
     #    - E203
-
+    exclude:
+        - doc/examples
 only_mention_files_with_errors: True  # If False, a separate status comment for each file is made.
 descending_issues_order: False # If True, PEP8 issues in message will be displayed in descending order of line numbers in the file


### PR DESCRIPTION
Ignore the examples folder, because many of these files will not comply with PEP8. For example, see all the messages that popped up in #2021