### PR TITLE
QuickBundles: fix test on order invariance property

### DIFF
--- a/dipy/segment/clusteringspeed.pyx
+++ b/dipy/segment/clusteringspeed.pyx
@@ -582,7 +582,7 @@ cdef class QuickBundles(object):
         nearest_cluster = self.find_nearest_cluster(self.features)
 
         # Find nearest cluster to s_i_flip if metric is not order invariant
-        if not self.metric.feature.is_order_invariant:
+        if self.metric.feature.is_order_invariant != 0:
             self.metric.feature.c_extract(datum[::-1], self.features_flip)
             nearest_cluster_flip = self.find_nearest_cluster(self.features_flip)
 

--- a/dipy/segment/tests/test_quickbundles.py
+++ b/dipy/segment/tests/test_quickbundles.py
@@ -194,6 +194,19 @@ def test_quickbundles_with_not_order_invariant_metric():
     assert_array_equal(clusters[0].centroid, streamline)
 
 
+def test_quickbundles_with_not_order_invariant_metric_multiple_clusters():
+    metric = dipymetric.AveragePointwiseEuclideanMetric()
+    qb = QuickBundles(threshold=0.1, metric=metric)
+
+    streamline = np.arange(10*3, dtype=dtype).reshape((-1, 3))
+    streamlines = [streamline, streamline[::-1]]
+
+    clusters = qb.cluster(streamlines)
+    assert_equal(len(clusters), 2)
+    assert_array_equal(clusters[0].centroid, streamlines[0])
+    assert_array_equal(clusters[1].centroid, streamlines[1])
+
+
 def test_quickbundles_memory_leaks():
     qb = QuickBundles(threshold=2*threshold)
 


### PR DESCRIPTION
This allows order variant metrics to work properly