### PR TITLE
[MAINT] Use the array proxy instead of get_fdata()

### DIFF
--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -3,15 +3,15 @@ import nibabel as nib
 import numpy as np
 
 
-def load_nifti_data(fname):
+def load_nifti_data(fname, as_ndarray=True):
     img = nib.load(fname)
-    return np.asarray(img.dataobj)
+    return np.asanyarray(img.dataobj) if as_ndarray else img.dataobj
 
 
 def load_nifti(fname, return_img=False, return_voxsize=False,
-               return_coords=False):
+               return_coords=False, as_ndarray=True):
     img = nib.load(fname)
-    data = np.asarray(img.dataobj)
+    data = np.asanyarray(img.dataobj) if as_ndarray else img.dataobj
     vox_size = img.header.get_zooms()[:3]
 
     ret_val = [data, img.affine]

--- a/dipy/io/image.py
+++ b/dipy/io/image.py
@@ -3,15 +3,15 @@ import nibabel as nib
 import numpy as np
 
 
-def load_nifti_data(fname, dtype=np.float64):
+def load_nifti_data(fname):
     img = nib.load(fname)
-    return img.get_fdata(dtype=dtype)
+    return np.asarray(img.dataobj)
 
 
 def load_nifti(fname, return_img=False, return_voxsize=False,
-               return_coords=False, dtype=np.float64):
+               return_coords=False):
     img = nib.load(fname)
-    data = img.get_fdata(dtype=dtype)
+    data = np.asarray(img.dataobj)
     vox_size = img.header.get_zooms()[:3]
 
     ret_val = [data, img.affine]

--- a/dipy/tracking/tests/test_life.py
+++ b/dipy/tracking/tests/test_life.py
@@ -158,7 +158,7 @@ def test_fit_data():
     fstreamlines = dpd.get_fnames('small_25_streamlines')
     gtab = grad.gradient_table(fbval, fbvec)
     ni_data = nib.load(fdata)
-    data = ni_data.get_fdata()
+    data = np.asarray(ni_data.dataobj)
 
     tensor_streamlines = nib.streamlines.load(fstreamlines).streamlines
     sft = StatefulTractogram(tensor_streamlines, ni_data, Space.RASMM)

--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -205,7 +205,7 @@ class Horizon(object):
             if self.random_colors:
                 colors = next(color_gen)
             else:
-                colors = "RGB"
+                colors = None
 
             if not self.world_coords:
                 # TODO we need to read the affine of a tractogram

--- a/dipy/viz/app.py
+++ b/dipy/viz/app.py
@@ -205,7 +205,7 @@ class Horizon(object):
             if self.random_colors:
                 colors = next(color_gen)
             else:
-                colors = None
+                colors = "RGB"
 
             if not self.world_coords:
                 # TODO we need to read the affine of a tractogram

--- a/doc/api_changes.rst
+++ b/doc/api_changes.rst
@@ -5,7 +5,7 @@ API changes
 Here we provide information about functions or classes that have been removed,
 renamed or are deprecated (not recommended) during different release circles.
 
-DIPY 1.1.0 changes
+DIPY 1.1.x changes
 ----------------
 
 **Tractogram**

--- a/doc/examples/denoise_gibbs.py
+++ b/doc/examples/denoise_gibbs.py
@@ -155,7 +155,7 @@ bvals = [200, 400, 1000, 2000]
 
 img, gtab = read_cenir_multib(bvals)
 
-data = img.get_fdata()
+data = np.asarray(img.dataobj)
 
 """
 For illustration proposes, we select two slices of this dataset

--- a/doc/examples/reconst_forecast.py
+++ b/doc/examples/reconst_forecast.py
@@ -10,6 +10,7 @@ axially symmetric tensor and the fODF using the FORECAST model from
 First import the necessary modules:
 """
 
+import numpy as np
 import matplotlib.pyplot as plt
 from dipy.reconst.forecast import ForecastModel
 from dipy.viz import actor, window
@@ -26,7 +27,7 @@ fetch_cenir_multib(with_raw=False)
 
 bvals = [1000, 2000, 3000]
 img, gtab = read_cenir_multib(bvals)
-data = img.get_fdata()
+data = np.asarray(img.dataobj)
 
 """
 Let us consider only a single slice for the FORECAST fitting

--- a/doc/examples/reconst_fwdti.py
+++ b/doc/examples/reconst_fwdti.py
@@ -65,7 +65,7 @@ bvals = [200, 400, 1000, 2000]
 
 img, gtab = read_cenir_multib(bvals)
 
-data = img.get_fdata()
+data = np.asarray(img.dataobj)
 
 affine = img.affine
 

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -25,6 +25,7 @@ b0 from the Stanford HARDI dataset:
 
 """
 
+import numpy as np
 import nibabel as nib
 import os.path as op
 
@@ -57,8 +58,8 @@ fetch_mni_template()
 img_t2_mni = read_mni_template("a", contrast="T2")
 
 new_zooms = (2., 2., 2.)
-data2, affine2 = reslice(img_t2_mni.get_fdata(), img_t2_mni.affine,
-img_t2_mni.header.get_zooms(), new_zooms)
+data2, affine2 = reslice(np.asarray(img_t2_mni.dataobj), img_t2_mni.affine,
+                         img_t2_mni.header.get_zooms(), new_zooms)
 img_t2_mni = nib.Nifti1Image(data2, affine=affine2)
 
 """
@@ -66,8 +67,6 @@ We filter the diffusion data from the Stanford HARDI dataset to find the b0
 images.
 
 """
-
-import numpy as np
 
 b0_idx_stanford = np.where(gtab.b0s_mask)[0]
 b0_data_stanford = data[..., b0_idx_stanford]
@@ -111,7 +110,7 @@ from dipy.align.imaffine import (MutualInformationMetric, AffineRegistration,
 from dipy.align.transforms import (TranslationTransform3D, RigidTransform3D,
                                    AffineTransform3D)
 
-static = img_t2_mni.get_fdata()
+static = np.asarray(img_t2_mni.dataobj)
 static_affine = img_t2_mni.affine
 moving = mean_b0_masked_stanford
 moving_affine = hardi_img.affine


### PR DESCRIPTION
In Nibabel, `get_data` was using the array proxy by default which seems to not be the case for `get_fdata`. So now, we use `np.asarray(img.dataobj)` to keep the default behavior.

this is a PR for the maintenance branch, I will have to cut a new release which will be DIPY 1.1.1 and announce this one by default instead of DIPY 1.1.0. 